### PR TITLE
Add datums and harmonic constituents to subordinate stations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neaps/tide-database",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A public database of tide harmonics",
   "keywords": [
     "tides",

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,5 +1,5 @@
 import { around, distance } from "geokdbush";
-import { allStations, qualityFilter } from "../stations.js";
+import { allStations, qualityFilter, stationsById } from "../stations.js";
 import { createGeoIndex } from "./geo.js" with { type: "macro" };
 import { loadGeoIndex } from "./geo.js";
 import { createTextIndex } from "./text.js" with { type: "macro" };
@@ -113,8 +113,6 @@ export function positionToPoint(options: Position): [number, number] {
   return [longitude, latitude];
 }
 
-const stationMap = new Map(allStations.map((s) => [s.id, s]));
-
 /**
  * Search for stations by text across name, region, country, and continent.
  * Supports fuzzy matching and prefix search.
@@ -129,7 +127,7 @@ export function search(
 
   if (combined) {
     searchOptions.filter = (result) => {
-      const station = stationMap.get(result.id);
+      const station = stationsById.get(result.id);
       return station ? combined(station) : false;
     };
   }
@@ -138,6 +136,6 @@ export function search(
 
   return results
     .slice(0, maxResults)
-    .map((result) => stationMap.get(result.id)!)
+    .map((result) => stationsById.get(result.id)!)
     .filter(Boolean);
 }

--- a/src/stations.ts
+++ b/src/stations.ts
@@ -20,4 +20,20 @@ export const allStations: Station[] = Object.entries(modules).map(
   },
 );
 
+export const stationsById = new Map(allStations.map((s) => [s.id, s]));
+
 export const stations: Station[] = allStations.filter(qualityFilter);
+
+// Populate subordinate stations with datums and harmonic constituents from their reference stations.
+allStations.forEach((station) => {
+  if (station.type === "subordinate") {
+    const reference = stationsById.get(station.offsets!.reference);
+    if (!reference)
+      throw new Error(
+        `Reference station ${station.offsets!.reference} not found for station ${station.id}`,
+      );
+
+    const { datums, harmonic_constituents } = reference;
+    Object.assign(station, { datums, harmonic_constituents });
+  }
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,8 +17,14 @@ const validate = ajv.compile(schema);
 
 stations.forEach((station) => {
   describe(station.id, () => {
-    test("is valid", () => {
-      const valid = validate(station);
+    test("is valid", async () => {
+      // Validate against the on-disk JSON, not the in-memory station. Subordinate
+      // stations are enriched at runtime with datums/harmonic_constituents from
+      // their reference station, but the schema describes the source file format.
+      const raw = JSON.parse(
+        await readFile(join(ROOT, "data", `${station.id}.json`), "utf-8"),
+      );
+      const valid = validate({ id: station.id, ...raw });
       if (!valid)
         throw new Error(
           ajv.errorsText(validate.errors) +
@@ -46,34 +52,34 @@ stations.forEach((station) => {
       }
     });
 
-    if (station.type === "reference") {
-      test("has logically ordered datums", () => {
-        const datums = station.datums;
-        if (!datums || Object.keys(datums).length === 0) return;
+    test("has logically ordered datums", () => {
+      const datums = station.datums;
+      if (!datums || Object.keys(datums).length === 0) return;
 
-        // MHHW/MHW and MLW/MLLW are diurnal-pair averages that converge at weakly
-        // diurnal stations, so their relative ordering is not enforced here.
-        // MSL and MTL can appear in either order depending on tidal asymmetry,
-        // so they are checked independently against their shared bounds.
-        const CHAINS = [
-          ["MHW", "MSL", "MLW", "LAT"],
-          ["MHW", "MTL", "MLW"],
-        ] as const;
-        for (const chain of CHAINS) {
-          for (let i = 0; i < chain.length - 1; i++) {
-            const higher = chain[i]!;
-            const lower = chain[i + 1]!;
-            const h = datums[higher],
-              l = datums[lower];
-            if (h === undefined || l === undefined) continue;
-            expect(
-              h,
-              `Station ${station.id}: ${higher} (${h.toFixed(3)}m) should be >= ${lower} (${l.toFixed(3)}m)`,
-            ).toBeGreaterThanOrEqual(l);
-          }
+      // MHHW/MHW and MLW/MLLW are diurnal-pair averages that converge at weakly
+      // diurnal stations, so their relative ordering is not enforced here.
+      // MSL and MTL can appear in either order depending on tidal asymmetry,
+      // so they are checked independently against their shared bounds.
+      const CHAINS = [
+        ["MHW", "MSL", "MLW", "LAT"],
+        ["MHW", "MTL", "MLW"],
+      ] as const;
+      for (const chain of CHAINS) {
+        for (let i = 0; i < chain.length - 1; i++) {
+          const higher = chain[i]!;
+          const lower = chain[i + 1]!;
+          const h = datums[higher],
+            l = datums[lower];
+          if (h === undefined || l === undefined) continue;
+          expect(
+            h,
+            `Station ${station.id}: ${higher} (${h.toFixed(3)}m) should be >= ${lower} (${l.toFixed(3)}m)`,
+          ).toBeGreaterThanOrEqual(l);
         }
-      });
-    } else if (station.type === "subordinate") {
+      }
+    });
+
+    if (station.type === "subordinate") {
       test("has valid reference station", () => {
         const id = station.offsets!.reference;
         const reference = stations.find((s) => s.id === id);


### PR DESCRIPTION
This updates the npm module to include the reference station's datums and harmonic constituents in the subordinate station's data so it doesn't have to manually resolve them.

cc https://github.com/openwatersio/neaps/pull/198