### PR TITLE
[tcd] Fix datum, add metric and imperial builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,11 +30,13 @@ jobs:
       - name: Publish to npm
         run: npm publish
 
-      - name: Build TCD harmonics file
+      - name: Build TCD harmonics files
         run: npm run build -w tcd
 
-      - name: Rename TCD file for release
-        run: mv packages/tcd/dist/harmonics.tcd "packages/tcd/dist/neaps-${RELEASE_VERSION##*.}.tcd"
+      - name: Rename TCD files for release
+        run: |
+          mv packages/tcd/dist/harmonics-metric.tcd "packages/tcd/dist/neaps-${RELEASE_VERSION##*.}-metric.tcd"
+          mv packages/tcd/dist/harmonics-imperial.tcd "packages/tcd/dist/neaps-${RELEASE_VERSION##*.}-imperial.tcd"
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1

--- a/packages/tcd/build
+++ b/packages/tcd/build
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Remove any existing files to ensure a clean build
+rm -rf dist
+
+# Build the harmonics and offsets files
+node build.ts
+
+# Build the .tcd files
+for units in metric imperial; do
+  docker compose run --rm build-tcd dist/harmonics-${units}.tcd dist/harmonics-${units}.txt dist/offsets-${units}.xml
+done

--- a/packages/tcd/docker-compose.yml
+++ b/packages/tcd/docker-compose.yml
@@ -2,14 +2,13 @@ services:
   build-tcd:
     image: openwatersio/xtide
     volumes:
-      - ./dist:/data
-    command: >
-      build_tide_db /data/harmonics.tcd /data/harmonics.txt /data/offsets.xml
+      - ./dist:/dist
+    entrypoint: ["build_tide_db"]
 
   xtide:
     image: openwatersio/xtide
     volumes:
       - ./dist:/data
     environment:
-      - HFILE_PATH=/data/harmonics.tcd
+      - HFILE_PATH=/data/harmonics-metric.tcd
     entrypoint: ["tide"]

--- a/packages/tcd/package.json
+++ b/packages/tcd/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "node build.ts && rm -f dist/harmonics.tcd && docker compose run --rm build-tcd",
+    "build": "./build",
     "pretest": "npm run build",
     "test": "vitest"
   },

--- a/packages/tcd/test/neaps-predictions.ts
+++ b/packages/tcd/test/neaps-predictions.ts
@@ -42,9 +42,13 @@ export function getNeapsPredictions(
     phase: hc.phase,
   }));
 
-  // Create tide predictor
+  // Create tide predictor with Z₀ offset (MSL above MLLW)
+  const msl = station.datums?.["MSL"] ?? 0;
+  const mllw = station.datums?.["MLLW"] ?? 0;
+  const z0 = msl && mllw ? msl - mllw : false;
+
   const predictor = createTidePredictor(constituents, {
-    offset: station.datums?.["MLLW"] ?? false,
+    offset: z0,
   });
 
   // Get extreme predictions (high/low tides)

--- a/packages/tcd/test/tcd.test.ts
+++ b/packages/tcd/test/tcd.test.ts
@@ -120,36 +120,52 @@ describe("XTide TCD", () => {
   });
 
   describe("TCD file integrity", () => {
-    test("TCD file exists and is not empty", () => {
-      const tcdPath = join(process.cwd(), "dist", "harmonics.tcd");
-      expect(existsSync(tcdPath)).toBe(true);
+    for (const variant of ["metric", "imperial"] as const) {
+      describe(variant, () => {
+        test("TCD file exists and is not empty", () => {
+          const tcdPath = join(
+            process.cwd(),
+            "dist",
+            `harmonics-${variant}.tcd`,
+          );
+          expect(existsSync(tcdPath)).toBe(true);
 
-      const stats = statSync(tcdPath);
-      expect(stats.size).toBeGreaterThan(1000); // At least 1KB
-    });
+          const stats = statSync(tcdPath);
+          expect(stats.size).toBeGreaterThan(1000); // At least 1KB
+        });
 
-    test("harmonics.txt exists and is valid", () => {
-      const harmonicsPath = join(process.cwd(), "dist", "harmonics.txt");
-      expect(existsSync(harmonicsPath)).toBe(true);
+        test("harmonics.txt exists and is valid", () => {
+          const harmonicsPath = join(
+            process.cwd(),
+            "dist",
+            `harmonics-${variant}.txt`,
+          );
+          expect(existsSync(harmonicsPath)).toBe(true);
 
-      const content = readFileSync(harmonicsPath, "utf-8");
+          const content = readFileSync(harmonicsPath, "utf-8");
 
-      // Check for required header elements
-      expect(content).toContain("# Tide Harmonics Database");
-      expect(content).toContain("MERCHANTABILITY");
-      expect(content).toContain("Number of constituents");
-    });
+          // Check for required header elements
+          expect(content).toContain("# Tide Harmonics Database");
+          expect(content).toContain("MERCHANTABILITY");
+          expect(content).toContain("Number of constituents");
+        });
 
-    test("offsets.xml exists and is valid", () => {
-      const offsetsPath = join(process.cwd(), "dist", "offsets.xml");
-      expect(existsSync(offsetsPath)).toBe(true);
+        test("offsets.xml exists and is valid", () => {
+          const offsetsPath = join(
+            process.cwd(),
+            "dist",
+            `offsets-${variant}.xml`,
+          );
+          expect(existsSync(offsetsPath)).toBe(true);
 
-      const content = readFileSync(offsetsPath, "utf-8");
+          const content = readFileSync(offsetsPath, "utf-8");
 
-      // Check for required XML structure
-      expect(content).toContain('<?xml version="1.0"');
-      expect(content).toContain("<document>");
-      expect(content).toContain("</document>");
-    });
+          // Check for required XML structure
+          expect(content).toContain('<?xml version="1.0"');
+          expect(content).toContain("<document>");
+          expect(content).toContain("</document>");
+        });
+      });
+    }
   });
 });


### PR DESCRIPTION
This fixes the datum for the TCD builds (MSL - MLLW), and splits the outputs into imperial (ft) and metric (m) builds.