### PR TITLE
Re-reference RWS harmonic phases to UTC (DST fix)

### DIFF
--- a/data/ticon/altengamme-5930070-deu-wsv.json
+++ b/data/ticon/altengamme-5930070-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.0634550956371462,
-      "phase": 125.91952474969247
+      "amplitude": 1.063,
+      "phase": 125.92
     },
     {
       "name": "N2",
-      "amplitude": 0.15515122593208047,
-      "phase": 99.35948692232915
+      "amplitude": 0.155,
+      "phase": 99.36
     },
     {
       "name": "S2",
-      "amplitude": 0.24402035613577522,
-      "phase": 205.7147603166758
+      "amplitude": 0.244,
+      "phase": 205.71
     },
     {
       "name": "K2",
-      "amplitude": 0.06767222219098609,
-      "phase": 208.6385351386185
+      "amplitude": 0.068,
+      "phase": 208.64
     },
     {
       "name": "2N2",
-      "amplitude": 0.015850994821754897,
-      "phase": 76.42464040614414
+      "amplitude": 0.016,
+      "phase": 76.42
     },
     {
       "name": "S1",
-      "amplitude": 0.018310724138605777,
-      "phase": 103.94619535407611
+      "amplitude": 0.018,
+      "phase": 103.95
     },
     {
       "name": "K1",
-      "amplitude": 0.061328476420085945,
-      "phase": 131.56149689366873
+      "amplitude": 0.061,
+      "phase": 131.56
     },
     {
       "name": "P1",
-      "amplitude": 0.021835394093874413,
-      "phase": 116.017115061776
+      "amplitude": 0.022,
+      "phase": 116.02
     },
     {
       "name": "O1",
-      "amplitude": 0.07219894526241748,
-      "phase": 331.317189531614
+      "amplitude": 0.072,
+      "phase": 331.32
     },
     {
       "name": "Q1",
-      "amplitude": 0.01902391515838958,
-      "phase": 268.69265215664
+      "amplitude": 0.019,
+      "phase": 268.69
     },
     {
       "name": "M1",
-      "amplitude": 0.0019190456207012266,
-      "phase": 167.24734400496936
+      "amplitude": 0.002,
+      "phase": 167.25
     },
     {
       "name": "M4",
-      "amplitude": 0.19886865969115983,
-      "phase": 181.17340484471666
+      "amplitude": 0.199,
+      "phase": 181.17
     },
     {
       "name": "MM",
-      "amplitude": 0.020942406665033813,
-      "phase": 78.25677012552558
+      "amplitude": 0.021,
+      "phase": 78.26
     },
     {
       "name": "MF",
-      "amplitude": 0.020184763627954738,
-      "phase": 82.19698596217148
+      "amplitude": 0.02,
+      "phase": 82.2
     },
     {
       "name": "SA",
-      "amplitude": 0.40585873855794624,
-      "phase": 327.6658178859095
+      "amplitude": 0.406,
+      "phase": 327.67
     },
     {
       "name": "SSA",
-      "amplitude": 0.12008528885749001,
-      "phase": 304.4126969058273
+      "amplitude": 0.12,
+      "phase": 304.41
     },
     {
       "name": "T2",
-      "amplitude": 0.010500970527306105,
-      "phase": 304.5290632213237
+      "amplitude": 0.011,
+      "phase": 304.53
     },
     {
       "name": "J1",
-      "amplitude": 0.006659950362529009,
-      "phase": 250.32308063331732
+      "amplitude": 0.007,
+      "phase": 250.32
     },
     {
       "name": "L2",
-      "amplitude": 0.10136092626798525,
-      "phase": 142.92532996808882
+      "amplitude": 0.101,
+      "phase": 142.93
     },
     {
       "name": "R2",
-      "amplitude": 0.029202275444039374,
-      "phase": 274.55026614369126
+      "amplitude": 0.029,
+      "phase": 274.55
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004515722009856867,
-      "phase": 202.4919227547935
+      "amplitude": 0.005,
+      "phase": 202.49
     },
     {
       "name": "MSF",
-      "amplitude": 0.0882560668529061,
-      "phase": 66.16547626914132
+      "amplitude": 0.088,
+      "phase": 66.17
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00786585610636245,
-      "phase": 27.512536871603572
+      "amplitude": 0.008,
+      "phase": 27.51
     },
     {
       "name": "EP2",
-      "amplitude": 0.027447880733335966,
-      "phase": 183.05584363366034
+      "amplitude": 0.027,
+      "phase": 183.06
     },
     {
       "name": "M3",
-      "amplitude": 0.0038331409389926966,
-      "phase": 214.253134200552
+      "amplitude": 0.004,
+      "phase": 214.25
     },
     {
       "name": "MU2",
-      "amplitude": 0.1450117957988137,
-      "phase": 211.4295821052205
+      "amplitude": 0.145,
+      "phase": 211.43
     },
     {
       "name": "MTM",
-      "amplitude": 0.0014235239868112966,
-      "phase": 134.61188626907688
+      "amplitude": 0.001,
+      "phase": 134.61
     },
     {
       "name": "NU2",
-      "amplitude": 0.07269869323172523,
-      "phase": 79.57388866402289
+      "amplitude": 0.073,
+      "phase": 79.57
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04594846879711435,
-      "phase": 146.60914716360594
+      "amplitude": 0.046,
+      "phase": 146.61
     },
     {
       "name": "MN4",
-      "amplitude": 0.06379599893506349,
-      "phase": 154.63590625634822
+      "amplitude": 0.064,
+      "phase": 154.64
     },
     {
       "name": "MS4",
-      "amplitude": 0.10296897750724118,
-      "phase": 258.84331363563683
+      "amplitude": 0.103,
+      "phase": 258.84
     },
     {
       "name": "N4",
-      "amplitude": 0.012164164983349516,
-      "phase": 132.7471218846183
+      "amplitude": 0.012,
+      "phase": 132.75
     },
     {
       "name": "M6",
-      "amplitude": 0.02444055400576266,
-      "phase": 156.39600047392616
+      "amplitude": 0.024,
+      "phase": 156.4
     },
     {
       "name": "M8",
-      "amplitude": 0.01898722314983192,
-      "phase": 151.25993547657015
+      "amplitude": 0.019,
+      "phase": 151.26
     },
     {
       "name": "S4",
-      "amplitude": 0.0073272291458032,
-      "phase": 46.869339949936546
+      "amplitude": 0.007,
+      "phase": 46.87
     },
     {
       "name": "OO1",
-      "amplitude": 0.0022240286787940738,
-      "phase": 254.40016990360056
+      "amplitude": 0.002,
+      "phase": 254.4
     },
     {
       "name": "S3",
-      "amplitude": 0.0009632112962942281,
-      "phase": 131.63426181052853
+      "amplitude": 0.001,
+      "phase": 131.63
     },
     {
       "name": "MA2",
-      "amplitude": 0.08971478078426601,
-      "phase": 349.0618877280571
+      "amplitude": 0.09,
+      "phase": 349.06
     },
     {
       "name": "MB2",
-      "amplitude": 0.10695288158646588,
-      "phase": 278.3168813264651
+      "amplitude": 0.107,
+      "phase": 278.32
     },
     {
       "name": "T3",
-      "amplitude": 0.0017457451954496887,
-      "phase": 226.9376769852411
+      "amplitude": 0.002,
+      "phase": 226.94
     },
     {
       "name": "R3",
-      "amplitude": 0.005584411345816599,
-      "phase": 253.18905660311154
+      "amplitude": 0.006,
+      "phase": 253.19
     },
     {
       "name": "RHO1",
-      "amplitude": 0.003983671877121441,
-      "phase": 276.5213228912137
+      "amplitude": 0.004,
+      "phase": 276.52
     },
     {
       "name": "SGM",
-      "amplitude": 0.005533627184321145,
-      "phase": 106.21520197960132
+      "amplitude": 0.006,
+      "phase": 106.22
     },
     {
       "name": "3L2",
-      "amplitude": 0.0008701545494938874,
-      "phase": 151.76673229705506
+      "amplitude": 0.001,
+      "phase": 151.77
     },
     {
       "name": "3N2",
-      "amplitude": 0.04615250585109421,
-      "phase": 272.13902623974013
+      "amplitude": 0.046,
+      "phase": 272.14
     },
     {
       "name": "2SM2",
-      "amplitude": 0.025151853474030293,
-      "phase": 77.21841023333349
+      "amplitude": 0.025,
+      "phase": 77.22
     },
     {
       "name": "2MS6",
-      "amplitude": 0.022354649289631615,
-      "phase": 234.56000180020044
+      "amplitude": 0.022,
+      "phase": 234.56
     },
     {
       "name": "2MK5",
-      "amplitude": 0.002423923720490488,
-      "phase": 165.7762569775282
+      "amplitude": 0.002,
+      "phase": 165.78
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0044834821963954455,
-      "phase": 56.595794792439506
+      "amplitude": 0.004,
+      "phase": 56.6
     }
   ],
   "epoch": {

--- a/data/ticon/althagen-9650024-deu-wsv.json
+++ b/data/ticon/althagen-9650024-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.00030552310932773933,
-      "phase": 159.7514573782505
+      "amplitude": 0,
+      "phase": 159.75
     },
     {
       "name": "N2",
-      "amplitude": 0.00003916591868658455,
-      "phase": 128.77234772881923
+      "amplitude": 0,
+      "phase": 128.77
     },
     {
       "name": "S2",
-      "amplitude": 0.0005917657741215493,
-      "phase": 250.6636339832329
+      "amplitude": 0.001,
+      "phase": 250.66
     },
     {
       "name": "K2",
-      "amplitude": 0.00006477599306900768,
-      "phase": 317.57580747653196
+      "amplitude": 0,
+      "phase": 317.58
     },
     {
       "name": "2N2",
-      "amplitude": 0.00007596102468447343,
-      "phase": 12.200427564361348
+      "amplitude": 0,
+      "phase": 12.2
     },
     {
       "name": "S1",
-      "amplitude": 0.001471988746090793,
-      "phase": 242.90311569938441
+      "amplitude": 0.001,
+      "phase": 242.9
     },
     {
       "name": "K1",
-      "amplitude": 0.00035458082429943574,
-      "phase": 318.90175270694573
+      "amplitude": 0,
+      "phase": 318.9
     },
     {
       "name": "P1",
-      "amplitude": 0.0008025576075193608,
-      "phase": 215.49438950273077
+      "amplitude": 0.001,
+      "phase": 215.49
     },
     {
       "name": "O1",
-      "amplitude": 0.0006407846423628992,
-      "phase": 347.8368426951119
+      "amplitude": 0.001,
+      "phase": 347.84
     },
     {
       "name": "Q1",
-      "amplitude": 0.00016045388341447999,
-      "phase": 285.84360113871526
+      "amplitude": 0,
+      "phase": 285.84
     },
     {
       "name": "M1",
-      "amplitude": 0.00006637462676333177,
-      "phase": 331.0402192991705
+      "amplitude": 0,
+      "phase": 331.04
     },
     {
       "name": "M4",
-      "amplitude": 0.000019458055610235742,
-      "phase": 61.85596201727736
+      "amplitude": 0,
+      "phase": 61.86
     },
     {
       "name": "MM",
-      "amplitude": 0.014191128924887296,
-      "phase": 337.33658335617
+      "amplitude": 0.014,
+      "phase": 337.34
     },
     {
       "name": "MF",
-      "amplitude": 0.009132883585229542,
-      "phase": 311.13941638878515
+      "amplitude": 0.009,
+      "phase": 311.14
     },
     {
       "name": "SA",
-      "amplitude": 0.04191550639213812,
-      "phase": 216.55988480520728
+      "amplitude": 0.042,
+      "phase": 216.56
     },
     {
       "name": "SSA",
-      "amplitude": 0.0176703530266823,
-      "phase": 286.08432771574974
+      "amplitude": 0.018,
+      "phase": 286.08
     },
     {
       "name": "T2",
-      "amplitude": 0.00011408713602450227,
-      "phase": 67.22278236489649
+      "amplitude": 0,
+      "phase": 67.22
     },
     {
       "name": "J1",
-      "amplitude": 0.0000643596385667109,
-      "phase": 134.2565424357236
+      "amplitude": 0,
+      "phase": 134.26
     },
     {
       "name": "L2",
-      "amplitude": 0.00006711777294222605,
-      "phase": 107.8458620641452
+      "amplitude": 0,
+      "phase": 107.85
     },
     {
       "name": "R2",
-      "amplitude": 0.00009686929564163759,
-      "phase": 177.39929486764913
+      "amplitude": 0,
+      "phase": 177.4
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00004243091646787903,
-      "phase": 188.52475307684384
+      "amplitude": 0,
+      "phase": 188.52
     },
     {
       "name": "MSF",
-      "amplitude": 0.0010880544101944884,
-      "phase": 46.45333755169344
+      "amplitude": 0.001,
+      "phase": 46.45
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0040798497070725255,
-      "phase": 273.2170309311824
+      "amplitude": 0.004,
+      "phase": 273.22
     },
     {
       "name": "EP2",
-      "amplitude": 0.000015246984680391459,
-      "phase": 67.34317643594812
+      "amplitude": 0,
+      "phase": 67.34
     },
     {
       "name": "M3",
-      "amplitude": 0.00002968210102377124,
-      "phase": 354.00802886879205
+      "amplitude": 0,
+      "phase": 354.01
     },
     {
       "name": "MU2",
-      "amplitude": 0.000044018371150580834,
-      "phase": 52.63737244156613
+      "amplitude": 0,
+      "phase": 52.64
     },
     {
       "name": "MTM",
-      "amplitude": 0.002279208240666398,
-      "phase": 67.91414129802524
+      "amplitude": 0.002,
+      "phase": 67.91
     },
     {
       "name": "NU2",
-      "amplitude": 0.000038789717527227485,
-      "phase": 156.98428269090368
+      "amplitude": 0,
+      "phase": 156.98
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00004457998238922904,
-      "phase": 323.7583971779626
+      "amplitude": 0,
+      "phase": 323.76
     },
     {
       "name": "MN4",
-      "amplitude": 0.000022569023357938834,
-      "phase": 164.5621070890213
+      "amplitude": 0,
+      "phase": 164.56
     },
     {
       "name": "MS4",
-      "amplitude": 0.000028387299095008358,
-      "phase": 127.82792101146765
+      "amplitude": 0,
+      "phase": 127.83
     },
     {
       "name": "N4",
-      "amplitude": 0.000017911077191017133,
-      "phase": 240.21612340928328
+      "amplitude": 0,
+      "phase": 240.22
     },
     {
       "name": "M6",
-      "amplitude": 0.000018539042611834637,
-      "phase": 12.801660718259939
+      "amplitude": 0,
+      "phase": 12.8
     },
     {
       "name": "M8",
-      "amplitude": 0.00002338740777090159,
-      "phase": 60.076510388072336
+      "amplitude": 0,
+      "phase": 60.08
     },
     {
       "name": "S4",
-      "amplitude": 0.000011807335740745634,
-      "phase": 314.6070943866381
+      "amplitude": 0,
+      "phase": 314.61
     },
     {
       "name": "OO1",
-      "amplitude": 0.0001514671528479871,
-      "phase": 21.282724604305827
+      "amplitude": 0,
+      "phase": 21.28
     },
     {
       "name": "S3",
-      "amplitude": 0.00010735311683709531,
-      "phase": 63.697680268145064
+      "amplitude": 0,
+      "phase": 63.7
     },
     {
       "name": "MA2",
-      "amplitude": 0.000051501816216860254,
-      "phase": 184.8223812803188
+      "amplitude": 0,
+      "phase": 184.82
     },
     {
       "name": "MB2",
-      "amplitude": 0.000016862741417071348,
-      "phase": 20.797422069726338
+      "amplitude": 0,
+      "phase": 20.8
     },
     {
       "name": "T3",
-      "amplitude": 0.000050467353361604256,
-      "phase": 40.39394221082182
+      "amplitude": 0,
+      "phase": 40.39
     },
     {
       "name": "R3",
-      "amplitude": 0.00006171484453272846,
-      "phase": 144.8946918132266
+      "amplitude": 0,
+      "phase": 144.89
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00007314126227312696,
-      "phase": 342.0690417906245
+      "amplitude": 0,
+      "phase": 342.07
     },
     {
       "name": "SGM",
-      "amplitude": 0.00008107205013354971,
-      "phase": 135.43308272298896
+      "amplitude": 0,
+      "phase": 135.43
     },
     {
       "name": "3L2",
-      "amplitude": 0.000009917260210667028,
-      "phase": 324.98564621136995
+      "amplitude": 0,
+      "phase": 324.99
     },
     {
       "name": "3N2",
-      "amplitude": 0.000030176512804060114,
-      "phase": 283.7549619885298
+      "amplitude": 0,
+      "phase": 283.75
     },
     {
       "name": "2SM2",
-      "amplitude": 0.000029169056152525034,
-      "phase": 161.4074794578837
+      "amplitude": 0,
+      "phase": 161.41
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000013875491870825642,
-      "phase": 340.4730925417723
+      "amplitude": 0,
+      "phase": 340.47
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0000331363411536964,
-      "phase": 231.76174155637628
+      "amplitude": 0,
+      "phase": 231.76
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0000038683895249414845,
-      "phase": 124.57486779269556
+      "amplitude": 0,
+      "phase": 124.57
     }
   ],
   "epoch": {

--- a/data/ticon/amaliahaven-amlahvn-nld-rws.json
+++ b/data/ticon/amaliahaven-amlahvn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.80260602,
-      "phase": 74.06564700000001
+      "amplitude": 0.834,
+      "phase": 57.38
     },
     {
       "name": "N2",
-      "amplitude": 0.14962011,
-      "phase": 46.46180400000003
+      "amplitude": 0.119,
+      "phase": 28.76
     },
     {
       "name": "S2",
-      "amplitude": 0.1910245,
-      "phase": 136.42485499999998
+      "amplitude": 0.198,
+      "phase": 118.57
     },
     {
       "name": "K2",
-      "amplitude": 0.048583100000000004,
-      "phase": 146.69401500000004
+      "amplitude": 0.058,
+      "phase": 116.55
     },
     {
       "name": "2N2",
-      "amplitude": 0.02257204,
-      "phase": 43.996605999999986
+      "amplitude": 0.024,
+      "phase": 30.12
     },
     {
       "name": "S1",
-      "amplitude": 0.00817297,
-      "phase": 8.967804999999998
+      "amplitude": 0.008,
+      "phase": 296.96
     },
     {
       "name": "K1",
-      "amplitude": 0.08727008,
-      "phase": 350.524677
+      "amplitude": 0.088,
+      "phase": 341.13
     },
     {
       "name": "P1",
-      "amplitude": 0.0341905,
-      "phase": 336.172031
+      "amplitude": 0.034,
+      "phase": 330.44
     },
     {
       "name": "O1",
-      "amplitude": 0.10560394000000001,
-      "phase": 190.828093
+      "amplitude": 0.106,
+      "phase": 181.26
     },
     {
       "name": "Q1",
-      "amplitude": 0.04854647,
-      "phase": 137.63210600000002
+      "amplitude": 0.048,
+      "phase": 129.96
     },
     {
       "name": "M1",
-      "amplitude": 0.01286518,
-      "phase": 296.309557
+      "amplitude": 0.011,
+      "phase": 330.78
     },
     {
       "name": "M4",
-      "amplitude": 0.17957,
-      "phase": 140.57298300000002
+      "amplitude": 0.211,
+      "phase": 100.92
     },
     {
       "name": "MM",
-      "amplitude": 0.01722587,
-      "phase": 251.804304
+      "amplitude": 0.018,
+      "phase": 249.75
     },
     {
       "name": "MF",
-      "amplitude": 0.01092496,
-      "phase": 141.24415599999998
+      "amplitude": 0.01,
+      "phase": 140.24
     },
     {
       "name": "SA",
-      "amplitude": 0.09814598000000001,
-      "phase": 209.167926
+      "amplitude": 0.108,
+      "phase": 213.27
     },
     {
       "name": "SSA",
-      "amplitude": 0.02488205,
-      "phase": 121.28573
+      "amplitude": 0.025,
+      "phase": 120.7
     },
     {
       "name": "T2",
-      "amplitude": 0.03542082,
-      "phase": 58.93946699999998
+      "amplitude": 0.017,
+      "phase": 96.74
     },
     {
       "name": "J1",
-      "amplitude": 0.00830337,
-      "phase": 77.617953
+      "amplitude": 0.01,
+      "phase": 67.29
     },
     {
       "name": "L2",
-      "amplitude": 0.08165541,
-      "phase": 93.019046
+      "amplitude": 0.082,
+      "phase": 72.04
     },
     {
       "name": "R2",
-      "amplitude": 0.025836519999999998,
-      "phase": 240.67393800000002
+      "amplitude": 0.003,
+      "phase": 8.21
     },
     {
       "name": "2Q1",
-      "amplitude": 0.007142389999999999,
-      "phase": 59.23792800000001
+      "amplitude": 0.008,
+      "phase": 45.37
     },
     {
       "name": "MSF",
-      "amplitude": 0.01656388,
-      "phase": 29.403187000000003
+      "amplitude": 0.016,
+      "phase": 26.88
     },
     {
       "name": "MSQM",
-      "amplitude": 0.021377709999999998,
-      "phase": 320.181945
+      "amplitude": 0.021,
+      "phase": 318.21
     },
     {
       "name": "EP2",
-      "amplitude": 0.015993280000000002,
-      "phase": 167.005991
+      "amplitude": 0.015,
+      "phase": 150.9
     },
     {
       "name": "M3",
-      "amplitude": 0.00214224,
-      "phase": 312.125319
+      "amplitude": 0.002,
+      "phase": 104.78
     },
     {
       "name": "MU2",
-      "amplitude": 0.08408112,
-      "phase": 191.401089
+      "amplitude": 0.086,
+      "phase": 175.7
     },
     {
       "name": "MTM",
-      "amplitude": 0.0087033,
-      "phase": 202.309703
+      "amplitude": 0.009,
+      "phase": 203.35
     },
     {
       "name": "NU2",
-      "amplitude": 0.04867039,
-      "phase": 46.62016599999998
+      "amplitude": 0.052,
+      "phase": 24.08
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03190474,
-      "phase": 95.933673
+      "amplitude": 0.034,
+      "phase": 82.76
     },
     {
       "name": "MN4",
-      "amplitude": 0.06660815,
-      "phase": 113.18012599999997
+      "amplitude": 0.074,
+      "phase": 77.13
     },
     {
       "name": "MS4",
-      "amplitude": 0.10906454,
-      "phase": 195.688741
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.040022,
-      "phase": 206.851113
+      "amplitude": 0.13,
+      "phase": 156.8
     },
     {
       "name": "N4",
-      "amplitude": 0.01705436,
-      "phase": 85.62317200000001
+      "amplitude": 0.018,
+      "phase": 60.84
     },
     {
       "name": "M6",
-      "amplitude": 0.04832792,
-      "phase": 105.03202299999998
+      "amplitude": 0.062,
+      "phase": 49.1
     },
     {
       "name": "M8",
-      "amplitude": 0.021401240000000002,
-      "phase": 212.23896
+      "amplitude": 0.039,
+      "phase": 117.61
     },
     {
       "name": "S4",
-      "amplitude": 0.00915374,
-      "phase": 277.172984
+      "amplitude": 0.009,
+      "phase": 232.22
     },
     {
       "name": "OO1",
-      "amplitude": 0.00051132,
-      "phase": 133.45759899999996
+      "amplitude": 0.001,
+      "phase": 20.51
     },
     {
       "name": "S3",
-      "amplitude": 0.00263181,
-      "phase": 24.246013000000005
+      "amplitude": 0.001,
+      "phase": 164.01
     },
     {
       "name": "MA2",
-      "amplitude": 0.146518,
-      "phase": 52.934934999999996
+      "amplitude": 0.024,
+      "phase": 51.44
     },
     {
       "name": "MB2",
-      "amplitude": 0.11873570000000001,
-      "phase": 271.27981
+      "amplitude": 0.013,
+      "phase": 68.63
     },
     {
       "name": "T3",
-      "amplitude": 0.0008311200000000001,
-      "phase": 16.430226000000005
+      "amplitude": 0.001,
+      "phase": 198.6
     },
     {
       "name": "R3",
-      "amplitude": 0.00485662,
-      "phase": 239.776113
+      "amplitude": 0.006,
+      "phase": 304.95
     },
     {
       "name": "RHO1",
-      "amplitude": 0.01143269,
-      "phase": 142.060251
+      "amplitude": 0.014,
+      "phase": 128.63
     },
     {
       "name": "SGM",
-      "amplitude": 0.00154821,
-      "phase": 118.92533400000002
+      "amplitude": 0.002,
+      "phase": 303.44
     },
     {
       "name": "3L2",
-      "amplitude": 0.02487668,
-      "phase": 231.270473
+      "amplitude": 0.022,
+      "phase": 310.02
     },
     {
       "name": "3N2",
-      "amplitude": 0.034096600000000005,
-      "phase": 17.516902000000016
+      "amplitude": 0.007,
+      "phase": 233.97
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02093029,
-      "phase": 12.605305999999985
+      "amplitude": 0.023,
+      "phase": 352.12
     },
     {
       "name": "2MS6",
-      "amplitude": 0.038577810000000004,
-      "phase": 164.540437
+      "amplitude": 0.051,
+      "phase": 106.86
     },
     {
       "name": "2MK5",
-      "amplitude": 0.013028370000000001,
-      "phase": 253.578025
+      "amplitude": 0.018,
+      "phase": 301.52
     },
     {
       "name": "2MO5",
-      "amplitude": 0.01265174,
-      "phase": 301.273006
+      "amplitude": 0.018,
+      "phase": 152.59
     }
   ],
   "epoch": {

--- a/data/ticon/amelander_westgat_platform-awgpfm-nld-rws.json
+++ b/data/ticon/amelander_westgat_platform-awgpfm-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.9061537900000001,
-      "phase": 253.612168
+      "amplitude": 0.938,
+      "phase": 236.46
     },
     {
       "name": "N2",
-      "amplitude": 0.14883055,
-      "phase": 229.178128
+      "amplitude": 0.154,
+      "phase": 212.15
     },
     {
       "name": "S2",
-      "amplitude": 0.24636116000000002,
-      "phase": 316.086132
+      "amplitude": 0.254,
+      "phase": 298.25
     },
     {
       "name": "K2",
-      "amplitude": 0.06696352,
-      "phase": 321.25190299999997
+      "amplitude": 0.075,
+      "phase": 296.87
     },
     {
       "name": "2N2",
-      "amplitude": 0.021008520000000003,
-      "phase": 210.246872
+      "amplitude": 0.021,
+      "phase": 194.13
     },
     {
       "name": "S1",
-      "amplitude": 0.00723491,
-      "phase": 34.046809999999994
+      "amplitude": 0.006,
+      "phase": 317.81
     },
     {
       "name": "K1",
-      "amplitude": 0.07175015,
-      "phase": 4.362302
+      "amplitude": 0.072,
+      "phase": 355.57
     },
     {
       "name": "P1",
-      "amplitude": 0.026368990000000002,
-      "phase": 4.433898999999997
+      "amplitude": 0.027,
+      "phase": 357.79
     },
     {
       "name": "O1",
-      "amplitude": 0.08822252000000001,
-      "phase": 210.301975
+      "amplitude": 0.088,
+      "phase": 202.31
     },
     {
       "name": "Q1",
-      "amplitude": 0.029885039999999998,
-      "phase": 152.289666
+      "amplitude": 0.03,
+      "phase": 143.97
     },
     {
       "name": "M1",
-      "amplitude": 0.00027052,
-      "phase": 77.59790499999997
+      "amplitude": 0.002,
+      "phase": 50.31
     },
     {
       "name": "M4",
-      "amplitude": 0.07597451999999999,
-      "phase": 358.640679
+      "amplitude": 0.09,
+      "phase": 320.76
     },
     {
       "name": "MM",
-      "amplitude": 0.01985245,
-      "phase": 200.571046
+      "amplitude": 0.02,
+      "phase": 199.19
     },
     {
       "name": "MF",
-      "amplitude": 0.01155931,
-      "phase": 164.55684799999995
+      "amplitude": 0.011,
+      "phase": 164.51
     },
     {
       "name": "SA",
-      "amplitude": 0.10334165000000001,
-      "phase": 223.624145
+      "amplitude": 0.102,
+      "phase": 224.04
     },
     {
       "name": "SSA",
-      "amplitude": 0.022462990000000002,
-      "phase": 192.306191
+      "amplitude": 0.023,
+      "phase": 192.75
     },
     {
       "name": "T2",
-      "amplitude": 0.04567572,
-      "phase": 228.923792
+      "amplitude": 0.013,
+      "phase": 276.83
     },
     {
       "name": "J1",
-      "amplitude": 0.00173462,
-      "phase": 71.37382000000002
+      "amplitude": 0.002,
+      "phase": 60.64
     },
     {
       "name": "L2",
-      "amplitude": 0.06754386,
-      "phase": 271.684553
+      "amplitude": 0.068,
+      "phase": 253.13
     },
     {
       "name": "R2",
-      "amplitude": 0.03182835,
-      "phase": 57.65630599999997
+      "amplitude": 0.003,
+      "phase": 298.99
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00555634,
-      "phase": 97.06163900000001
+      "amplitude": 0.006,
+      "phase": 91.55
     },
     {
       "name": "MSF",
-      "amplitude": 0.01267774,
-      "phase": 42.429328999999996
+      "amplitude": 0.012,
+      "phase": 42.72
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0013564399999999998,
-      "phase": 74.805499
+      "amplitude": 0.001,
+      "phase": 74.98
     },
     {
       "name": "EP2",
-      "amplitude": 0.01704769,
-      "phase": 321.58702900000003
+      "amplitude": 0.017,
+      "phase": 305.49
     },
     {
       "name": "M3",
-      "amplitude": 0.0036646,
-      "phase": 40.20554099999998
+      "amplitude": 0.004,
+      "phase": 192.03
     },
     {
       "name": "MU2",
-      "amplitude": 0.07045129,
-      "phase": 346.346936
+      "amplitude": 0.075,
+      "phase": 329.31
     },
     {
       "name": "MTM",
-      "amplitude": 0.00577294,
-      "phase": 258.262903
+      "amplitude": 0.005,
+      "phase": 259.12
     },
     {
       "name": "NU2",
-      "amplitude": 0.04893547,
-      "phase": 216.085406
+      "amplitude": 0.05,
+      "phase": 199.6
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.029374760000000003,
-      "phase": 264.63892699999997
+      "amplitude": 0.032,
+      "phase": 245.94
     },
     {
       "name": "MN4",
-      "amplitude": 0.023892959999999998,
-      "phase": 331.427061
+      "amplitude": 0.029,
+      "phase": 295.75
     },
     {
       "name": "MS4",
-      "amplitude": 0.05276484,
-      "phase": 68.42740600000002
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.0413531,
-      "phase": 30.550523
+      "amplitude": 0.061,
+      "phase": 32.07
     },
     {
       "name": "N4",
-      "amplitude": 0.0064602800000000005,
-      "phase": 316.464994
+      "amplitude": 0.007,
+      "phase": 281.64
     },
     {
       "name": "M6",
-      "amplitude": 0.02853448,
-      "phase": 148.634953
+      "amplitude": 0.04,
+      "phase": 90.56
     },
     {
       "name": "M8",
-      "amplitude": 0.00701559,
-      "phase": 341.91368
+      "amplitude": 0.013,
+      "phase": 255.45
     },
     {
       "name": "S4",
-      "amplitude": 0.006378190000000001,
-      "phase": 198.944922
+      "amplitude": 0.007,
+      "phase": 165.25
     },
     {
       "name": "OO1",
-      "amplitude": 0.00182656,
-      "phase": 192.024206
+      "amplitude": 0.002,
+      "phase": 151.46
     },
     {
       "name": "S3",
-      "amplitude": 0.00056959,
-      "phase": 269.38804500000003
+      "amplitude": 0.001,
+      "phase": 51.69
     },
     {
       "name": "MA2",
-      "amplitude": 0.16699414,
-      "phase": 227.615122
+      "amplitude": 0.025,
+      "phase": 193.26
     },
     {
       "name": "MB2",
-      "amplitude": 0.14297002,
-      "phase": 85.547305
+      "amplitude": 0.014,
+      "phase": 335.75
     },
     {
       "name": "T3",
-      "amplitude": 0.0011787400000000002,
-      "phase": 125.46954399999998
+      "amplitude": 0.001,
+      "phase": 288.51
     },
     {
       "name": "R3",
-      "amplitude": 0.00196136,
-      "phase": 194.024061
+      "amplitude": 0.002,
+      "phase": 252.47
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00632459,
-      "phase": 157.89165500000001
+      "amplitude": 0.006,
+      "phase": 155.26
     },
     {
       "name": "SGM",
-      "amplitude": 0.0026324599999999997,
-      "phase": 241.745826
+      "amplitude": 0.003,
+      "phase": 49.94
     },
     {
       "name": "3L2",
-      "amplitude": 0.00539778,
-      "phase": 98.91480999999999
+      "amplitude": 0.004,
+      "phase": 161.51
     },
     {
       "name": "3N2",
-      "amplitude": 0.00319471,
-      "phase": 81.82948299999998
+      "amplitude": 0.008,
+      "phase": 48.01
     },
     {
       "name": "2SM2",
-      "amplitude": 0.020693410000000002,
-      "phase": 175.11719400000004
+      "amplitude": 0.021,
+      "phase": 157.23
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02606226,
-      "phase": 209.040683
+      "amplitude": 0.036,
+      "phase": 150.72
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00192216,
-      "phase": 74.62059299999999
+      "amplitude": 0.002,
+      "phase": 113.93
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00205681,
-      "phase": 246.96171800000002
+      "amplitude": 0.003,
+      "phase": 111.02
     }
   ],
   "epoch": {

--- a/data/ticon/anklam-9660001-deu-wsv.json
+++ b/data/ticon/anklam-9660001-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.0018535286805089705,
-      "phase": 124.60653793261974
+      "amplitude": 0.002,
+      "phase": 124.61
     },
     {
       "name": "N2",
-      "amplitude": 0.0004248214246421002,
-      "phase": 88.82566411085071
+      "amplitude": 0,
+      "phase": 88.83
     },
     {
       "name": "S2",
-      "amplitude": 0.001209306441210808,
-      "phase": 189.0175351598345
+      "amplitude": 0.001,
+      "phase": 189.02
     },
     {
       "name": "K2",
-      "amplitude": 0.00008524871443460817,
-      "phase": 212.99126508688465
+      "amplitude": 0,
+      "phase": 212.99
     },
     {
       "name": "2N2",
-      "amplitude": 0.00022934004150439307,
-      "phase": 30.645455425883313
+      "amplitude": 0,
+      "phase": 30.65
     },
     {
       "name": "S1",
-      "amplitude": 0.0043637315417651285,
-      "phase": 166.20964783583588
+      "amplitude": 0.004,
+      "phase": 166.21
     },
     {
       "name": "K1",
-      "amplitude": 0.0010879630732407296,
-      "phase": 223.7185781713065
+      "amplitude": 0.001,
+      "phase": 223.72
     },
     {
       "name": "P1",
-      "amplitude": 0.001283758542099779,
-      "phase": 146.55318804548955
+      "amplitude": 0.001,
+      "phase": 146.55
     },
     {
       "name": "O1",
-      "amplitude": 0.002630067431498809,
-      "phase": 259.6842153784828
+      "amplitude": 0.003,
+      "phase": 259.68
     },
     {
       "name": "Q1",
-      "amplitude": 0.0008225977192602669,
-      "phase": 214.33802276019415
+      "amplitude": 0.001,
+      "phase": 214.34
     },
     {
       "name": "M1",
-      "amplitude": 0.00016767344284109696,
-      "phase": 203.80981674863176
+      "amplitude": 0,
+      "phase": 203.81
     },
     {
       "name": "M4",
-      "amplitude": 0.00008204368756956618,
-      "phase": 218.9203596680532
+      "amplitude": 0,
+      "phase": 218.92
     },
     {
       "name": "MM",
-      "amplitude": 0.010943450927327177,
-      "phase": 297.9420932510117
+      "amplitude": 0.011,
+      "phase": 297.94
     },
     {
       "name": "MF",
-      "amplitude": 0.0073529093993780405,
-      "phase": 291.29080102108196
+      "amplitude": 0.007,
+      "phase": 291.29
     },
     {
       "name": "SA",
-      "amplitude": 0.02358664932896237,
-      "phase": 240.84874358862885
+      "amplitude": 0.024,
+      "phase": 240.85
     },
     {
       "name": "SSA",
-      "amplitude": 0.03443933191551207,
-      "phase": 263.8594380428822
+      "amplitude": 0.034,
+      "phase": 263.86
     },
     {
       "name": "T2",
-      "amplitude": 0.00021868595031594062,
-      "phase": 285.80651442084184
+      "amplitude": 0,
+      "phase": 285.81
     },
     {
       "name": "J1",
-      "amplitude": 0.00020102946684327717,
-      "phase": 181.77136776877293
+      "amplitude": 0,
+      "phase": 181.77
     },
     {
       "name": "L2",
-      "amplitude": 0.00013285208131222842,
-      "phase": 208.83824752852104
+      "amplitude": 0,
+      "phase": 208.84
     },
     {
       "name": "R2",
-      "amplitude": 0.00012654499386594622,
-      "phase": 147.92695482204192
+      "amplitude": 0,
+      "phase": 147.93
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00005701772695162181,
-      "phase": 90.90510330788413
+      "amplitude": 0,
+      "phase": 90.91
     },
     {
       "name": "MSF",
-      "amplitude": 0.001012768057604701,
-      "phase": 305.5422891321988
+      "amplitude": 0.001,
+      "phase": 305.54
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0033618631745157886,
-      "phase": 226.46218842911517
+      "amplitude": 0.003,
+      "phase": 226.46
     },
     {
       "name": "EP2",
-      "amplitude": 0.00013622811362853216,
-      "phase": 236.06914686257497
+      "amplitude": 0,
+      "phase": 236.07
     },
     {
       "name": "M3",
-      "amplitude": 0.000050069786769860725,
-      "phase": 159.80407466014697
+      "amplitude": 0,
+      "phase": 159.8
     },
     {
       "name": "MU2",
-      "amplitude": 0.00021370181889264798,
-      "phase": 299.6847484779024
+      "amplitude": 0,
+      "phase": 299.68
     },
     {
       "name": "MTM",
-      "amplitude": 0.0035374184586393254,
-      "phase": 28.809227068092866
+      "amplitude": 0.004,
+      "phase": 28.81
     },
     {
       "name": "NU2",
-      "amplitude": 0.00023586563240052488,
-      "phase": 145.325095518294
+      "amplitude": 0,
+      "phase": 145.33
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00015695739570419358,
-      "phase": 248.3229327979219
+      "amplitude": 0,
+      "phase": 248.32
     },
     {
       "name": "MN4",
-      "amplitude": 0.0000731877264256164,
-      "phase": 75.65672817238732
+      "amplitude": 0,
+      "phase": 75.66
     },
     {
       "name": "MS4",
-      "amplitude": 0.00003932887825063311,
-      "phase": 99.66932093047893
+      "amplitude": 0,
+      "phase": 99.67
     },
     {
       "name": "N4",
-      "amplitude": 0.00006575609367234118,
-      "phase": 21.330588725196833
+      "amplitude": 0,
+      "phase": 21.33
     },
     {
       "name": "M6",
-      "amplitude": 0.000027136558628190515,
-      "phase": 209.54930319790134
+      "amplitude": 0,
+      "phase": 209.55
     },
     {
       "name": "M8",
-      "amplitude": 0.000019042188372475657,
-      "phase": 186.5169444999178
+      "amplitude": 0,
+      "phase": 186.52
     },
     {
       "name": "S4",
-      "amplitude": 0.00007886677351698533,
-      "phase": 346.2539518027672
+      "amplitude": 0,
+      "phase": 346.25
     },
     {
       "name": "OO1",
-      "amplitude": 0.000051871635774246805,
-      "phase": 76.35399837535954
+      "amplitude": 0,
+      "phase": 76.35
     },
     {
       "name": "S3",
-      "amplitude": 0.00019289768673585688,
-      "phase": 51.136322663538124
+      "amplitude": 0,
+      "phase": 51.14
     },
     {
       "name": "MA2",
-      "amplitude": 0.00014111369682837105,
-      "phase": 69.22735269161296
+      "amplitude": 0,
+      "phase": 69.23
     },
     {
       "name": "MB2",
-      "amplitude": 0.00034747785987607416,
-      "phase": 263.4771722380785
+      "amplitude": 0,
+      "phase": 263.48
     },
     {
       "name": "T3",
-      "amplitude": 0.0002330143404387389,
-      "phase": 315.35514332822294
+      "amplitude": 0,
+      "phase": 315.36
     },
     {
       "name": "R3",
-      "amplitude": 0.00025233127280665233,
-      "phase": 71.77969299543196
+      "amplitude": 0,
+      "phase": 71.78
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00022393523649157218,
-      "phase": 288.7325023931861
+      "amplitude": 0,
+      "phase": 288.73
     },
     {
       "name": "SGM",
-      "amplitude": 0.00008785776997850985,
-      "phase": 280.4372401043764
+      "amplitude": 0,
+      "phase": 280.44
     },
     {
       "name": "3L2",
-      "amplitude": 0.00011784521615218082,
-      "phase": 286.93912820133494
+      "amplitude": 0,
+      "phase": 286.94
     },
     {
       "name": "3N2",
-      "amplitude": 0.000033498807367187676,
-      "phase": 242.61792329706944
+      "amplitude": 0,
+      "phase": 242.62
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00010372435732466131,
-      "phase": 185.61617901438638
+      "amplitude": 0,
+      "phase": 185.62
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000053738959800394835,
-      "phase": 141.79150425758894
+      "amplitude": 0,
+      "phase": 141.79
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000012367585133405786,
-      "phase": 305.95535879701424
+      "amplitude": 0,
+      "phase": 305.96
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00001667444686411153,
-      "phase": 317.8973207877335
+      "amplitude": 0,
+      "phase": 317.9
     }
   ],
   "epoch": {

--- a/data/ticon/antwerpen_prosperpolder-antwppppdr-nld-rws.json
+++ b/data/ticon/antwerpen_prosperpolder-antwppppdr-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 2.04152861,
-      "phase": 81.43324899999999
+      "amplitude": 2.112,
+      "phase": 66
     },
     {
       "name": "N2",
-      "amplitude": 0.32157896,
-      "phase": 57.51967500000001
+      "amplitude": 0.332,
+      "phase": 42.06
     },
     {
       "name": "S2",
-      "amplitude": 0.52503798,
-      "phase": 145.275717
+      "amplitude": 0.544,
+      "phase": 129.79
     },
     {
       "name": "K2",
-      "amplitude": 0.14844838,
-      "phase": 143.91033100000004
+      "amplitude": 0.157,
+      "phase": 126.65
     },
     {
       "name": "2N2",
-      "amplitude": 0.03618707,
-      "phase": 28.513398999999993
+      "amplitude": 0.038,
+      "phase": 11.72
     },
     {
       "name": "S1",
-      "amplitude": 0.011463049999999999,
-      "phase": 42.19821400000001
+      "amplitude": 0.012,
+      "phase": 352.15
     },
     {
       "name": "K1",
-      "amplitude": 0.06995374,
-      "phase": 31.499169999999992
+      "amplitude": 0.071,
+      "phase": 22.94
     },
     {
       "name": "P1",
-      "amplitude": 0.03494084,
-      "phase": 20.17821600000002
+      "amplitude": 0.035,
+      "phase": 11.82
     },
     {
       "name": "O1",
-      "amplitude": 0.10599081999999999,
-      "phase": 210.96009
+      "amplitude": 0.106,
+      "phase": 203.5
     },
     {
       "name": "Q1",
-      "amplitude": 0.03489451,
-      "phase": 156.155445
+      "amplitude": 0.035,
+      "phase": 149.08
     },
     {
       "name": "M1",
-      "amplitude": 0.0016855300000000002,
-      "phase": 288.64689599999997
+      "amplitude": 0.002,
+      "phase": 60.83
     },
     {
       "name": "M4",
-      "amplitude": 0.107623,
-      "phase": 149.783228
+      "amplitude": 0.124,
+      "phase": 118.3
     },
     {
       "name": "MM",
-      "amplitude": 0.03328354,
-      "phase": 25.239666999999997
+      "amplitude": 0.033,
+      "phase": 25.54
     },
     {
       "name": "MF",
-      "amplitude": 0.01621513,
-      "phase": 34.980980999999986
+      "amplitude": 0.016,
+      "phase": 34.88
     },
     {
       "name": "SA",
-      "amplitude": 0.05388955,
-      "phase": 214.08204
+      "amplitude": 0.054,
+      "phase": 213.96
     },
     {
       "name": "SSA",
-      "amplitude": 0.00399748,
-      "phase": 350.767821
+      "amplitude": 0.004,
+      "phase": 350.92
     },
     {
       "name": "T2",
-      "amplitude": 0.10214059,
-      "phase": 68.69159200000001
+      "amplitude": 0.024,
+      "phase": 112.88
     },
     {
       "name": "J1",
-      "amplitude": 0.00425859,
-      "phase": 136.426151
+      "amplitude": 0.004,
+      "phase": 125.41
     },
     {
       "name": "L2",
-      "amplitude": 0.16767496999999998,
-      "phase": 95.54231099999998
+      "amplitude": 0.174,
+      "phase": 80.63
     },
     {
       "name": "R2",
-      "amplitude": 0.0670426,
-      "phase": 245.470284
+      "amplitude": 0.007,
+      "phase": 318.07
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00486827,
-      "phase": 142.038929
+      "amplitude": 0.005,
+      "phase": 126.79
     },
     {
       "name": "MSF",
-      "amplitude": 0.0609775,
-      "phase": 48.43786799999998
+      "amplitude": 0.06,
+      "phase": 47.16
     },
     {
       "name": "MSQM",
-      "amplitude": 0.012044019999999999,
-      "phase": 215.045941
+      "amplitude": 0.012,
+      "phase": 213.61
     },
     {
       "name": "EP2",
-      "amplitude": 0.03944676,
-      "phase": 167.93414600000006
+      "amplitude": 0.039,
+      "phase": 152.67
     },
     {
       "name": "M3",
-      "amplitude": 0.009118330000000001,
-      "phase": 191.572886
+      "amplitude": 0.01,
+      "phase": 349.11
     },
     {
       "name": "MU2",
-      "amplitude": 0.19887291999999998,
-      "phase": 175.89294100000006
+      "amplitude": 0.204,
+      "phase": 160.99
     },
     {
       "name": "MTM",
-      "amplitude": 0.00686663,
-      "phase": 172.35618799999997
+      "amplitude": 0.007,
+      "phase": 176.02
     },
     {
       "name": "NU2",
-      "amplitude": 0.1193756,
-      "phase": 41.71564000000001
+      "amplitude": 0.124,
+      "phase": 26.52
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07133099999999999,
-      "phase": 90.968861
+      "amplitude": 0.074,
+      "phase": 79
     },
     {
       "name": "MN4",
-      "amplitude": 0.03523581,
-      "phase": 121.01728000000003
+      "amplitude": 0.041,
+      "phase": 89.58
     },
     {
       "name": "MS4",
-      "amplitude": 0.06781415,
-      "phase": 207.093635
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.04498107,
-      "phase": 235.70488899999998
+      "amplitude": 0.078,
+      "phase": 177.94
     },
     {
       "name": "N4",
-      "amplitude": 0.004731679999999999,
-      "phase": 78.760242
+      "amplitude": 0.007,
+      "phase": 52.84
     },
     {
       "name": "M6",
-      "amplitude": 0.0983409,
-      "phase": 227.0058
+      "amplitude": 0.133,
+      "phase": 179.4
     },
     {
       "name": "M8",
-      "amplitude": 0.024469949999999997,
-      "phase": 245.47007200000002
+      "amplitude": 0.047,
+      "phase": 177.85
     },
     {
       "name": "S4",
-      "amplitude": 0.00266826,
-      "phase": 284.007738
+      "amplitude": 0.003,
+      "phase": 258.49
     },
     {
       "name": "OO1",
-      "amplitude": 0.00579394,
-      "phase": 158.00827200000003
+      "amplitude": 0.006,
+      "phase": 165.88
     },
     {
       "name": "S3",
-      "amplitude": 0.00347011,
-      "phase": 158.31365500000004
+      "amplitude": 0.001,
+      "phase": 86.75
     },
     {
       "name": "MA2",
-      "amplitude": 0.36945701999999997,
-      "phase": 66.054575
+      "amplitude": 0.046,
+      "phase": 19.12
     },
     {
       "name": "MB2",
-      "amplitude": 0.32553761000000003,
-      "phase": 268.784069
+      "amplitude": 0.014,
+      "phase": 131.91
     },
     {
       "name": "T3",
-      "amplitude": 0.00202985,
-      "phase": 140.336248
+      "amplitude": 0.002,
+      "phase": 305.25
     },
     {
       "name": "R3",
-      "amplitude": 0.012411179999999999,
-      "phase": 343.799465
+      "amplitude": 0.013,
+      "phase": 53.93
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00663456,
-      "phase": 151.67978400000004
+      "amplitude": 0.008,
+      "phase": 143.89
     },
     {
       "name": "SGM",
-      "amplitude": 0.0031443900000000004,
-      "phase": 154.10434199999997
+      "amplitude": 0.004,
+      "phase": 319.44
     },
     {
       "name": "3L2",
-      "amplitude": 0.00587076,
-      "phase": 187.765181
+      "amplitude": 0.004,
+      "phase": 267.43
     },
     {
       "name": "3N2",
-      "amplitude": 0.01225768,
-      "phase": 248.487934
+      "amplitude": 0.021,
+      "phase": 257.13
     },
     {
       "name": "2SM2",
-      "amplitude": 0.05075855,
-      "phase": 12.440176000000008
+      "amplitude": 0.052,
+      "phase": 355.44
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08847654,
-      "phase": 278.185989
+      "amplitude": 0.125,
+      "phase": 232.19
     },
     {
       "name": "2MK5",
-      "amplitude": 0.01119425,
-      "phase": 219.610416
+      "amplitude": 0.014,
+      "phase": 272.92
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006883780000000001,
-      "phase": 263.377518
+      "amplitude": 0.009,
+      "phase": 131.32
     }
   ],
   "epoch": {

--- a/data/ticon/aukfield_platform-aukfpfm-nld-rws.json
+++ b/data/ticon/aukfield_platform-aukfpfm-nld-rws.json
@@ -33,253 +33,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.42686164,
-      "phase": 95.42862200000002
+      "amplitude": 0.442,
+      "phase": 79.62
     },
     {
       "name": "N2",
-      "amplitude": 0.08446638000000001,
-      "phase": 70.04049399999997
+      "amplitude": 0.086,
+      "phase": 54.35
     },
     {
       "name": "S2",
-      "amplitude": 0.13244775,
-      "phase": 134.43528400000002
+      "amplitude": 0.137,
+      "phase": 118.15
     },
     {
       "name": "K2",
-      "amplitude": 0.03693591,
-      "phase": 137.44235300000003
+      "amplitude": 0.039,
+      "phase": 117.22
     },
     {
       "name": "2N2",
-      "amplitude": 0.01249624,
-      "phase": 48.55079999999998
+      "amplitude": 0.012,
+      "phase": 33.06
     },
     {
       "name": "S1",
-      "amplitude": 0.00401715,
-      "phase": 293.075349
+      "amplitude": 0.004,
+      "phase": 218.83
     },
     {
       "name": "K1",
-      "amplitude": 0.03926102,
-      "phase": 265.45007
+      "amplitude": 0.04,
+      "phase": 257.47
     },
     {
       "name": "P1",
-      "amplitude": 0.013373900000000001,
-      "phase": 249.78018600000001
+      "amplitude": 0.013,
+      "phase": 242.46
     },
     {
       "name": "O1",
-      "amplitude": 0.044823919999999996,
-      "phase": 108.105031
+      "amplitude": 0.045,
+      "phase": 100.89
     },
     {
       "name": "Q1",
-      "amplitude": 0.01743841,
-      "phase": 57.08808499999998
+      "amplitude": 0.017,
+      "phase": 49.88
     },
     {
       "name": "M1",
-      "amplitude": 0.0017595,
-      "phase": 101.77450399999998
+      "amplitude": 0.001,
+      "phase": 309.08
     },
     {
       "name": "M4",
-      "amplitude": 0.00868515,
-      "phase": 102.537374
+      "amplitude": 0.011,
+      "phase": 67.6
     },
     {
       "name": "MM",
-      "amplitude": 0.014478139999999999,
-      "phase": 198.78676
+      "amplitude": 0.015,
+      "phase": 199.34
     },
     {
       "name": "MF",
-      "amplitude": 0.01615361,
-      "phase": 215.315599
+      "amplitude": 0.015,
+      "phase": 212.09
     },
     {
       "name": "SA",
-      "amplitude": 0.07459213,
-      "phase": 250.045808
+      "amplitude": 0.074,
+      "phase": 253.09
     },
     {
       "name": "SSA",
-      "amplitude": 0.00453074,
-      "phase": 293.89969
+      "amplitude": 0.003,
+      "phase": 308.71
     },
     {
       "name": "T2",
-      "amplitude": 0.02389952,
-      "phase": 56.23882600000002
+      "amplitude": 0.005,
+      "phase": 117.54
     },
     {
       "name": "J1",
-      "amplitude": 0.00160346,
-      "phase": 320.267163
+      "amplitude": 0.002,
+      "phase": 315.63
     },
     {
       "name": "L2",
-      "amplitude": 0.0156824,
-      "phase": 124.53266200000002
+      "amplitude": 0.016,
+      "phase": 109.95
     },
     {
       "name": "R2",
-      "amplitude": 0.01911079,
-      "phase": 225.21631
+      "amplitude": 0.003,
+      "phase": 188.26
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00405098,
-      "phase": 14.175464999999974
+      "amplitude": 0.004,
+      "phase": 2.7
     },
     {
       "name": "MSF",
-      "amplitude": 0.010086999999999999,
-      "phase": 271.343829
+      "amplitude": 0.011,
+      "phase": 271.03
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00684505,
-      "phase": 185.990092
+      "amplitude": 0.007,
+      "phase": 186.39
     },
     {
       "name": "EP2",
-      "amplitude": 0.0006046399999999999,
-      "phase": 211.844018
+      "amplitude": 0,
+      "phase": 222.75
     },
     {
       "name": "M3",
-      "amplitude": 0.00245966,
-      "phase": 79.05817300000001
+      "amplitude": 0.003,
+      "phase": 236.32
     },
     {
       "name": "MU2",
-      "amplitude": 0.00492104,
-      "phase": 320.375354
+      "amplitude": 0.005,
+      "phase": 303.74
     },
     {
       "name": "MTM",
-      "amplitude": 0.00652378,
-      "phase": 158.018773
+      "amplitude": 0.006,
+      "phase": 158.54
     },
     {
       "name": "NU2",
-      "amplitude": 0.017613840000000002,
-      "phase": 79.10924899999998
+      "amplitude": 0.019,
+      "phase": 62.85
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00525088,
-      "phase": 111.32775700000002
+      "amplitude": 0.006,
+      "phase": 98.51
     },
     {
       "name": "MN4",
-      "amplitude": 0.0015040899999999998,
-      "phase": 74.798656
+      "amplitude": 0.002,
+      "phase": 47.82
     },
     {
       "name": "MS4",
-      "amplitude": 0.00926914,
-      "phase": 198.555455
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.00768332,
-      "phase": 216.241295
+      "amplitude": 0.011,
+      "phase": 164.7
     },
     {
       "name": "N4",
-      "amplitude": 0.00016315,
-      "phase": 93.59979699999997
+      "amplitude": 0,
+      "phase": 354.2
     },
     {
       "name": "M6",
-      "amplitude": 0.00221713,
-      "phase": 296.48508
+      "amplitude": 0.003,
+      "phase": 248.32
     },
     {
       "name": "M8",
-      "amplitude": 0.00114893,
-      "phase": 17.67759000000001
+      "amplitude": 0.002,
+      "phase": 306.15
     },
     {
       "name": "S4",
-      "amplitude": 0.00218009,
-      "phase": 338.727993
+      "amplitude": 0.002,
+      "phase": 312.83
     },
     {
       "name": "OO1",
-      "amplitude": 0.00156952,
-      "phase": 46.94790999999998
+      "amplitude": 0.002,
+      "phase": 42.63
     },
     {
       "name": "S3",
-      "amplitude": 0.00082207,
-      "phase": 43.08140000000003
+      "amplitude": 0,
+      "phase": 221.57
     },
     {
       "name": "MA2",
-      "amplitude": 0.06800766,
-      "phase": 79.994846
+      "amplitude": 0.004,
+      "phase": 324.53
     },
     {
       "name": "MB2",
-      "amplitude": 0.07295802,
-      "phase": 281.706249
+      "amplitude": 0.007,
+      "phase": 226.99
     },
     {
       "name": "T3",
-      "amplitude": 0.00042660999999999996,
-      "phase": 349.370051
+      "amplitude": 0,
+      "phase": 171.68
     },
     {
       "name": "R3",
-      "amplitude": 0.00097232,
-      "phase": 200.210633
+      "amplitude": 0.001,
+      "phase": 265.69
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00295417,
-      "phase": 55.335042999999985
+      "amplitude": 0.003,
+      "phase": 50.35
     },
     {
       "name": "SGM",
-      "amplitude": 0.0031532,
-      "phase": 209.129437
+      "amplitude": 0.003,
+      "phase": 22.36
     },
     {
       "name": "3L2",
-      "amplitude": 0.00211133,
-      "phase": 141.156496
+      "amplitude": 0.001,
+      "phase": 255.02
     },
     {
       "name": "3N2",
-      "amplitude": 0.00199406,
-      "phase": 159.44948999999997
+      "amplitude": 0,
+      "phase": 170.91
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0017201900000000001,
-      "phase": 349.496691
+      "amplitude": 0.002,
+      "phase": 355.45
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00165247,
-      "phase": 354.806828
+      "amplitude": 0.002,
+      "phase": 310.02
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00097212,
-      "phase": 5.146255999999994
+      "amplitude": 0.001,
+      "phase": 56.16
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00091977,
-      "phase": 359.119431
+      "amplitude": 0.001,
+      "phase": 241.72
     }
   ],
   "epoch": {

--- a/data/ticon/bakea-9510063-deu-wsv.json
+++ b/data/ticon/bakea-9510063-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3751211786025797,
-      "phase": 311.9198259694915
+      "amplitude": 1.375,
+      "phase": 311.92
     },
     {
       "name": "N2",
-      "amplitude": 0.2199817882778652,
-      "phase": 286.35334039598195
+      "amplitude": 0.22,
+      "phase": 286.35
     },
     {
       "name": "S2",
-      "amplitude": 0.3666258393265354,
-      "phase": 19.764740659820063
+      "amplitude": 0.367,
+      "phase": 19.76
     },
     {
       "name": "K2",
-      "amplitude": 0.10954973193368782,
-      "phase": 18.297241036804166
+      "amplitude": 0.11,
+      "phase": 18.3
     },
     {
       "name": "2N2",
-      "amplitude": 0.024941577759349628,
-      "phase": 263.1309546085132
+      "amplitude": 0.025,
+      "phase": 263.13
     },
     {
       "name": "S1",
-      "amplitude": 0.010396941577489627,
-      "phase": 10.139927143748707
+      "amplitude": 0.01,
+      "phase": 10.14
     },
     {
       "name": "K1",
-      "amplitude": 0.07274035646271772,
-      "phase": 20.8344975963941
+      "amplitude": 0.073,
+      "phase": 20.83
     },
     {
       "name": "P1",
-      "amplitude": 0.030413840509749615,
-      "phase": 26.639545024887695
+      "amplitude": 0.03,
+      "phase": 26.64
     },
     {
       "name": "O1",
-      "amplitude": 0.09482248142226506,
-      "phase": 231.84819197714108
+      "amplitude": 0.095,
+      "phase": 231.85
     },
     {
       "name": "Q1",
-      "amplitude": 0.03001160742067212,
-      "phase": 174.42188494543484
+      "amplitude": 0.03,
+      "phase": 174.42
     },
     {
       "name": "M1",
-      "amplitude": 0.0018812947920279152,
-      "phase": 95.30650772210947
+      "amplitude": 0.002,
+      "phase": 95.31
     },
     {
       "name": "M4",
-      "amplitude": 0.0775811935707209,
-      "phase": 144.96655998284166
+      "amplitude": 0.078,
+      "phase": 144.97
     },
     {
       "name": "MM",
-      "amplitude": 0.022146005413981488,
-      "phase": 187.14968742840043
+      "amplitude": 0.022,
+      "phase": 187.15
     },
     {
       "name": "MF",
-      "amplitude": 0.00822267832883956,
-      "phase": 189.48079241673923
+      "amplitude": 0.008,
+      "phase": 189.48
     },
     {
       "name": "SA",
-      "amplitude": 0.10532766126755401,
-      "phase": 221.39048377630016
+      "amplitude": 0.105,
+      "phase": 221.39
     },
     {
       "name": "SSA",
-      "amplitude": 0.03514862457918788,
-      "phase": 195.2482478747526
+      "amplitude": 0.035,
+      "phase": 195.25
     },
     {
       "name": "T2",
-      "amplitude": 0.018542265503764532,
-      "phase": 0.13557531157630365
+      "amplitude": 0.019,
+      "phase": 0.14
     },
     {
       "name": "J1",
-      "amplitude": 0.001914480183928886,
-      "phase": 143.3887150606232
+      "amplitude": 0.002,
+      "phase": 143.39
     },
     {
       "name": "L2",
-      "amplitude": 0.10530152736634403,
-      "phase": 330.25745179282745
+      "amplitude": 0.105,
+      "phase": 330.26
     },
     {
       "name": "R2",
-      "amplitude": 0.0038335577306455437,
-      "phase": 346.3134647284182
+      "amplitude": 0.004,
+      "phase": 346.31
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006306584462175972,
-      "phase": 113.33847693635539
+      "amplitude": 0.006,
+      "phase": 113.34
     },
     {
       "name": "MSF",
-      "amplitude": 0.004355101354961383,
-      "phase": 10.684105580626976
+      "amplitude": 0.004,
+      "phase": 10.68
     },
     {
       "name": "MSQM",
-      "amplitude": 0.01127113679286826,
-      "phase": 69.15041339087526
+      "amplitude": 0.011,
+      "phase": 69.15
     },
     {
       "name": "EP2",
-      "amplitude": 0.029710557265796824,
-      "phase": 18.441441460873875
+      "amplitude": 0.03,
+      "phase": 18.44
     },
     {
       "name": "M3",
-      "amplitude": 0.004220880716479221,
-      "phase": 320.6877175819245
+      "amplitude": 0.004,
+      "phase": 320.69
     },
     {
       "name": "MU2",
-      "amplitude": 0.12936653655494515,
-      "phase": 42.52834373131668
+      "amplitude": 0.129,
+      "phase": 42.53
     },
     {
       "name": "MTM",
-      "amplitude": 0.0045356520588727255,
-      "phase": 265.0074489975559
+      "amplitude": 0.005,
+      "phase": 265.01
     },
     {
       "name": "NU2",
-      "amplitude": 0.07800623504122493,
-      "phase": 272.09786020903135
+      "amplitude": 0.078,
+      "phase": 272.1
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05092500379584473,
-      "phase": 322.4094554027867
+      "amplitude": 0.051,
+      "phase": 322.41
     },
     {
       "name": "MN4",
-      "amplitude": 0.027461704233365525,
-      "phase": 125.25623043499928
+      "amplitude": 0.027,
+      "phase": 125.26
     },
     {
       "name": "MS4",
-      "amplitude": 0.052808868422174214,
-      "phase": 205.56397226569678
+      "amplitude": 0.053,
+      "phase": 205.56
     },
     {
       "name": "N4",
-      "amplitude": 0.006247427767783626,
-      "phase": 106.70869107838837
+      "amplitude": 0.006,
+      "phase": 106.71
     },
     {
       "name": "M6",
-      "amplitude": 0.04641754029675323,
-      "phase": 337.2519345021835
+      "amplitude": 0.046,
+      "phase": 337.25
     },
     {
       "name": "M8",
-      "amplitude": 0.005490876163104189,
-      "phase": 200.17337764994957
+      "amplitude": 0.005,
+      "phase": 200.17
     },
     {
       "name": "S4",
-      "amplitude": 0.006312204828283992,
-      "phase": 315.50166045059603
+      "amplitude": 0.006,
+      "phase": 315.5
     },
     {
       "name": "OO1",
-      "amplitude": 0.002086614942856847,
-      "phase": 183.83092871655455
+      "amplitude": 0.002,
+      "phase": 183.83
     },
     {
       "name": "S3",
-      "amplitude": 0.000511530321022171,
-      "phase": 128.69239665159262
+      "amplitude": 0.001,
+      "phase": 128.69
     },
     {
       "name": "MA2",
-      "amplitude": 0.04300161422959974,
-      "phase": 253.45510296548937
+      "amplitude": 0.043,
+      "phase": 253.46
     },
     {
       "name": "MB2",
-      "amplitude": 0.02840114627689128,
-      "phase": 25.301073600647214
+      "amplitude": 0.028,
+      "phase": 25.3
     },
     {
       "name": "T3",
-      "amplitude": 0.00045534384101025637,
-      "phase": 14.567016146038952
+      "amplitude": 0,
+      "phase": 14.57
     },
     {
       "name": "R3",
-      "amplitude": 0.002197062550030106,
-      "phase": 2.949004667558995
+      "amplitude": 0.002,
+      "phase": 2.95
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006441132792522776,
-      "phase": 181.94438972265482
+      "amplitude": 0.006,
+      "phase": 181.94
     },
     {
       "name": "SGM",
-      "amplitude": 0.002054303342960709,
-      "phase": 50.515057982076826
+      "amplitude": 0.002,
+      "phase": 50.52
     },
     {
       "name": "3L2",
-      "amplitude": 0.0028968144223677585,
-      "phase": 236.30742138959477
+      "amplitude": 0.003,
+      "phase": 236.31
     },
     {
       "name": "3N2",
-      "amplitude": 0.016825587775175465,
-      "phase": 109.89195890674142
+      "amplitude": 0.017,
+      "phase": 109.89
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03448326737413639,
-      "phase": 240.92883274257238
+      "amplitude": 0.034,
+      "phase": 240.93
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04476023225491667,
-      "phase": 35.256470821258574
+      "amplitude": 0.045,
+      "phase": 35.26
     },
     {
       "name": "2MK5",
-      "amplitude": 0.002647427320881339,
-      "phase": 68.04912320518525
+      "amplitude": 0.003,
+      "phase": 68.05
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005239882634775419,
-      "phase": 295.2497819861187
+      "amplitude": 0.005,
+      "phase": 295.25
     }
   ],
   "epoch": {

--- a/data/ticon/bakez-9510066-deu-wsv.json
+++ b/data/ticon/bakez-9510066-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.02822509074125184,
-      "phase": 11.586625303786661
+      "amplitude": 0.028,
+      "phase": 11.59
     },
     {
       "name": "N2",
-      "amplitude": 0.01640302728011254,
-      "phase": 92.02826481754937
+      "amplitude": 0.016,
+      "phase": 92.03
     },
     {
       "name": "S2",
-      "amplitude": 0.03002823044769914,
-      "phase": 2.5151415954019853
+      "amplitude": 0.03,
+      "phase": 2.52
     },
     {
       "name": "K2",
-      "amplitude": 0.03653399235401111,
-      "phase": 323.45358269707333
+      "amplitude": 0.037,
+      "phase": 323.45
     },
     {
       "name": "2N2",
-      "amplitude": 0.014617129939307883,
-      "phase": 310.5575092682625
+      "amplitude": 0.015,
+      "phase": 310.56
     },
     {
       "name": "S1",
-      "amplitude": 0.006276607615664357,
-      "phase": 39.57025407852302
+      "amplitude": 0.006,
+      "phase": 39.57
     },
     {
       "name": "K1",
-      "amplitude": 0.002254613783860281,
-      "phase": 154.67351539552283
+      "amplitude": 0.002,
+      "phase": 154.67
     },
     {
       "name": "P1",
-      "amplitude": 0.003904249672788741,
-      "phase": 293.01833781091847
+      "amplitude": 0.004,
+      "phase": 293.02
     },
     {
       "name": "O1",
-      "amplitude": 0.01298559633242882,
-      "phase": 59.41759184818443
+      "amplitude": 0.013,
+      "phase": 59.42
     },
     {
       "name": "Q1",
-      "amplitude": 0.006762324680172108,
-      "phase": 14.562426036533793
+      "amplitude": 0.007,
+      "phase": 14.56
     },
     {
       "name": "M1",
-      "amplitude": 0.0015733263410017601,
-      "phase": 235.1550406531195
+      "amplitude": 0.002,
+      "phase": 235.16
     },
     {
       "name": "M4",
-      "amplitude": 0.0022029116086123663,
-      "phase": 60.743937464566216
+      "amplitude": 0.002,
+      "phase": 60.74
     },
     {
       "name": "MM",
-      "amplitude": 0.003517905379882113,
-      "phase": 308.4913400093585
+      "amplitude": 0.004,
+      "phase": 308.49
     },
     {
       "name": "MF",
-      "amplitude": 0.008824623168764107,
-      "phase": 295.30720408587445
+      "amplitude": 0.009,
+      "phase": 295.31
     },
     {
       "name": "SA",
-      "amplitude": 0.25259155689132406,
-      "phase": 163.41132757973742
+      "amplitude": 0.253,
+      "phase": 163.41
     },
     {
       "name": "SSA",
-      "amplitude": 0.059092478797992155,
-      "phase": 41.09113941657256
+      "amplitude": 0.059,
+      "phase": 41.09
     },
     {
       "name": "T2",
-      "amplitude": 0.013350917332837907,
-      "phase": 313.45151965290256
+      "amplitude": 0.013,
+      "phase": 313.45
     },
     {
       "name": "J1",
-      "amplitude": 0.0012286695396484914,
-      "phase": 4.987376782234662
+      "amplitude": 0.001,
+      "phase": 4.99
     },
     {
       "name": "L2",
-      "amplitude": 0.00313371179080067,
-      "phase": 9.687395445521986
+      "amplitude": 0.003,
+      "phase": 9.69
     },
     {
       "name": "R2",
-      "amplitude": 0.02710973681869545,
-      "phase": 223.28605141150092
+      "amplitude": 0.027,
+      "phase": 223.29
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0025208076898699232,
-      "phase": 298.1007615713862
+      "amplitude": 0.003,
+      "phase": 298.1
     },
     {
       "name": "MSF",
-      "amplitude": 0.0035579694926904013,
-      "phase": 108.86757223358757
+      "amplitude": 0.004,
+      "phase": 108.87
     },
     {
       "name": "MSQM",
-      "amplitude": 0.006777891951765401,
-      "phase": 246.2691710003146
+      "amplitude": 0.007,
+      "phase": 246.27
     },
     {
       "name": "EP2",
-      "amplitude": 0.005878245292368672,
-      "phase": 150.31026134213278
+      "amplitude": 0.006,
+      "phase": 150.31
     },
     {
       "name": "M3",
-      "amplitude": 0.0009574040262080447,
-      "phase": 95.62499954114452
+      "amplitude": 0.001,
+      "phase": 95.62
     },
     {
       "name": "MU2",
-      "amplitude": 0.035667134895026584,
-      "phase": 200.67230505263902
+      "amplitude": 0.036,
+      "phase": 200.67
     },
     {
       "name": "MTM",
-      "amplitude": 0.015578871624249032,
-      "phase": 175.53108199304165
+      "amplitude": 0.016,
+      "phase": 175.53
     },
     {
       "name": "NU2",
-      "amplitude": 0.019021974774359036,
-      "phase": 80.55194572909153
+      "amplitude": 0.019,
+      "phase": 80.55
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.01160356353567849,
-      "phase": 294.43257502946847
+      "amplitude": 0.012,
+      "phase": 294.43
     },
     {
       "name": "MN4",
-      "amplitude": 0.0013574973936920313,
-      "phase": 251.66337954186503
+      "amplitude": 0.001,
+      "phase": 251.66
     },
     {
       "name": "MS4",
-      "amplitude": 0.0026058379472401485,
-      "phase": 227.37046662645227
+      "amplitude": 0.003,
+      "phase": 227.37
     },
     {
       "name": "N4",
-      "amplitude": 0.0009255223978343679,
-      "phase": 264.6539107631857
+      "amplitude": 0.001,
+      "phase": 264.65
     },
     {
       "name": "M6",
-      "amplitude": 0.006344811655521298,
-      "phase": 30.91889311047271
+      "amplitude": 0.006,
+      "phase": 30.92
     },
     {
       "name": "M8",
-      "amplitude": 0.0013668263495202684,
-      "phase": 2.0336668636908257
+      "amplitude": 0.001,
+      "phase": 2.03
     },
     {
       "name": "S4",
-      "amplitude": 0.000353576611918338,
-      "phase": 359.13474963941337
+      "amplitude": 0,
+      "phase": 359.13
     },
     {
       "name": "OO1",
-      "amplitude": 0.0009663743539634398,
-      "phase": 171.71286915472297
+      "amplitude": 0.001,
+      "phase": 171.71
     },
     {
       "name": "S3",
-      "amplitude": 0.0002500082326964675,
-      "phase": 284.01073449035937
+      "amplitude": 0,
+      "phase": 284.01
     },
     {
       "name": "MA2",
-      "amplitude": 0.08443766633331642,
-      "phase": 7.163267665000774
+      "amplitude": 0.084,
+      "phase": 7.16
     },
     {
       "name": "MB2",
-      "amplitude": 0.10105556683821273,
-      "phase": 94.22708805720248
+      "amplitude": 0.101,
+      "phase": 94.23
     },
     {
       "name": "T3",
-      "amplitude": 0.0004723451848871916,
-      "phase": 250.62235415441404
+      "amplitude": 0,
+      "phase": 250.62
     },
     {
       "name": "R3",
-      "amplitude": 0.0011727229229120872,
-      "phase": 171.9348459252367
+      "amplitude": 0.001,
+      "phase": 171.93
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00028463202236354455,
-      "phase": 191.0149203251695
+      "amplitude": 0,
+      "phase": 191.01
     },
     {
       "name": "SGM",
-      "amplitude": 0.0007221975214417106,
-      "phase": 85.26492328885598
+      "amplitude": 0.001,
+      "phase": 85.26
     },
     {
       "name": "3L2",
-      "amplitude": 0.006113265228575231,
-      "phase": 226.65136671729866
+      "amplitude": 0.006,
+      "phase": 226.65
     },
     {
       "name": "3N2",
-      "amplitude": 0.03649534529545194,
-      "phase": 178.16317948965593
+      "amplitude": 0.036,
+      "phase": 178.16
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0027896437925121645,
-      "phase": 275.05482577467586
+      "amplitude": 0.003,
+      "phase": 275.05
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0072287421030497075,
-      "phase": 138.622269076831
+      "amplitude": 0.007,
+      "phase": 138.62
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0004485787012225126,
-      "phase": 135.38189468078383
+      "amplitude": 0,
+      "phase": 135.38
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0013451219619977182,
-      "phase": 39.08306704822979
+      "amplitude": 0.001,
+      "phase": 39.08
     }
   ],
   "epoch": {

--- a/data/ticon/barhft-9650040-deu-wsv.json
+++ b/data/ticon/barhft-9650040-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.004985109225782392,
-      "phase": 256.6474086069451
+      "amplitude": 0.005,
+      "phase": 256.65
     },
     {
       "name": "N2",
-      "amplitude": 0.0009999840780020909,
-      "phase": 266.09208150367476
+      "amplitude": 0.001,
+      "phase": 266.09
     },
     {
       "name": "S2",
-      "amplitude": 0.0031839724295704332,
-      "phase": 255.35730870328072
+      "amplitude": 0.003,
+      "phase": 255.36
     },
     {
       "name": "K2",
-      "amplitude": 0.0009019105074695947,
-      "phase": 251.72429971610285
+      "amplitude": 0.001,
+      "phase": 251.72
     },
     {
       "name": "2N2",
-      "amplitude": 0.00023462400655142833,
-      "phase": 355.4372075751632
+      "amplitude": 0,
+      "phase": 355.44
     },
     {
       "name": "S1",
-      "amplitude": 0.002917344698689837,
-      "phase": 67.2813506252582
+      "amplitude": 0.003,
+      "phase": 67.28
     },
     {
       "name": "K1",
-      "amplitude": 0.009535931941589004,
-      "phase": 177.58871300812848
+      "amplitude": 0.01,
+      "phase": 177.59
     },
     {
       "name": "P1",
-      "amplitude": 0.002350462237590642,
-      "phase": 183.57564302698356
+      "amplitude": 0.002,
+      "phase": 183.58
     },
     {
       "name": "O1",
-      "amplitude": 0.014003733854058738,
-      "phase": 155.9597733462747
+      "amplitude": 0.014,
+      "phase": 155.96
     },
     {
       "name": "Q1",
-      "amplitude": 0.0017102044707428268,
-      "phase": 104.13908058784932
+      "amplitude": 0.002,
+      "phase": 104.14
     },
     {
       "name": "M1",
-      "amplitude": 0.0005501416533107496,
-      "phase": 42.08618132634086
+      "amplitude": 0.001,
+      "phase": 42.09
     },
     {
       "name": "M4",
-      "amplitude": 0.0009847761897411544,
-      "phase": 144.31387793045496
+      "amplitude": 0.001,
+      "phase": 144.31
     },
     {
       "name": "MM",
-      "amplitude": 0.010861138524617607,
-      "phase": 282.30910670903677
+      "amplitude": 0.011,
+      "phase": 282.31
     },
     {
       "name": "MF",
-      "amplitude": 0.008302733961226568,
-      "phase": 272.0415407221128
+      "amplitude": 0.008,
+      "phase": 272.04
     },
     {
       "name": "SA",
-      "amplitude": 0.042156199115717795,
-      "phase": 200.38302305591256
+      "amplitude": 0.042,
+      "phase": 200.38
     },
     {
       "name": "SSA",
-      "amplitude": 0.030437904754731012,
-      "phase": 246.1157367617541
+      "amplitude": 0.03,
+      "phase": 246.12
     },
     {
       "name": "T2",
-      "amplitude": 0.00060438526883859,
-      "phase": 271.01517757812644
+      "amplitude": 0.001,
+      "phase": 271.02
     },
     {
       "name": "J1",
-      "amplitude": 0.0008326896687134674,
-      "phase": 220.12221720896835
+      "amplitude": 0.001,
+      "phase": 220.12
     },
     {
       "name": "L2",
-      "amplitude": 0.00006802204609023156,
-      "phase": 199.68332334334664
+      "amplitude": 0,
+      "phase": 199.68
     },
     {
       "name": "R2",
-      "amplitude": 0.00027624825806689824,
-      "phase": 19.30282053219139
+      "amplitude": 0,
+      "phase": 19.3
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00006452584240042421,
-      "phase": 279.1683863948713
+      "amplitude": 0,
+      "phase": 279.17
     },
     {
       "name": "MSF",
-      "amplitude": 0.0015084878962357585,
-      "phase": 259.0222278399712
+      "amplitude": 0.002,
+      "phase": 259.02
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0031878636887621133,
-      "phase": 202.04432571945185
+      "amplitude": 0.003,
+      "phase": 202.04
     },
     {
       "name": "EP2",
-      "amplitude": 0.000027438962844897064,
-      "phase": 254.9141110721707
+      "amplitude": 0,
+      "phase": 254.91
     },
     {
       "name": "M3",
-      "amplitude": 0.00024854420273266384,
-      "phase": 111.06525920778404
+      "amplitude": 0,
+      "phase": 111.07
     },
     {
       "name": "MU2",
-      "amplitude": 0.000418227313445864,
-      "phase": 200.4438999095568
+      "amplitude": 0,
+      "phase": 200.44
     },
     {
       "name": "MTM",
-      "amplitude": 0.0030353609516720653,
-      "phase": 329.8959090727138
+      "amplitude": 0.003,
+      "phase": 329.9
     },
     {
       "name": "NU2",
-      "amplitude": 0.00036517968293469565,
-      "phase": 280.19035004442713
+      "amplitude": 0,
+      "phase": 280.19
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00010861629880598536,
-      "phase": 38.53696249175289
+      "amplitude": 0,
+      "phase": 38.54
     },
     {
       "name": "MN4",
-      "amplitude": 0.0003345987144743528,
-      "phase": 75.1229265892905
+      "amplitude": 0,
+      "phase": 75.12
     },
     {
       "name": "MS4",
-      "amplitude": 0.0003448873549777911,
-      "phase": 307.95728700153336
+      "amplitude": 0,
+      "phase": 307.96
     },
     {
       "name": "N4",
-      "amplitude": 0.00009704545780739582,
-      "phase": 27.445935239630785
+      "amplitude": 0,
+      "phase": 27.45
     },
     {
       "name": "M6",
-      "amplitude": 0.00006035448880775298,
-      "phase": 48.22815511503916
+      "amplitude": 0,
+      "phase": 48.23
     },
     {
       "name": "M8",
-      "amplitude": 0.00005731088266028851,
-      "phase": 331.1846147082322
+      "amplitude": 0,
+      "phase": 331.18
     },
     {
       "name": "S4",
-      "amplitude": 0.00003586642655751971,
-      "phase": 289.0309399105772
+      "amplitude": 0,
+      "phase": 289.03
     },
     {
       "name": "OO1",
-      "amplitude": 0.0006229028469159301,
-      "phase": 154.31495099762105
+      "amplitude": 0.001,
+      "phase": 154.31
     },
     {
       "name": "S3",
-      "amplitude": 0.000277000249069241,
-      "phase": 147.8474968751923
+      "amplitude": 0,
+      "phase": 147.85
     },
     {
       "name": "MA2",
-      "amplitude": 0.0001321861996932144,
-      "phase": 79.31493254288637
+      "amplitude": 0,
+      "phase": 79.31
     },
     {
       "name": "MB2",
-      "amplitude": 0.0006743446111924542,
-      "phase": 61.1887537845505
+      "amplitude": 0.001,
+      "phase": 61.19
     },
     {
       "name": "T3",
-      "amplitude": 0.0003791094544039761,
-      "phase": 50.40578762476741
+      "amplitude": 0,
+      "phase": 50.41
     },
     {
       "name": "R3",
-      "amplitude": 0.0002902266102739072,
-      "phase": 139.3308358812493
+      "amplitude": 0,
+      "phase": 139.33
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0001291079419779886,
-      "phase": 351.3949938338128
+      "amplitude": 0,
+      "phase": 351.39
     },
     {
       "name": "SGM",
-      "amplitude": 0.0013774034644349856,
-      "phase": 243.25828825350268
+      "amplitude": 0.001,
+      "phase": 243.26
     },
     {
       "name": "3L2",
-      "amplitude": 0.00006991068322148297,
-      "phase": 305.6873950365756
+      "amplitude": 0,
+      "phase": 305.69
     },
     {
       "name": "3N2",
-      "amplitude": 0.00014214766783691166,
-      "phase": 214.67210182668785
+      "amplitude": 0,
+      "phase": 214.67
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0002329565004708289,
-      "phase": 28.72845217410105
+      "amplitude": 0,
+      "phase": 28.73
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00012787315327484675,
-      "phase": 111.36175078289239
+      "amplitude": 0,
+      "phase": 111.36
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000050223168359000396,
-      "phase": 115.97349268129591
+      "amplitude": 0,
+      "phase": 115.97
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00010118114465985238,
-      "phase": 21.5512754653422
+      "amplitude": 0,
+      "phase": 21.55
     }
   ],
   "epoch": {

--- a/data/ticon/barth-9650030-deu-wsv.json
+++ b/data/ticon/barth-9650030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.0006895264078875467,
-      "phase": 24.299567209867575
+      "amplitude": 0.001,
+      "phase": 24.3
     },
     {
       "name": "N2",
-      "amplitude": 0.00006171588949108428,
-      "phase": 31.149086247863806
+      "amplitude": 0,
+      "phase": 31.15
     },
     {
       "name": "S2",
-      "amplitude": 0.0006520753341617606,
-      "phase": 135.15578158334847
+      "amplitude": 0.001,
+      "phase": 135.16
     },
     {
       "name": "K2",
-      "amplitude": 0.0000601695724114117,
-      "phase": 168.47795495606954
+      "amplitude": 0,
+      "phase": 168.48
     },
     {
       "name": "2N2",
-      "amplitude": 0.00013344131569325679,
-      "phase": 316.09701757434516
+      "amplitude": 0,
+      "phase": 316.1
     },
     {
       "name": "S1",
-      "amplitude": 0.0012087385276427112,
-      "phase": 132.0428877189915
+      "amplitude": 0.001,
+      "phase": 132.04
     },
     {
       "name": "K1",
-      "amplitude": 0.001296835745161291,
-      "phase": 257.5390681563556
+      "amplitude": 0.001,
+      "phase": 257.54
     },
     {
       "name": "P1",
-      "amplitude": 0.00023188419590261462,
-      "phase": 44.77356423864313
+      "amplitude": 0,
+      "phase": 44.77
     },
     {
       "name": "O1",
-      "amplitude": 0.002283625617428308,
-      "phase": 240.00827370016594
+      "amplitude": 0.002,
+      "phase": 240.01
     },
     {
       "name": "Q1",
-      "amplitude": 0.00028523120786592884,
-      "phase": 178.25738565633822
+      "amplitude": 0,
+      "phase": 178.26
     },
     {
       "name": "M1",
-      "amplitude": 0.00007474785112040863,
-      "phase": 147.18176835970218
+      "amplitude": 0,
+      "phase": 147.18
     },
     {
       "name": "M4",
-      "amplitude": 0.000037790796313328044,
-      "phase": 35.98064801353269
+      "amplitude": 0,
+      "phase": 35.98
     },
     {
       "name": "MM",
-      "amplitude": 0.010906542569223156,
-      "phase": 320.456072291788
+      "amplitude": 0.011,
+      "phase": 320.46
     },
     {
       "name": "MF",
-      "amplitude": 0.007452334861492334,
-      "phase": 306.3263047240057
+      "amplitude": 0.007,
+      "phase": 306.33
     },
     {
       "name": "SA",
-      "amplitude": 0.04558631896397505,
-      "phase": 220.49219851877922
+      "amplitude": 0.046,
+      "phase": 220.49
     },
     {
       "name": "SSA",
-      "amplitude": 0.023304806675078574,
-      "phase": 262.4710968929062
+      "amplitude": 0.023,
+      "phase": 262.47
     },
     {
       "name": "T2",
-      "amplitude": 0.00004323267533437464,
-      "phase": 245.3078538001129
+      "amplitude": 0,
+      "phase": 245.31
     },
     {
       "name": "J1",
-      "amplitude": 0.00006472451666308685,
-      "phase": 7.818757624913644
+      "amplitude": 0,
+      "phase": 7.82
     },
     {
       "name": "L2",
-      "amplitude": 0.00006598559856892698,
-      "phase": 341.0161041028397
+      "amplitude": 0,
+      "phase": 341.02
     },
     {
       "name": "R2",
-      "amplitude": 0.0001852726280588506,
-      "phase": 86.14367715892047
+      "amplitude": 0,
+      "phase": 86.14
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00014390572041319977,
-      "phase": 108.90740117629309
+      "amplitude": 0,
+      "phase": 108.91
     },
     {
       "name": "MSF",
-      "amplitude": 0.0015410408254917256,
-      "phase": 357.32544172964253
+      "amplitude": 0.002,
+      "phase": 357.33
     },
     {
       "name": "MSQM",
-      "amplitude": 0.002328329620212385,
-      "phase": 243.9241931693225
+      "amplitude": 0.002,
+      "phase": 243.92
     },
     {
       "name": "EP2",
-      "amplitude": 0.00007543435341430079,
-      "phase": 106.38043110553377
+      "amplitude": 0,
+      "phase": 106.38
     },
     {
       "name": "M3",
-      "amplitude": 0.00006469648312804181,
-      "phase": 303.2596696696624
+      "amplitude": 0,
+      "phase": 303.26
     },
     {
       "name": "MU2",
-      "amplitude": 0.0001346159003362007,
-      "phase": 344.73059657443207
+      "amplitude": 0,
+      "phase": 344.73
     },
     {
       "name": "MTM",
-      "amplitude": 0.001350109488884876,
-      "phase": 6.199059563152105
+      "amplitude": 0.001,
+      "phase": 6.2
     },
     {
       "name": "NU2",
-      "amplitude": 0.000051098843543588067,
-      "phase": 68.49878242905203
+      "amplitude": 0,
+      "phase": 68.5
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00008388204054243133,
-      "phase": 238.68006165886726
+      "amplitude": 0,
+      "phase": 238.68
     },
     {
       "name": "MN4",
-      "amplitude": 0.00001724476699967824,
-      "phase": 169.94122691179587
+      "amplitude": 0,
+      "phase": 169.94
     },
     {
       "name": "MS4",
-      "amplitude": 0.00005310682242645271,
-      "phase": 16.72137377794013
+      "amplitude": 0,
+      "phase": 16.72
     },
     {
       "name": "N4",
-      "amplitude": 0.000013976073950669564,
-      "phase": 48.694470694519055
+      "amplitude": 0,
+      "phase": 48.69
     },
     {
       "name": "M6",
-      "amplitude": 0.000023314320605763357,
-      "phase": 219.33125280022233
+      "amplitude": 0,
+      "phase": 219.33
     },
     {
       "name": "M8",
-      "amplitude": 0.00004800343393772484,
-      "phase": 275.77837731681666
+      "amplitude": 0,
+      "phase": 275.78
     },
     {
       "name": "S4",
-      "amplitude": 0.000017634253949568308,
-      "phase": 41.11427964662778
+      "amplitude": 0,
+      "phase": 41.11
     },
     {
       "name": "OO1",
-      "amplitude": 0.00006457849933369491,
-      "phase": 215.369454534344
+      "amplitude": 0,
+      "phase": 215.37
     },
     {
       "name": "S3",
-      "amplitude": 0.00022901517692659317,
-      "phase": 332.1720130612648
+      "amplitude": 0,
+      "phase": 332.17
     },
     {
       "name": "MA2",
-      "amplitude": 0.00006768166511741354,
-      "phase": 102.4609941811479
+      "amplitude": 0,
+      "phase": 102.46
     },
     {
       "name": "MB2",
-      "amplitude": 0.00012120602724423331,
-      "phase": 191.83506359075722
+      "amplitude": 0,
+      "phase": 191.84
     },
     {
       "name": "T3",
-      "amplitude": 0.0002035427729432683,
-      "phase": 300.3569090642108
+      "amplitude": 0,
+      "phase": 300.36
     },
     {
       "name": "R3",
-      "amplitude": 0.00017494069815239064,
-      "phase": 21.47853281173184
+      "amplitude": 0,
+      "phase": 21.48
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00005359141045245405,
-      "phase": 241.36742667156787
+      "amplitude": 0,
+      "phase": 241.37
     },
     {
       "name": "SGM",
-      "amplitude": 0.0002559858219884688,
-      "phase": 304.7587204300061
+      "amplitude": 0,
+      "phase": 304.76
     },
     {
       "name": "3L2",
-      "amplitude": 0.0000407023051720494,
-      "phase": 135.89975145610617
+      "amplitude": 0,
+      "phase": 135.9
     },
     {
       "name": "3N2",
-      "amplitude": 0.000024036045772004576,
-      "phase": 293.493569648788
+      "amplitude": 0,
+      "phase": 293.49
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00005286199329777873,
-      "phase": 174.45285183684723
+      "amplitude": 0,
+      "phase": 174.45
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000025284802856989614,
-      "phase": 26.24414119596554
+      "amplitude": 0,
+      "phase": 26.24
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000039489760412672175,
-      "phase": 270.2522648452741
+      "amplitude": 0,
+      "phase": 270.25
     },
     {
       "name": "2MO5",
-      "amplitude": 0.000030439088086365002,
-      "phase": 178.04911338988632
+      "amplitude": 0,
+      "phase": 178.05
     }
   ],
   "epoch": {

--- a/data/ticon/belum-5980060-deu-wsv.json
+++ b/data/ticon/belum-5980060-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.1901290310238848,
-      "phase": 9.006791599846451
+      "amplitude": 1.19,
+      "phase": 9.01
     },
     {
       "name": "N2",
-      "amplitude": 0.18420397225618315,
-      "phase": 343.07236296338806
+      "amplitude": 0.184,
+      "phase": 343.07
     },
     {
       "name": "S2",
-      "amplitude": 0.29362557535498895,
-      "phase": 79.17264331597494
+      "amplitude": 0.294,
+      "phase": 79.17
     },
     {
       "name": "K2",
-      "amplitude": 0.08664799623264655,
-      "phase": 77.77247302835008
+      "amplitude": 0.087,
+      "phase": 77.77
     },
     {
       "name": "2N2",
-      "amplitude": 0.022019487072849377,
-      "phase": 321.69626509363843
+      "amplitude": 0.022,
+      "phase": 321.7
     },
     {
       "name": "S1",
-      "amplitude": 0.01473829987641195,
-      "phase": 65.09688681592047
+      "amplitude": 0.015,
+      "phase": 65.1
     },
     {
       "name": "K1",
-      "amplitude": 0.06963730529492236,
-      "phase": 63.30751260880322
+      "amplitude": 0.07,
+      "phase": 63.31
     },
     {
       "name": "P1",
-      "amplitude": 0.028579355382573453,
-      "phase": 60.47904139915181
+      "amplitude": 0.029,
+      "phase": 60.48
     },
     {
       "name": "O1",
-      "amplitude": 0.08758043147534361,
-      "phase": 268.86174806723204
+      "amplitude": 0.088,
+      "phase": 268.86
     },
     {
       "name": "Q1",
-      "amplitude": 0.026066270455700598,
-      "phase": 211.02237528726684
+      "amplitude": 0.026,
+      "phase": 211.02
     },
     {
       "name": "M1",
-      "amplitude": 0.001844606423469175,
-      "phase": 103.27949557449574
+      "amplitude": 0.002,
+      "phase": 103.28
     },
     {
       "name": "M4",
-      "amplitude": 0.12170587649893376,
-      "phase": 274.19166291164305
+      "amplitude": 0.122,
+      "phase": 274.19
     },
     {
       "name": "MM",
-      "amplitude": 0.016394760441600056,
-      "phase": 146.9645591686966
+      "amplitude": 0.016,
+      "phase": 146.96
     },
     {
       "name": "MF",
-      "amplitude": 0.014215411010813958,
-      "phase": 111.79268159714127
+      "amplitude": 0.014,
+      "phase": 111.79
     },
     {
       "name": "SA",
-      "amplitude": 0.08828342400048118,
-      "phase": 228.94536750200226
+      "amplitude": 0.088,
+      "phase": 228.95
     },
     {
       "name": "SSA",
-      "amplitude": 0.04901385407996365,
-      "phase": 214.6730941275666
+      "amplitude": 0.049,
+      "phase": 214.67
     },
     {
       "name": "T2",
-      "amplitude": 0.01565705967665368,
-      "phase": 66.45617999203017
+      "amplitude": 0.016,
+      "phase": 66.46
     },
     {
       "name": "J1",
-      "amplitude": 0.004847387469545025,
-      "phase": 188.52519142626605
+      "amplitude": 0.005,
+      "phase": 188.53
     },
     {
       "name": "L2",
-      "amplitude": 0.09899361978920047,
-      "phase": 29.39682879352449
+      "amplitude": 0.099,
+      "phase": 29.4
     },
     {
       "name": "R2",
-      "amplitude": 0.004832844028433109,
-      "phase": 69.88215930605617
+      "amplitude": 0.005,
+      "phase": 69.88
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005799315741020577,
-      "phase": 151.41030038900556
+      "amplitude": 0.006,
+      "phase": 151.41
     },
     {
       "name": "MSF",
-      "amplitude": 0.04956814289954215,
-      "phase": 62.08928660040522
+      "amplitude": 0.05,
+      "phase": 62.09
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007705995919574079,
-      "phase": 58.52166466117046
+      "amplitude": 0.008,
+      "phase": 58.52
     },
     {
       "name": "EP2",
-      "amplitude": 0.028544073748929737,
-      "phase": 74.6124219737473
+      "amplitude": 0.029,
+      "phase": 74.61
     },
     {
       "name": "M3",
-      "amplitude": 0.0033126575644883273,
-      "phase": 34.42025819974748
+      "amplitude": 0.003,
+      "phase": 34.42
     },
     {
       "name": "MU2",
-      "amplitude": 0.1343663227630834,
-      "phase": 100.85012018001635
+      "amplitude": 0.134,
+      "phase": 100.85
     },
     {
       "name": "MTM",
-      "amplitude": 0.006076915427067019,
-      "phase": 235.82180931387367
+      "amplitude": 0.006,
+      "phase": 235.82
     },
     {
       "name": "NU2",
-      "amplitude": 0.07449661704846443,
-      "phase": 328.1368516266974
+      "amplitude": 0.074,
+      "phase": 328.14
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04529562954986952,
-      "phase": 24.625484578988676
+      "amplitude": 0.045,
+      "phase": 24.63
     },
     {
       "name": "MN4",
-      "amplitude": 0.04232767636439243,
-      "phase": 250.46093722701903
+      "amplitude": 0.042,
+      "phase": 250.46
     },
     {
       "name": "MS4",
-      "amplitude": 0.07251717877146227,
-      "phase": 340.9180637798243
+      "amplitude": 0.073,
+      "phase": 340.92
     },
     {
       "name": "N4",
-      "amplitude": 0.009133344322613155,
-      "phase": 228.44070358815677
+      "amplitude": 0.009,
+      "phase": 228.44
     },
     {
       "name": "M6",
-      "amplitude": 0.06565562615548098,
-      "phase": 116.45217180180396
+      "amplitude": 0.066,
+      "phase": 116.45
     },
     {
       "name": "M8",
-      "amplitude": 0.022726947388149406,
-      "phase": 39.90016049664456
+      "amplitude": 0.023,
+      "phase": 39.9
     },
     {
       "name": "S4",
-      "amplitude": 0.006562083257814519,
-      "phase": 99.83661055396453
+      "amplitude": 0.007,
+      "phase": 99.84
     },
     {
       "name": "OO1",
-      "amplitude": 0.0030189927376365285,
-      "phase": 198.48486426665255
+      "amplitude": 0.003,
+      "phase": 198.48
     },
     {
       "name": "S3",
-      "amplitude": 0.0009376500294398511,
-      "phase": 256.65195909563
+      "amplitude": 0.001,
+      "phase": 256.65
     },
     {
       "name": "MA2",
-      "amplitude": 0.027764454203328907,
-      "phase": 310.0080845233388
+      "amplitude": 0.028,
+      "phase": 310.01
     },
     {
       "name": "MB2",
-      "amplitude": 0.027216963349681295,
-      "phase": 80.93961012072532
+      "amplitude": 0.027,
+      "phase": 80.94
     },
     {
       "name": "T3",
-      "amplitude": 0.00037789388276349405,
-      "phase": 69.84537038632129
+      "amplitude": 0,
+      "phase": 69.85
     },
     {
       "name": "R3",
-      "amplitude": 0.0037038982254085605,
-      "phase": 55.836111921198665
+      "amplitude": 0.004,
+      "phase": 55.84
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005646208395228533,
-      "phase": 213.09689143895022
+      "amplitude": 0.006,
+      "phase": 213.1
     },
     {
       "name": "SGM",
-      "amplitude": 0.003260358498835568,
-      "phase": 61.458730912178055
+      "amplitude": 0.003,
+      "phase": 61.46
     },
     {
       "name": "3L2",
-      "amplitude": 0.0035633768634157647,
-      "phase": 260.433280790137
+      "amplitude": 0.004,
+      "phase": 260.43
     },
     {
       "name": "3N2",
-      "amplitude": 0.016556873045144697,
-      "phase": 173.49744743517397
+      "amplitude": 0.017,
+      "phase": 173.5
     },
     {
       "name": "2SM2",
-      "amplitude": 0.029105664387436725,
-      "phase": 304.63504247810374
+      "amplitude": 0.029,
+      "phase": 304.64
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0643960395940955,
-      "phase": 184.0983050692002
+      "amplitude": 0.064,
+      "phase": 184.1
     },
     {
       "name": "2MK5",
-      "amplitude": 0.002961677039878497,
-      "phase": 117.10914458187568
+      "amplitude": 0.003,
+      "phase": 117.11
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0024580801209636337,
-      "phase": 48.60616266278953
+      "amplitude": 0.002,
+      "phase": 48.61
     }
   ],
   "epoch": {

--- a/data/ticon/bergse_diepsluis_west-bergsdswt-nld-rws.json
+++ b/data/ticon/bergse_diepsluis_west-bergsdswt-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.43297794,
-      "phase": 84.29256599999997
+      "amplitude": 1.486,
+      "phase": 68.76
     },
     {
       "name": "N2",
-      "amplitude": 0.21337990999999998,
-      "phase": 59.24062200000003
+      "amplitude": 0.228,
+      "phase": 46.05
     },
     {
       "name": "S2",
-      "amplitude": 0.36379268000000003,
-      "phase": 149.28735900000004
+      "amplitude": 0.375,
+      "phase": 133.38
     },
     {
       "name": "K2",
-      "amplitude": 0.10685221,
-      "phase": 150.33246199999996
+      "amplitude": 0.109,
+      "phase": 132.59
     },
     {
       "name": "2N2",
-      "amplitude": 0.04281851,
-      "phase": 20.828322000000014
+      "amplitude": 0.049,
+      "phase": 11.09
     },
     {
       "name": "S1",
-      "amplitude": 0.00969246,
-      "phase": 32.77205700000002
+      "amplitude": 0.011,
+      "phase": 335.54
     },
     {
       "name": "K1",
-      "amplitude": 0.07063017,
-      "phase": 25.516586000000018
+      "amplitude": 0.071,
+      "phase": 17.18
     },
     {
       "name": "P1",
-      "amplitude": 0.0334354,
-      "phase": 11.259899000000019
+      "amplitude": 0.033,
+      "phase": 3.18
     },
     {
       "name": "O1",
-      "amplitude": 0.10627533,
-      "phase": 205.302134
+      "amplitude": 0.107,
+      "phase": 198.35
     },
     {
       "name": "Q1",
-      "amplitude": 0.02927419,
-      "phase": 152.45039299999996
+      "amplitude": 0.03,
+      "phase": 144.62
     },
     {
       "name": "M1",
-      "amplitude": 0.0099215,
-      "phase": 107.09408400000001
+      "amplitude": 0.003,
+      "phase": 349.75
     },
     {
       "name": "M4",
-      "amplitude": 0.09101409,
-      "phase": 190.932204
+      "amplitude": 0.105,
+      "phase": 165.2
     },
     {
       "name": "MM",
-      "amplitude": 0.014343539999999998,
-      "phase": 347.095304
+      "amplitude": 0.016,
+      "phase": 349.2
     },
     {
       "name": "MF",
-      "amplitude": 0.00771213,
-      "phase": 76.61093700000004
+      "amplitude": 0.007,
+      "phase": 77.22
     },
     {
       "name": "SA",
-      "amplitude": 0.07658842,
-      "phase": 220.618617
+      "amplitude": 0.079,
+      "phase": 220.57
     },
     {
       "name": "SSA",
-      "amplitude": 0.00363643,
-      "phase": 11.644145999999978
+      "amplitude": 0.004,
+      "phase": 39.02
     },
     {
       "name": "T2",
-      "amplitude": 0.07556933,
-      "phase": 77.577696
+      "amplitude": 0.023,
+      "phase": 121.56
     },
     {
       "name": "J1",
-      "amplitude": 0.0044751800000000005,
-      "phase": 104.94922700000001
+      "amplitude": 0.005,
+      "phase": 98.24
     },
     {
       "name": "L2",
-      "amplitude": 0.10802981,
-      "phase": 98.18425000000002
+      "amplitude": 0.114,
+      "phase": 84.21
     },
     {
       "name": "R2",
-      "amplitude": 0.04324777,
-      "phase": 243.985971
+      "amplitude": 0.003,
+      "phase": 190.09
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005367340000000001,
-      "phase": 127.01903199999998
+      "amplitude": 0.005,
+      "phase": 111.85
     },
     {
       "name": "MSF",
-      "amplitude": 0.056021409999999994,
-      "phase": 33.24870900000002
+      "amplitude": 0.057,
+      "phase": 31.57
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00801296,
-      "phase": 190.773881
+      "amplitude": 0.008,
+      "phase": 187.84
     },
     {
       "name": "EP2",
-      "amplitude": 0.02715588,
-      "phase": 168.822857
+      "amplitude": 0.027,
+      "phase": 155.21
     },
     {
       "name": "M3",
-      "amplitude": 0.0020364099999999998,
-      "phase": 187.518598
+      "amplitude": 0.002,
+      "phase": 337.77
     },
     {
       "name": "MU2",
-      "amplitude": 0.15538672,
-      "phase": 181.252628
+      "amplitude": 0.158,
+      "phase": 168.09
     },
     {
       "name": "MTM",
-      "amplitude": 0.01920591,
-      "phase": 162.977348
+      "amplitude": 0.021,
+      "phase": 161.81
     },
     {
       "name": "NU2",
-      "amplitude": 0.08502611,
-      "phase": 49.774996999999985
+      "amplitude": 0.088,
+      "phase": 29.58
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.058430239999999994,
-      "phase": 100.75656700000002
+      "amplitude": 0.06,
+      "phase": 84.59
     },
     {
       "name": "MN4",
-      "amplitude": 0.027402419999999997,
-      "phase": 164.702541
+      "amplitude": 0.034,
+      "phase": 140.46
     },
     {
       "name": "MS4",
-      "amplitude": 0.05636907,
-      "phase": 248.126551
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03112962,
-      "phase": 221.497849
+      "amplitude": 0.066,
+      "phase": 220.2
     },
     {
       "name": "N4",
-      "amplitude": 0.00853949,
-      "phase": 139.880401
+      "amplitude": 0.011,
+      "phase": 113.93
     },
     {
       "name": "M6",
-      "amplitude": 0.0571218,
-      "phase": 226.522674
+      "amplitude": 0.084,
+      "phase": 185.61
     },
     {
       "name": "M8",
-      "amplitude": 0.00248631,
-      "phase": 195.362374
+      "amplitude": 0.006,
+      "phase": 146.88
     },
     {
       "name": "S4",
-      "amplitude": 0.00459507,
-      "phase": 5.230575999999985
+      "amplitude": 0.005,
+      "phase": 334.88
     },
     {
       "name": "OO1",
-      "amplitude": 0.00368811,
-      "phase": 173.83032000000003
+      "amplitude": 0.003,
+      "phase": 190.21
     },
     {
       "name": "S3",
-      "amplitude": 0.0014910899999999998,
-      "phase": 146.825132
+      "amplitude": 0.001,
+      "phase": 94.12
     },
     {
       "name": "MA2",
-      "amplitude": 0.25853633,
-      "phase": 73.15891199999999
+      "amplitude": 0.028,
+      "phase": 56.18
     },
     {
       "name": "MB2",
-      "amplitude": 0.25243932,
-      "phase": 268.079357
+      "amplitude": 0.025,
+      "phase": 204.11
     },
     {
       "name": "T3",
-      "amplitude": 0.00155891,
-      "phase": 111.02756
+      "amplitude": 0.002,
+      "phase": 274.28
     },
     {
       "name": "R3",
-      "amplitude": 0.00552599,
-      "phase": 343.362594
+      "amplitude": 0.005,
+      "phase": 53.74
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0053527800000000006,
-      "phase": 163.814529
+      "amplitude": 0.006,
+      "phase": 149.47
     },
     {
       "name": "SGM",
-      "amplitude": 0.00727189,
-      "phase": 189.602213
+      "amplitude": 0.006,
+      "phase": 354.91
     },
     {
       "name": "3L2",
-      "amplitude": 0.01388112,
-      "phase": 115.145333
+      "amplitude": 0.01,
+      "phase": 138.87
     },
     {
       "name": "3N2",
-      "amplitude": 0.00792266,
-      "phase": 117.88471600000003
+      "amplitude": 0.018,
+      "phase": 235.47
     },
     {
       "name": "2SM2",
-      "amplitude": 0.042644549999999996,
-      "phase": 11.355092000000013
+      "amplitude": 0.044,
+      "phase": 356.48
     },
     {
       "name": "2MS6",
-      "amplitude": 0.050117919999999996,
-      "phase": 278.970554
+      "amplitude": 0.074,
+      "phase": 237.29
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0033432699999999997,
-      "phase": 166.629634
+      "amplitude": 0.004,
+      "phase": 224
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0026040200000000003,
-      "phase": 41.623468
+      "amplitude": 0.003,
+      "phase": 280.14
     }
   ],
   "epoch": {

--- a/data/ticon/bhvalterleuchtturm-4990010-deu-wsv.json
+++ b/data/ticon/bhvalterleuchtturm-4990010-deu-wsv.json
@@ -1,6 +1,6 @@
 {
   "name": "Bhvalterleuchtturm",
-  "region": "City state Bremen",
+  "region": "Bremen",
   "country": "Germany",
   "continent": "Europe",
   "latitude": 53.546511,
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.6941085106913643,
-      "phase": 345.64474169339627
+      "amplitude": 1.694,
+      "phase": 345.64
     },
     {
       "name": "N2",
-      "amplitude": 0.26566193990612674,
-      "phase": 321.0827712761762
+      "amplitude": 0.266,
+      "phase": 321.08
     },
     {
       "name": "S2",
-      "amplitude": 0.4376657385478618,
-      "phase": 60.09809829401104
+      "amplitude": 0.438,
+      "phase": 60.1
     },
     {
       "name": "K2",
-      "amplitude": 0.129475937986779,
-      "phase": 56.79557300588078
+      "amplitude": 0.129,
+      "phase": 56.8
     },
     {
       "name": "2N2",
-      "amplitude": 0.029079765177808053,
-      "phase": 300.2713145583227
+      "amplitude": 0.029,
+      "phase": 300.27
     },
     {
       "name": "S1",
-      "amplitude": 0.017216155355850457,
-      "phase": 49.44588809141726
+      "amplitude": 0.017,
+      "phase": 49.45
     },
     {
       "name": "K1",
-      "amplitude": 0.0728260755252673,
-      "phase": 42.28481516856476
+      "amplitude": 0.073,
+      "phase": 42.28
     },
     {
       "name": "P1",
-      "amplitude": 0.03293122749734667,
-      "phase": 47.27280853074899
+      "amplitude": 0.033,
+      "phase": 47.27
     },
     {
       "name": "O1",
-      "amplitude": 0.0941955564150608,
-      "phase": 250.2014166112413
+      "amplitude": 0.094,
+      "phase": 250.2
     },
     {
       "name": "Q1",
-      "amplitude": 0.028829749680359854,
-      "phase": 191.14084583508844
+      "amplitude": 0.029,
+      "phase": 191.14
     },
     {
       "name": "M1",
-      "amplitude": 0.0022327147405127386,
-      "phase": 104.243674251122
+      "amplitude": 0.002,
+      "phase": 104.24
     },
     {
       "name": "M4",
-      "amplitude": 0.15230600022269122,
-      "phase": 154.15393613690776
+      "amplitude": 0.152,
+      "phase": 154.15
     },
     {
       "name": "MM",
-      "amplitude": 0.019389137729424983,
-      "phase": 163.3929400852113
+      "amplitude": 0.019,
+      "phase": 163.39
     },
     {
       "name": "MF",
-      "amplitude": 0.009824990599001354,
-      "phase": 146.656815070667
+      "amplitude": 0.01,
+      "phase": 146.66
     },
     {
       "name": "SA",
-      "amplitude": 0.08182987957788841,
-      "phase": 223.80938301020046
+      "amplitude": 0.082,
+      "phase": 223.81
     },
     {
       "name": "SSA",
-      "amplitude": 0.041730734495064294,
-      "phase": 213.33927488574423
+      "amplitude": 0.042,
+      "phase": 213.34
     },
     {
       "name": "T2",
-      "amplitude": 0.024515831535743174,
-      "phase": 29.811663366475955
+      "amplitude": 0.025,
+      "phase": 29.81
     },
     {
       "name": "J1",
-      "amplitude": 0.002799083342121507,
-      "phase": 180.6178241387873
+      "amplitude": 0.003,
+      "phase": 180.62
     },
     {
       "name": "L2",
-      "amplitude": 0.14347696987260922,
-      "phase": 1.673552102120766
+      "amplitude": 0.143,
+      "phase": 1.67
     },
     {
       "name": "R2",
-      "amplitude": 0.0037782495348051663,
-      "phase": 299.7246572913043
+      "amplitude": 0.004,
+      "phase": 299.72
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006176207995403858,
-      "phase": 133.9228547747527
+      "amplitude": 0.006,
+      "phase": 133.92
     },
     {
       "name": "MSF",
-      "amplitude": 0.019988550964319295,
-      "phase": 58.486923048961444
+      "amplitude": 0.02,
+      "phase": 58.49
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009153012944025605,
-      "phase": 57.55172774453666
+      "amplitude": 0.009,
+      "phase": 57.55
     },
     {
       "name": "EP2",
-      "amplitude": 0.04192370211816089,
-      "phase": 44.87980539368647
+      "amplitude": 0.042,
+      "phase": 44.88
     },
     {
       "name": "M3",
-      "amplitude": 0.004058685608304721,
-      "phase": 41.33882875878464
+      "amplitude": 0.004,
+      "phase": 41.34
     },
     {
       "name": "MU2",
-      "amplitude": 0.19279422226405996,
-      "phase": 67.7955591740182
+      "amplitude": 0.193,
+      "phase": 67.8
     },
     {
       "name": "MTM",
-      "amplitude": 0.004378962952169765,
-      "phase": 240.80614564171236
+      "amplitude": 0.004,
+      "phase": 240.81
     },
     {
       "name": "NU2",
-      "amplitude": 0.10241186205307112,
-      "phase": 300.82155045197555
+      "amplitude": 0.102,
+      "phase": 300.82
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06771456806110836,
-      "phase": 358.37686628196434
+      "amplitude": 0.068,
+      "phase": 358.38
     },
     {
       "name": "MN4",
-      "amplitude": 0.04691847555960854,
-      "phase": 130.44358341436362
+      "amplitude": 0.047,
+      "phase": 130.44
     },
     {
       "name": "MS4",
-      "amplitude": 0.10374156476141527,
-      "phase": 235.66335959613883
+      "amplitude": 0.104,
+      "phase": 235.66
     },
     {
       "name": "N4",
-      "amplitude": 0.009619354668235562,
-      "phase": 108.83353143227549
+      "amplitude": 0.01,
+      "phase": 108.83
     },
     {
       "name": "M6",
-      "amplitude": 0.04532965787240904,
-      "phase": 357.5447370754554
+      "amplitude": 0.045,
+      "phase": 357.54
     },
     {
       "name": "M8",
-      "amplitude": 0.012260473886460808,
-      "phase": 287.55363687896636
+      "amplitude": 0.012,
+      "phase": 287.55
     },
     {
       "name": "S4",
-      "amplitude": 0.013151605203971607,
-      "phase": 20.079045469358107
+      "amplitude": 0.013,
+      "phase": 20.08
     },
     {
       "name": "OO1",
-      "amplitude": 0.0028663842111763317,
-      "phase": 204.91738346525125
+      "amplitude": 0.003,
+      "phase": 204.92
     },
     {
       "name": "S3",
-      "amplitude": 0.0005115380385056205,
-      "phase": 246.97961671832212
+      "amplitude": 0.001,
+      "phase": 246.98
     },
     {
       "name": "MA2",
-      "amplitude": 0.06630986714698435,
-      "phase": 298.6750235218878
+      "amplitude": 0.066,
+      "phase": 298.68
     },
     {
       "name": "MB2",
-      "amplitude": 0.013525571698413489,
-      "phase": 47.22022366224638
+      "amplitude": 0.014,
+      "phase": 47.22
     },
     {
       "name": "T3",
-      "amplitude": 0.0006499568649095955,
-      "phase": 182.91480833646776
+      "amplitude": 0.001,
+      "phase": 182.91
     },
     {
       "name": "R3",
-      "amplitude": 0.0036422447405804258,
-      "phase": 50.64187044705858
+      "amplitude": 0.004,
+      "phase": 50.64
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005930992772814624,
-      "phase": 195.02801585182596
+      "amplitude": 0.006,
+      "phase": 195.03
     },
     {
       "name": "SGM",
-      "amplitude": 0.0021780270088200644,
-      "phase": 45.864874504297006
+      "amplitude": 0.002,
+      "phase": 45.86
     },
     {
       "name": "3L2",
-      "amplitude": 0.004274534989358697,
-      "phase": 251.49127720112466
+      "amplitude": 0.004,
+      "phase": 251.49
     },
     {
       "name": "3N2",
-      "amplitude": 0.02169287563138762,
-      "phase": 156.08569367418932
+      "amplitude": 0.022,
+      "phase": 156.09
     },
     {
       "name": "2SM2",
-      "amplitude": 0.045527925363394874,
-      "phase": 281.4867629213473
+      "amplitude": 0.046,
+      "phase": 281.49
     },
     {
       "name": "2MS6",
-      "amplitude": 0.051303596513908506,
-      "phase": 70.58437926215657
+      "amplitude": 0.051,
+      "phase": 70.58
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00916777156376202,
-      "phase": 8.058974068395571
+      "amplitude": 0.009,
+      "phase": 8.06
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006013531652430451,
-      "phase": 185.9580219881054
+      "amplitude": 0.006,
+      "phase": 185.96
     }
   ],
   "epoch": {

--- a/data/ticon/borgfeld-4940010-deu-wsv.json
+++ b/data/ticon/borgfeld-4940010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.4702924393188402,
-      "phase": 127.37241539502497
+      "amplitude": 0.47,
+      "phase": 127.37
     },
     {
       "name": "N2",
-      "amplitude": 0.06679100899449217,
-      "phase": 103.97579928692005
+      "amplitude": 0.067,
+      "phase": 103.98
     },
     {
       "name": "S2",
-      "amplitude": 0.10780907221457818,
-      "phase": 215.01925262349542
+      "amplitude": 0.108,
+      "phase": 215.02
     },
     {
       "name": "K2",
-      "amplitude": 0.03268942119683108,
-      "phase": 222.34404337101648
+      "amplitude": 0.033,
+      "phase": 222.34
     },
     {
       "name": "2N2",
-      "amplitude": 0.005656889146633694,
-      "phase": 91.47913111002265
+      "amplitude": 0.006,
+      "phase": 91.48
     },
     {
       "name": "S1",
-      "amplitude": 0.010345655418067923,
-      "phase": 143.20451392762595
+      "amplitude": 0.01,
+      "phase": 143.2
     },
     {
       "name": "K1",
-      "amplitude": 0.02689741237736547,
-      "phase": 147.83499031385657
+      "amplitude": 0.027,
+      "phase": 147.83
     },
     {
       "name": "P1",
-      "amplitude": 0.011220729967545537,
-      "phase": 169.16016503930655
+      "amplitude": 0.011,
+      "phase": 169.16
     },
     {
       "name": "O1",
-      "amplitude": 0.032656827052618034,
-      "phase": 348.8808292904104
+      "amplitude": 0.033,
+      "phase": 348.88
     },
     {
       "name": "Q1",
-      "amplitude": 0.007140767340945532,
-      "phase": 271.7165056754024
+      "amplitude": 0.007,
+      "phase": 271.72
     },
     {
       "name": "M1",
-      "amplitude": 0.0005406982005617138,
-      "phase": 196.37397052887866
+      "amplitude": 0.001,
+      "phase": 196.37
     },
     {
       "name": "M4",
-      "amplitude": 0.08568827248633004,
-      "phase": 174.92941916533414
+      "amplitude": 0.086,
+      "phase": 174.93
     },
     {
       "name": "MM",
-      "amplitude": 0.012696719111779537,
-      "phase": 33.81574989643349
+      "amplitude": 0.013,
+      "phase": 33.82
     },
     {
       "name": "MF",
-      "amplitude": 0.014531189133395739,
-      "phase": 103.39355817130712
+      "amplitude": 0.015,
+      "phase": 103.39
     },
     {
       "name": "SA",
-      "amplitude": 0.330655687766449,
-      "phase": 309.442027454534
+      "amplitude": 0.331,
+      "phase": 309.44
     },
     {
       "name": "SSA",
-      "amplitude": 0.08183513877966145,
-      "phase": 259.33858051744573
+      "amplitude": 0.082,
+      "phase": 259.34
     },
     {
       "name": "T2",
-      "amplitude": 0.009321248169295115,
-      "phase": 12.655013920757028
+      "amplitude": 0.009,
+      "phase": 12.66
     },
     {
       "name": "J1",
-      "amplitude": 0.0019920827165400236,
-      "phase": 313.9451078014071
+      "amplitude": 0.002,
+      "phase": 313.95
     },
     {
       "name": "L2",
-      "amplitude": 0.04787874981289532,
-      "phase": 139.90476392498783
+      "amplitude": 0.048,
+      "phase": 139.9
     },
     {
       "name": "R2",
-      "amplitude": 0.01808373588686759,
-      "phase": 259.94706071906546
+      "amplitude": 0.018,
+      "phase": 259.95
     },
     {
       "name": "2Q1",
-      "amplitude": 0.000927358703154737,
-      "phase": 175.9624899684759
+      "amplitude": 0.001,
+      "phase": 175.96
     },
     {
       "name": "MSF",
-      "amplitude": 0.059973758964408055,
-      "phase": 72.70055069761128
+      "amplitude": 0.06,
+      "phase": 72.7
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00619705923245161,
-      "phase": 344.99118407994257
+      "amplitude": 0.006,
+      "phase": 344.99
     },
     {
       "name": "EP2",
-      "amplitude": 0.01776761971223521,
-      "phase": 181.7950871641433
+      "amplitude": 0.018,
+      "phase": 181.8
     },
     {
       "name": "M3",
-      "amplitude": 0.001579720305910421,
-      "phase": 254.403293007019
+      "amplitude": 0.002,
+      "phase": 254.4
     },
     {
       "name": "MU2",
-      "amplitude": 0.07925124108919804,
-      "phase": 205.20446881988218
+      "amplitude": 0.079,
+      "phase": 205.2
     },
     {
       "name": "MTM",
-      "amplitude": 0.0016635850055895661,
-      "phase": 136.58800151712103
+      "amplitude": 0.002,
+      "phase": 136.59
     },
     {
       "name": "NU2",
-      "amplitude": 0.03576401679771131,
-      "phase": 69.66184110145832
+      "amplitude": 0.036,
+      "phase": 69.66
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.022728113762306393,
-      "phase": 142.15498442252897
+      "amplitude": 0.023,
+      "phase": 142.15
     },
     {
       "name": "MN4",
-      "amplitude": 0.025283488396825236,
-      "phase": 149.3651374297704
+      "amplitude": 0.025,
+      "phase": 149.37
     },
     {
       "name": "MS4",
-      "amplitude": 0.0406394540421888,
-      "phase": 255.57704366698016
+      "amplitude": 0.041,
+      "phase": 255.58
     },
     {
       "name": "N4",
-      "amplitude": 0.004549278561451078,
-      "phase": 139.9368147322832
+      "amplitude": 0.005,
+      "phase": 139.94
     },
     {
       "name": "M6",
-      "amplitude": 0.0165637568767427,
-      "phase": 196.05923588372426
+      "amplitude": 0.017,
+      "phase": 196.06
     },
     {
       "name": "M8",
-      "amplitude": 0.004159486183319868,
-      "phase": 180.69101950473748
+      "amplitude": 0.004,
+      "phase": 180.69
     },
     {
       "name": "S4",
-      "amplitude": 0.0033502814718134404,
-      "phase": 79.44835942838512
+      "amplitude": 0.003,
+      "phase": 79.45
     },
     {
       "name": "OO1",
-      "amplitude": 0.0013908871024751112,
-      "phase": 1.3043317848854485
+      "amplitude": 0.001,
+      "phase": 1.3
     },
     {
       "name": "S3",
-      "amplitude": 0.0001578923988775792,
-      "phase": 331.3590730922524
+      "amplitude": 0,
+      "phase": 331.36
     },
     {
       "name": "MA2",
-      "amplitude": 0.07431855044012149,
-      "phase": 10.638726487322344
+      "amplitude": 0.074,
+      "phase": 10.64
     },
     {
       "name": "MB2",
-      "amplitude": 0.07374226696335662,
-      "phase": 255.11010018454562
+      "amplitude": 0.074,
+      "phase": 255.11
     },
     {
       "name": "T3",
-      "amplitude": 0.00006898636580992183,
-      "phase": 357.26910317255266
+      "amplitude": 0,
+      "phase": 357.27
     },
     {
       "name": "R3",
-      "amplitude": 0.0025490531359868163,
-      "phase": 193.984477330636
+      "amplitude": 0.003,
+      "phase": 193.98
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0035293890808489187,
-      "phase": 295.9151282244911
+      "amplitude": 0.004,
+      "phase": 295.92
     },
     {
       "name": "SGM",
-      "amplitude": 0.007119429508659434,
-      "phase": 117.1601814168738
+      "amplitude": 0.007,
+      "phase": 117.16
     },
     {
       "name": "3L2",
-      "amplitude": 0.0022924400711239507,
-      "phase": 0.6014973396267465
+      "amplitude": 0.002,
+      "phase": 0.6
     },
     {
       "name": "3N2",
-      "amplitude": 0.016258041939761943,
-      "phase": 229.9448081267596
+      "amplitude": 0.016,
+      "phase": 229.94
     },
     {
       "name": "2SM2",
-      "amplitude": 0.014032750505819426,
-      "phase": 77.26821917072357
+      "amplitude": 0.014,
+      "phase": 77.27
     },
     {
       "name": "2MS6",
-      "amplitude": 0.014072459254120567,
-      "phase": 265.21994262335494
+      "amplitude": 0.014,
+      "phase": 265.22
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004445297852430635,
-      "phase": 161.8556462039918
+      "amplitude": 0.004,
+      "phase": 161.86
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005030027016072409,
-      "phase": 18.614011379076373
+      "amplitude": 0.005,
+      "phase": 18.61
     }
   ],
   "epoch": {

--- a/data/ticon/borkumfischerbalje-9340020-deu-wsv.json
+++ b/data/ticon/borkumfischerbalje-9340020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.1029043972282435,
-      "phase": 275.8904560110661
+      "amplitude": 1.103,
+      "phase": 275.89
     },
     {
       "name": "N2",
-      "amplitude": 0.17816189255372136,
-      "phase": 251.21802671420176
+      "amplitude": 0.178,
+      "phase": 251.22
     },
     {
       "name": "S2",
-      "amplitude": 0.2848180752865259,
-      "phase": 341.58902971868025
+      "amplitude": 0.285,
+      "phase": 341.59
     },
     {
       "name": "K2",
-      "amplitude": 0.08585149536723546,
-      "phase": 339.52539318164787
+      "amplitude": 0.086,
+      "phase": 339.53
     },
     {
       "name": "2N2",
-      "amplitude": 0.02024303348180957,
-      "phase": 231.07226734444583
+      "amplitude": 0.02,
+      "phase": 231.07
     },
     {
       "name": "S1",
-      "amplitude": 0.007746580752503641,
-      "phase": 356.0488101841082
+      "amplitude": 0.008,
+      "phase": 356.05
     },
     {
       "name": "K1",
-      "amplitude": 0.06878050920163259,
-      "phase": 9.659716652735938
+      "amplitude": 0.069,
+      "phase": 9.66
     },
     {
       "name": "P1",
-      "amplitude": 0.027312196761057256,
-      "phase": 15.374876108417823
+      "amplitude": 0.027,
+      "phase": 15.37
     },
     {
       "name": "O1",
-      "amplitude": 0.08741812983931792,
-      "phase": 218.164217961822
+      "amplitude": 0.087,
+      "phase": 218.16
     },
     {
       "name": "Q1",
-      "amplitude": 0.028456462287623236,
-      "phase": 159.4205547157551
+      "amplitude": 0.028,
+      "phase": 159.42
     },
     {
       "name": "M1",
-      "amplitude": 0.001537501867603963,
-      "phase": 67.82975043620922
+      "amplitude": 0.002,
+      "phase": 67.83
     },
     {
       "name": "M4",
-      "amplitude": 0.07275852885075389,
-      "phase": 11.322044079425268
+      "amplitude": 0.073,
+      "phase": 11.32
     },
     {
       "name": "MM",
-      "amplitude": 0.02087297469562183,
-      "phase": 177.4785441069447
+      "amplitude": 0.021,
+      "phase": 177.48
     },
     {
       "name": "MF",
-      "amplitude": 0.009982113866740557,
-      "phase": 178.27124970488012
+      "amplitude": 0.01,
+      "phase": 178.27
     },
     {
       "name": "SA",
-      "amplitude": 0.09856869093435458,
-      "phase": 225.45207017016088
+      "amplitude": 0.099,
+      "phase": 225.45
     },
     {
       "name": "SSA",
-      "amplitude": 0.032727487129169085,
-      "phase": 204.74250908670732
+      "amplitude": 0.033,
+      "phase": 204.74
     },
     {
       "name": "T2",
-      "amplitude": 0.015857516994713106,
-      "phase": 315.0226862564545
+      "amplitude": 0.016,
+      "phase": 315.02
     },
     {
       "name": "J1",
-      "amplitude": 0.0012854202017912857,
-      "phase": 112.06253960957855
+      "amplitude": 0.001,
+      "phase": 112.06
     },
     {
       "name": "L2",
-      "amplitude": 0.08454204035617124,
-      "phase": 292.55291266346586
+      "amplitude": 0.085,
+      "phase": 292.55
     },
     {
       "name": "R2",
-      "amplitude": 0.00098192689732548,
-      "phase": 285.6505730709134
+      "amplitude": 0.001,
+      "phase": 285.65
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005648774492225833,
-      "phase": 107.0598786061849
+      "amplitude": 0.006,
+      "phase": 107.06
     },
     {
       "name": "MSF",
-      "amplitude": 0.0025450633722279275,
-      "phase": 43.53600504807952
+      "amplitude": 0.003,
+      "phase": 43.54
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00793476669513924,
-      "phase": 67.18847645716278
+      "amplitude": 0.008,
+      "phase": 67.19
     },
     {
       "name": "EP2",
-      "amplitude": 0.023563796959379494,
-      "phase": 346.8072009609938
+      "amplitude": 0.024,
+      "phase": 346.81
     },
     {
       "name": "M3",
-      "amplitude": 0.003254841271483218,
-      "phase": 257.33256548633256
+      "amplitude": 0.003,
+      "phase": 257.33
     },
     {
       "name": "MU2",
-      "amplitude": 0.10429084524659799,
-      "phase": 7.122171679207838
+      "amplitude": 0.104,
+      "phase": 7.12
     },
     {
       "name": "MTM",
-      "amplitude": 0.004679163313450436,
-      "phase": 250.90092898853646
+      "amplitude": 0.005,
+      "phase": 250.9
     },
     {
       "name": "NU2",
-      "amplitude": 0.06306157817180151,
-      "phase": 237.07613978085834
+      "amplitude": 0.063,
+      "phase": 237.08
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03955908212622745,
-      "phase": 286.5200017687041
+      "amplitude": 0.04,
+      "phase": 286.52
     },
     {
       "name": "MN4",
-      "amplitude": 0.023142824138983914,
-      "phase": 347.2661269390054
+      "amplitude": 0.023,
+      "phase": 347.27
     },
     {
       "name": "MS4",
-      "amplitude": 0.05106156535095606,
-      "phase": 86.91015588586157
+      "amplitude": 0.051,
+      "phase": 86.91
     },
     {
       "name": "N4",
-      "amplitude": 0.004957771661194204,
-      "phase": 328.67081654318804
+      "amplitude": 0.005,
+      "phase": 328.67
     },
     {
       "name": "M6",
-      "amplitude": 0.0432768481198901,
-      "phase": 182.27335118133556
+      "amplitude": 0.043,
+      "phase": 182.27
     },
     {
       "name": "M8",
-      "amplitude": 0.011507907699818298,
-      "phase": 333.12569434855715
+      "amplitude": 0.012,
+      "phase": 333.13
     },
     {
       "name": "S4",
-      "amplitude": 0.005840047634500884,
-      "phase": 221.52684629448314
+      "amplitude": 0.006,
+      "phase": 221.53
     },
     {
       "name": "OO1",
-      "amplitude": 0.0025691412198337745,
-      "phase": 176.98619922173611
+      "amplitude": 0.003,
+      "phase": 176.99
     },
     {
       "name": "S3",
-      "amplitude": 0.00040861804372532894,
-      "phase": 74.45516563915669
+      "amplitude": 0,
+      "phase": 74.46
     },
     {
       "name": "MA2",
-      "amplitude": 0.037949698160415594,
-      "phase": 235.60358677595207
+      "amplitude": 0.038,
+      "phase": 235.6
     },
     {
       "name": "MB2",
-      "amplitude": 0.009047053983715756,
-      "phase": 10.646585789574488
+      "amplitude": 0.009,
+      "phase": 10.65
     },
     {
       "name": "T3",
-      "amplitude": 0.0012557166276714468,
-      "phase": 331.534635900125
+      "amplitude": 0.001,
+      "phase": 331.53
     },
     {
       "name": "R3",
-      "amplitude": 0.002657822170527518,
-      "phase": 334.3384194227391
+      "amplitude": 0.003,
+      "phase": 334.34
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005582899254592123,
-      "phase": 167.33643869037587
+      "amplitude": 0.006,
+      "phase": 167.34
     },
     {
       "name": "SGM",
-      "amplitude": 0.002528403132569941,
-      "phase": 41.00392461750903
+      "amplitude": 0.003,
+      "phase": 41
     },
     {
       "name": "3L2",
-      "amplitude": 0.003428972336514105,
-      "phase": 188.7127896172412
+      "amplitude": 0.003,
+      "phase": 188.71
     },
     {
       "name": "3N2",
-      "amplitude": 0.010609751603991708,
-      "phase": 79.52848555188075
+      "amplitude": 0.011,
+      "phase": 79.53
     },
     {
       "name": "2SM2",
-      "amplitude": 0.025697197280230913,
-      "phase": 202.24575344242547
+      "amplitude": 0.026,
+      "phase": 202.25
     },
     {
       "name": "2MS6",
-      "amplitude": 0.040587741281817614,
-      "phase": 243.8121402017112
+      "amplitude": 0.041,
+      "phase": 243.81
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005097608186964161,
-      "phase": 208.76407327077402
+      "amplitude": 0.005,
+      "phase": 208.76
     },
     {
       "name": "2MO5",
-      "amplitude": 0.002353777684978605,
-      "phase": 81.84541907404099
+      "amplitude": 0.002,
+      "phase": 81.85
     }
   ],
   "epoch": {

--- a/data/ticon/borkumsdstrand-9340030-deu-wsv.json
+++ b/data/ticon/borkumsdstrand-9340030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.0633289781496391,
-      "phase": 267.6221258714846
+      "amplitude": 1.063,
+      "phase": 267.62
     },
     {
       "name": "N2",
-      "amplitude": 0.17264548449484013,
-      "phase": 243.03986313141195
+      "amplitude": 0.173,
+      "phase": 243.04
     },
     {
       "name": "S2",
-      "amplitude": 0.2768177819032907,
-      "phase": 332.2385897887764
+      "amplitude": 0.277,
+      "phase": 332.24
     },
     {
       "name": "K2",
-      "amplitude": 0.08344154676766748,
-      "phase": 330.0936260995781
+      "amplitude": 0.083,
+      "phase": 330.09
     },
     {
       "name": "2N2",
-      "amplitude": 0.0198744052885549,
-      "phase": 222.9612000727464
+      "amplitude": 0.02,
+      "phase": 222.96
     },
     {
       "name": "S1",
-      "amplitude": 0.008173463968393817,
-      "phase": 355.4532229643852
+      "amplitude": 0.008,
+      "phase": 355.45
     },
     {
       "name": "K1",
-      "amplitude": 0.07071633448572995,
-      "phase": 5.70687772167031
+      "amplitude": 0.071,
+      "phase": 5.71
     },
     {
       "name": "P1",
-      "amplitude": 0.02768624813185295,
-      "phase": 11.209356074836705
+      "amplitude": 0.028,
+      "phase": 11.21
     },
     {
       "name": "O1",
-      "amplitude": 0.0894943294497101,
-      "phase": 214.57015958715547
+      "amplitude": 0.089,
+      "phase": 214.57
     },
     {
       "name": "Q1",
-      "amplitude": 0.029297235192714013,
-      "phase": 155.76870912706886
+      "amplitude": 0.029,
+      "phase": 155.77
     },
     {
       "name": "M1",
-      "amplitude": 0.0016385517216825059,
-      "phase": 58.65103132988702
+      "amplitude": 0.002,
+      "phase": 58.65
     },
     {
       "name": "M4",
-      "amplitude": 0.07341822979907812,
-      "phase": 0.5692704342669117
+      "amplitude": 0.073,
+      "phase": 0.57
     },
     {
       "name": "MM",
-      "amplitude": 0.02014078711572259,
-      "phase": 181.2469859100056
+      "amplitude": 0.02,
+      "phase": 181.25
     },
     {
       "name": "MF",
-      "amplitude": 0.00893438138118724,
-      "phase": 187.7506598354561
+      "amplitude": 0.009,
+      "phase": 187.75
     },
     {
       "name": "SA",
-      "amplitude": 0.09635067924636515,
-      "phase": 225.37273841769576
+      "amplitude": 0.096,
+      "phase": 225.37
     },
     {
       "name": "SSA",
-      "amplitude": 0.03359260534167709,
-      "phase": 207.06620058437238
+      "amplitude": 0.034,
+      "phase": 207.07
     },
     {
       "name": "T2",
-      "amplitude": 0.015414177292570492,
-      "phase": 306.086471787193
+      "amplitude": 0.015,
+      "phase": 306.09
     },
     {
       "name": "J1",
-      "amplitude": 0.0013937197156683762,
-      "phase": 100.21090918333027
+      "amplitude": 0.001,
+      "phase": 100.21
     },
     {
       "name": "L2",
-      "amplitude": 0.07981519038076411,
-      "phase": 284.4085280226374
+      "amplitude": 0.08,
+      "phase": 284.41
     },
     {
       "name": "R2",
-      "amplitude": 0.0018526684053949299,
-      "phase": 286.69225742707687
+      "amplitude": 0.002,
+      "phase": 286.69
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005277345050344629,
-      "phase": 103.29746755181361
+      "amplitude": 0.005,
+      "phase": 103.3
     },
     {
       "name": "MSF",
-      "amplitude": 0.0029790727637077916,
-      "phase": 41.4671367788639
+      "amplitude": 0.003,
+      "phase": 41.47
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007953748558903092,
-      "phase": 49.70801864217674
+      "amplitude": 0.008,
+      "phase": 49.71
     },
     {
       "name": "EP2",
-      "amplitude": 0.02222619531905179,
-      "phase": 338.2625249860915
+      "amplitude": 0.022,
+      "phase": 338.26
     },
     {
       "name": "M3",
-      "amplitude": 0.0033452576855559956,
-      "phase": 237.3021216295288
+      "amplitude": 0.003,
+      "phase": 237.3
     },
     {
       "name": "MU2",
-      "amplitude": 0.09679876163389689,
-      "phase": 0.6708688655263018
+      "amplitude": 0.097,
+      "phase": 0.67
     },
     {
       "name": "MTM",
-      "amplitude": 0.003948295150904402,
-      "phase": 231.10449477848593
+      "amplitude": 0.004,
+      "phase": 231.1
     },
     {
       "name": "NU2",
-      "amplitude": 0.06043590906254334,
-      "phase": 230.14626502947988
+      "amplitude": 0.06,
+      "phase": 230.15
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.037405129675882554,
-      "phase": 277.5839786533682
+      "amplitude": 0.037,
+      "phase": 277.58
     },
     {
       "name": "MN4",
-      "amplitude": 0.02317343860185046,
-      "phase": 337.4753243182089
+      "amplitude": 0.023,
+      "phase": 337.48
     },
     {
       "name": "MS4",
-      "amplitude": 0.05242205712593489,
-      "phase": 73.33590825869857
+      "amplitude": 0.052,
+      "phase": 73.34
     },
     {
       "name": "N4",
-      "amplitude": 0.004851162919660023,
-      "phase": 322.810797442308
+      "amplitude": 0.005,
+      "phase": 322.81
     },
     {
       "name": "M6",
-      "amplitude": 0.05103063658040358,
-      "phase": 169.32973433906523
+      "amplitude": 0.051,
+      "phase": 169.33
     },
     {
       "name": "M8",
-      "amplitude": 0.01493639453933509,
-      "phase": 310.92796679387646
+      "amplitude": 0.015,
+      "phase": 310.93
     },
     {
       "name": "S4",
-      "amplitude": 0.005960122174455149,
-      "phase": 204.53706017340286
+      "amplitude": 0.006,
+      "phase": 204.54
     },
     {
       "name": "OO1",
-      "amplitude": 0.0025957643105907068,
-      "phase": 172.63884059766121
+      "amplitude": 0.003,
+      "phase": 172.64
     },
     {
       "name": "S3",
-      "amplitude": 0.0006305334761285534,
-      "phase": 40.90783633758355
+      "amplitude": 0.001,
+      "phase": 40.91
     },
     {
       "name": "MA2",
-      "amplitude": 0.03567814677097748,
-      "phase": 230.17012347067853
+      "amplitude": 0.036,
+      "phase": 230.17
     },
     {
       "name": "MB2",
-      "amplitude": 0.011262441303626724,
-      "phase": 4.844141117083154
+      "amplitude": 0.011,
+      "phase": 4.84
     },
     {
       "name": "T3",
-      "amplitude": 0.001309118054269159,
-      "phase": 313.4826865479407
+      "amplitude": 0.001,
+      "phase": 313.48
     },
     {
       "name": "R3",
-      "amplitude": 0.002056868860118368,
-      "phase": 313.929683779769
+      "amplitude": 0.002,
+      "phase": 313.93
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0053895212457851895,
-      "phase": 161.73498485877576
+      "amplitude": 0.005,
+      "phase": 161.73
     },
     {
       "name": "SGM",
-      "amplitude": 0.002299396244270895,
-      "phase": 35.55132998841077
+      "amplitude": 0.002,
+      "phase": 35.55
     },
     {
       "name": "3L2",
-      "amplitude": 0.0035191810081603996,
-      "phase": 179.25838380234882
+      "amplitude": 0.004,
+      "phase": 179.26
     },
     {
       "name": "3N2",
-      "amplitude": 0.01118992000732345,
-      "phase": 74.8390229498674
+      "amplitude": 0.011,
+      "phase": 74.84
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02485241816458821,
-      "phase": 192.14273757701605
+      "amplitude": 0.025,
+      "phase": 192.14
     },
     {
       "name": "2MS6",
-      "amplitude": 0.047657495133946466,
-      "phase": 230.617879803185
+      "amplitude": 0.048,
+      "phase": 230.62
     },
     {
       "name": "2MK5",
-      "amplitude": 0.003793356010221927,
-      "phase": 207.8064123236276
+      "amplitude": 0.004,
+      "phase": 207.81
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0031741604766273566,
-      "phase": 114.97955019257051
+      "amplitude": 0.003,
+      "phase": 114.98
     }
   ],
   "epoch": {

--- a/data/ticon/brake-4970020-deu-wsv.json
+++ b/data/ticon/brake-4970020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.7229708942262947,
-      "phase": 8.901525990792265
+      "amplitude": 1.723,
+      "phase": 8.9
     },
     {
       "name": "N2",
-      "amplitude": 0.26490789539685716,
-      "phase": 345.0779865664957
+      "amplitude": 0.265,
+      "phase": 345.08
     },
     {
       "name": "S2",
-      "amplitude": 0.43114459938237976,
-      "phase": 87.18327968066234
+      "amplitude": 0.431,
+      "phase": 87.18
     },
     {
       "name": "K2",
-      "amplitude": 0.1272748163314246,
-      "phase": 84.7575675884716
+      "amplitude": 0.127,
+      "phase": 84.76
     },
     {
       "name": "2N2",
-      "amplitude": 0.028024231786950408,
-      "phase": 324.5316205310098
+      "amplitude": 0.028,
+      "phase": 324.53
     },
     {
       "name": "S1",
-      "amplitude": 0.016573621550486056,
-      "phase": 70.17111790549131
+      "amplitude": 0.017,
+      "phase": 70.17
     },
     {
       "name": "K1",
-      "amplitude": 0.07034127585197204,
-      "phase": 57.303967925304846
+      "amplitude": 0.07,
+      "phase": 57.3
     },
     {
       "name": "P1",
-      "amplitude": 0.03128943113471797,
-      "phase": 62.55926941868455
+      "amplitude": 0.031,
+      "phase": 62.56
     },
     {
       "name": "O1",
-      "amplitude": 0.09033629983576347,
-      "phase": 264.3310491914141
+      "amplitude": 0.09,
+      "phase": 264.33
     },
     {
       "name": "Q1",
-      "amplitude": 0.026007942083489832,
-      "phase": 204.27710324667382
+      "amplitude": 0.026,
+      "phase": 204.28
     },
     {
       "name": "M1",
-      "amplitude": 0.002328124446565396,
-      "phase": 123.07355462033354
+      "amplitude": 0.002,
+      "phase": 123.07
     },
     {
       "name": "M4",
-      "amplitude": 0.10921737303136304,
-      "phase": 208.79251062455307
+      "amplitude": 0.109,
+      "phase": 208.79
     },
     {
       "name": "MM",
-      "amplitude": 0.013031032373891657,
-      "phase": 132.92248298365018
+      "amplitude": 0.013,
+      "phase": 132.92
     },
     {
       "name": "MF",
-      "amplitude": 0.01135824185094953,
-      "phase": 111.71765313524747
+      "amplitude": 0.011,
+      "phase": 111.72
     },
     {
       "name": "SA",
-      "amplitude": 0.06320423243009758,
-      "phase": 233.4576928920731
+      "amplitude": 0.063,
+      "phase": 233.46
     },
     {
       "name": "SSA",
-      "amplitude": 0.043412248207414975,
-      "phase": 220.90174642403392
+      "amplitude": 0.043,
+      "phase": 220.9
     },
     {
       "name": "T2",
-      "amplitude": 0.02654978724642135,
-      "phase": 64.18964685064753
+      "amplitude": 0.027,
+      "phase": 64.19
     },
     {
       "name": "J1",
-      "amplitude": 0.003640468375940716,
-      "phase": 184.36186208435862
+      "amplitude": 0.004,
+      "phase": 184.36
     },
     {
       "name": "L2",
-      "amplitude": 0.1539236053416579,
-      "phase": 23.379215335318804
+      "amplitude": 0.154,
+      "phase": 23.38
     },
     {
       "name": "R2",
-      "amplitude": 0.0009598435854374562,
-      "phase": 48.58306843990249
+      "amplitude": 0.001,
+      "phase": 48.58
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00545604420434663,
-      "phase": 147.09570839758544
+      "amplitude": 0.005,
+      "phase": 147.1
     },
     {
       "name": "MSF",
-      "amplitude": 0.044227786412193555,
-      "phase": 64.25755805569173
+      "amplitude": 0.044,
+      "phase": 64.26
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008457777403232407,
-      "phase": 42.59660355558992
+      "amplitude": 0.008,
+      "phase": 42.6
     },
     {
       "name": "EP2",
-      "amplitude": 0.04681707318790861,
-      "phase": 67.11928887498141
+      "amplitude": 0.047,
+      "phase": 67.12
     },
     {
       "name": "M3",
-      "amplitude": 0.00414691621644215,
-      "phase": 78.85925987199516
+      "amplitude": 0.004,
+      "phase": 78.86
     },
     {
       "name": "MU2",
-      "amplitude": 0.22431569861435502,
-      "phase": 90.3915194511489
+      "amplitude": 0.224,
+      "phase": 90.39
     },
     {
       "name": "MTM",
-      "amplitude": 0.0025751960754806023,
-      "phase": 236.1170371949969
+      "amplitude": 0.003,
+      "phase": 236.12
     },
     {
       "name": "NU2",
-      "amplitude": 0.11096466916387997,
-      "phase": 321.3902558663933
+      "amplitude": 0.111,
+      "phase": 321.39
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07244792967324555,
-      "phase": 22.59370703200443
+      "amplitude": 0.072,
+      "phase": 22.59
     },
     {
       "name": "MN4",
-      "amplitude": 0.03318613645726157,
-      "phase": 187.38600957339943
+      "amplitude": 0.033,
+      "phase": 187.39
     },
     {
       "name": "MS4",
-      "amplitude": 0.07940170003389972,
-      "phase": 291.0822969346383
+      "amplitude": 0.079,
+      "phase": 291.08
     },
     {
       "name": "N4",
-      "amplitude": 0.006767371497478339,
-      "phase": 168.55438819470692
+      "amplitude": 0.007,
+      "phase": 168.55
     },
     {
       "name": "M6",
-      "amplitude": 0.08226057718303703,
-      "phase": 76.0347260871531
+      "amplitude": 0.082,
+      "phase": 76.03
     },
     {
       "name": "M8",
-      "amplitude": 0.020513140114536955,
-      "phase": 343.67194888276254
+      "amplitude": 0.021,
+      "phase": 343.67
     },
     {
       "name": "S4",
-      "amplitude": 0.011085180434998851,
-      "phase": 78.64869658652799
+      "amplitude": 0.011,
+      "phase": 78.65
     },
     {
       "name": "OO1",
-      "amplitude": 0.0026711684217405104,
-      "phase": 213.435727865706
+      "amplitude": 0.003,
+      "phase": 213.44
     },
     {
       "name": "S3",
-      "amplitude": 0.0006351792364125063,
-      "phase": 306.83132117421917
+      "amplitude": 0.001,
+      "phase": 306.83
     },
     {
       "name": "MA2",
-      "amplitude": 0.05290358802410879,
-      "phase": 338.2674984260676
+      "amplitude": 0.053,
+      "phase": 338.27
     },
     {
       "name": "MB2",
-      "amplitude": 0.012104398447984123,
-      "phase": 101.75886160163793
+      "amplitude": 0.012,
+      "phase": 101.76
     },
     {
       "name": "T3",
-      "amplitude": 0.00024290441622574845,
-      "phase": 8.878015376088229
+      "amplitude": 0,
+      "phase": 8.88
     },
     {
       "name": "R3",
-      "amplitude": 0.004207525683395831,
-      "phase": 75.16030573374849
+      "amplitude": 0.004,
+      "phase": 75.16
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005655111457831103,
-      "phase": 209.6974299090019
+      "amplitude": 0.006,
+      "phase": 209.7
     },
     {
       "name": "SGM",
-      "amplitude": 0.004199117862714932,
-      "phase": 36.88802212710573
+      "amplitude": 0.004,
+      "phase": 36.89
     },
     {
       "name": "3L2",
-      "amplitude": 0.003935475797563937,
-      "phase": 286.5400418043246
+      "amplitude": 0.004,
+      "phase": 286.54
     },
     {
       "name": "3N2",
-      "amplitude": 0.024028962115854414,
-      "phase": 163.02990460675198
+      "amplitude": 0.024,
+      "phase": 163.03
     },
     {
       "name": "2SM2",
-      "amplitude": 0.046865827517355116,
-      "phase": 308.4898565904335
+      "amplitude": 0.047,
+      "phase": 308.49
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08790204885405654,
-      "phase": 147.94978703564368
+      "amplitude": 0.088,
+      "phase": 147.95
     },
     {
       "name": "2MK5",
-      "amplitude": 0.010284968495455071,
-      "phase": 80.61063205050255
+      "amplitude": 0.01,
+      "phase": 80.61
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006862553221569003,
-      "phase": 273.18932611319667
+      "amplitude": 0.007,
+      "phase": 273.19
     }
   ],
   "epoch": {

--- a/data/ticon/breitenberg-5970038-deu-wsv.json
+++ b/data/ticon/breitenberg-5970038-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.7695426825052685,
-      "phase": 106.7369039044541
+      "amplitude": 0.77,
+      "phase": 106.74
     },
     {
       "name": "N2",
-      "amplitude": 0.11216723267136199,
-      "phase": 81.04717830815639
+      "amplitude": 0.112,
+      "phase": 81.05
     },
     {
       "name": "S2",
-      "amplitude": 0.16640081240503807,
-      "phase": 183.0493491961245
+      "amplitude": 0.166,
+      "phase": 183.05
     },
     {
       "name": "K2",
-      "amplitude": 0.05040149912598498,
-      "phase": 183.98610239051538
+      "amplitude": 0.05,
+      "phase": 183.99
     },
     {
       "name": "2N2",
-      "amplitude": 0.010410169882178334,
-      "phase": 60.44439972220448
+      "amplitude": 0.01,
+      "phase": 60.44
     },
     {
       "name": "S1",
-      "amplitude": 0.011791405228102885,
-      "phase": 111.97140524653918
+      "amplitude": 0.012,
+      "phase": 111.97
     },
     {
       "name": "K1",
-      "amplitude": 0.05001567121240357,
-      "phase": 131.9928664715436
+      "amplitude": 0.05,
+      "phase": 131.99
     },
     {
       "name": "P1",
-      "amplitude": 0.018630220374602054,
-      "phase": 125.80490932405593
+      "amplitude": 0.019,
+      "phase": 125.8
     },
     {
       "name": "O1",
-      "amplitude": 0.06185111420561444,
-      "phase": 333.02832366142565
+      "amplitude": 0.062,
+      "phase": 333.03
     },
     {
       "name": "Q1",
-      "amplitude": 0.016765528012097707,
-      "phase": 271.712493845862
+      "amplitude": 0.017,
+      "phase": 271.71
     },
     {
       "name": "M1",
-      "amplitude": 0.0014699758406716387,
-      "phase": 179.6986425607647
+      "amplitude": 0.001,
+      "phase": 179.7
     },
     {
       "name": "M4",
-      "amplitude": 0.11846108796234037,
-      "phase": 129.1280489376618
+      "amplitude": 0.118,
+      "phase": 129.13
     },
     {
       "name": "MM",
-      "amplitude": 0.00992670713733773,
-      "phase": 111.56759095503753
+      "amplitude": 0.01,
+      "phase": 111.57
     },
     {
       "name": "MF",
-      "amplitude": 0.018288424360626224,
-      "phase": 98.97085482407795
+      "amplitude": 0.018,
+      "phase": 98.97
     },
     {
       "name": "SA",
-      "amplitude": 0.1347635673752058,
-      "phase": 285.77896537950454
+      "amplitude": 0.135,
+      "phase": 285.78
     },
     {
       "name": "SSA",
-      "amplitude": 0.05658239316336368,
-      "phase": 233.85390242880067
+      "amplitude": 0.057,
+      "phase": 233.85
     },
     {
       "name": "T2",
-      "amplitude": 0.0026692859403260136,
-      "phase": 193.37804150445166
+      "amplitude": 0.003,
+      "phase": 193.38
     },
     {
       "name": "J1",
-      "amplitude": 0.005036843415244536,
-      "phase": 261.66566412316104
+      "amplitude": 0.005,
+      "phase": 261.67
     },
     {
       "name": "L2",
-      "amplitude": 0.07315240989411935,
-      "phase": 125.9632818316997
+      "amplitude": 0.073,
+      "phase": 125.96
     },
     {
       "name": "R2",
-      "amplitude": 0.009811126654014775,
-      "phase": 214.86806838521588
+      "amplitude": 0.01,
+      "phase": 214.87
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0032294565584505015,
-      "phase": 207.60854165909512
+      "amplitude": 0.003,
+      "phase": 207.61
     },
     {
       "name": "MSF",
-      "amplitude": 0.07724865344739364,
-      "phase": 67.25697225831112
+      "amplitude": 0.077,
+      "phase": 67.26
     },
     {
       "name": "MSQM",
-      "amplitude": 0.005284269014749127,
-      "phase": 14.090418481085464
+      "amplitude": 0.005,
+      "phase": 14.09
     },
     {
       "name": "EP2",
-      "amplitude": 0.023315592289841425,
-      "phase": 173.15800131797755
+      "amplitude": 0.023,
+      "phase": 173.16
     },
     {
       "name": "M3",
-      "amplitude": 0.002359096074330536,
-      "phase": 184.67500716183932
+      "amplitude": 0.002,
+      "phase": 184.68
     },
     {
       "name": "MU2",
-      "amplitude": 0.1116196632317131,
-      "phase": 200.39643894235255
+      "amplitude": 0.112,
+      "phase": 200.4
     },
     {
       "name": "MTM",
-      "amplitude": 0.003645290259262344,
-      "phase": 182.77668192353303
+      "amplitude": 0.004,
+      "phase": 182.78
     },
     {
       "name": "NU2",
-      "amplitude": 0.05436554743347551,
-      "phase": 65.9259317990282
+      "amplitude": 0.054,
+      "phase": 65.93
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03284255758916026,
-      "phase": 131.28499383825954
+      "amplitude": 0.033,
+      "phase": 131.28
     },
     {
       "name": "MN4",
-      "amplitude": 0.0377972544939105,
-      "phase": 102.38208879798447
+      "amplitude": 0.038,
+      "phase": 102.38
     },
     {
       "name": "MS4",
-      "amplitude": 0.05846215034162383,
-      "phase": 202.2690634169532
+      "amplitude": 0.058,
+      "phase": 202.27
     },
     {
       "name": "N4",
-      "amplitude": 0.007143394378894538,
-      "phase": 86.22129429318255
+      "amplitude": 0.007,
+      "phase": 86.22
     },
     {
       "name": "M6",
-      "amplitude": 0.018897479065648704,
-      "phase": 18.78752793375338
+      "amplitude": 0.019,
+      "phase": 18.79
     },
     {
       "name": "M8",
-      "amplitude": 0.015154286610899188,
-      "phase": 24.2177191140467
+      "amplitude": 0.015,
+      "phase": 24.22
     },
     {
       "name": "S4",
-      "amplitude": 0.0031955124484122385,
-      "phase": 350.51957984010113
+      "amplitude": 0.003,
+      "phase": 350.52
     },
     {
       "name": "OO1",
-      "amplitude": 0.0019433924157392834,
-      "phase": 268.1141498055143
+      "amplitude": 0.002,
+      "phase": 268.11
     },
     {
       "name": "S3",
-      "amplitude": 0.0007303678272721532,
-      "phase": 259.84997750254945
+      "amplitude": 0.001,
+      "phase": 259.85
     },
     {
       "name": "MA2",
-      "amplitude": 0.0334973685325367,
-      "phase": 4.186605482402399
+      "amplitude": 0.033,
+      "phase": 4.19
     },
     {
       "name": "MB2",
-      "amplitude": 0.0446480778620271,
-      "phase": 226.07618700199902
+      "amplitude": 0.045,
+      "phase": 226.08
     },
     {
       "name": "T3",
-      "amplitude": 0.0015349106344248842,
-      "phase": 182.60360655437088
+      "amplitude": 0.002,
+      "phase": 182.6
     },
     {
       "name": "R3",
-      "amplitude": 0.0029738088943373777,
-      "phase": 203.90310998958876
+      "amplitude": 0.003,
+      "phase": 203.9
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004419842276655576,
-      "phase": 277.8291532967187
+      "amplitude": 0.004,
+      "phase": 277.83
     },
     {
       "name": "SGM",
-      "amplitude": 0.004972219554281979,
-      "phase": 107.12399616859449
+      "amplitude": 0.005,
+      "phase": 107.12
     },
     {
       "name": "3L2",
-      "amplitude": 0.0015128762715079843,
-      "phase": 66.58242360292792
+      "amplitude": 0.002,
+      "phase": 66.58
     },
     {
       "name": "3N2",
-      "amplitude": 0.015540240824903077,
-      "phase": 231.53736426305673
+      "amplitude": 0.016,
+      "phase": 231.54
     },
     {
       "name": "2SM2",
-      "amplitude": 0.018770242059819302,
-      "phase": 54.63186760623228
+      "amplitude": 0.019,
+      "phase": 54.63
     },
     {
       "name": "2MS6",
-      "amplitude": 0.017350659458365662,
-      "phase": 94.80674683083396
+      "amplitude": 0.017,
+      "phase": 94.81
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0018568485322127018,
-      "phase": 88.75306516113699
+      "amplitude": 0.002,
+      "phase": 88.75
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0033918233808679517,
-      "phase": 326.30439594861224
+      "amplitude": 0.003,
+      "phase": 326.3
     }
   ],
   "epoch": {

--- a/data/ticon/bremervrdeuw-5980010-deu-wsv.json
+++ b/data/ticon/bremervrdeuw-5980010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.3337604902087075,
-      "phase": 151.47369657830916
+      "amplitude": 0.334,
+      "phase": 151.47
     },
     {
       "name": "N2",
-      "amplitude": 0.04808218567029079,
-      "phase": 123.79203394686357
+      "amplitude": 0.048,
+      "phase": 123.79
     },
     {
       "name": "S2",
-      "amplitude": 0.07389053909060013,
-      "phase": 227.04228204883438
+      "amplitude": 0.074,
+      "phase": 227.04
     },
     {
       "name": "K2",
-      "amplitude": 0.02226920015854431,
-      "phase": 229.3378032310973
+      "amplitude": 0.022,
+      "phase": 229.34
     },
     {
       "name": "2N2",
-      "amplitude": 0.004378658793344506,
-      "phase": 98.87014194428008
+      "amplitude": 0.004,
+      "phase": 98.87
     },
     {
       "name": "S1",
-      "amplitude": 0.00892624277488512,
-      "phase": 158.1068751618078
+      "amplitude": 0.009,
+      "phase": 158.11
     },
     {
       "name": "K1",
-      "amplitude": 0.029196640202605494,
-      "phase": 165.7176325494121
+      "amplitude": 0.029,
+      "phase": 165.72
     },
     {
       "name": "P1",
-      "amplitude": 0.010276733027107045,
-      "phase": 159.65734233008493
+      "amplitude": 0.01,
+      "phase": 159.66
     },
     {
       "name": "O1",
-      "amplitude": 0.03453660450259804,
-      "phase": 7.081988374639536
+      "amplitude": 0.035,
+      "phase": 7.08
     },
     {
       "name": "Q1",
-      "amplitude": 0.009399963361161284,
-      "phase": 298.2660452401252
+      "amplitude": 0.009,
+      "phase": 298.27
     },
     {
       "name": "M1",
-      "amplitude": 0.0008345675222190891,
-      "phase": 219.95967498318785
+      "amplitude": 0.001,
+      "phase": 219.96
     },
     {
       "name": "M4",
-      "amplitude": 0.06521551230215332,
-      "phase": 223.0845022629232
+      "amplitude": 0.065,
+      "phase": 223.08
     },
     {
       "name": "MM",
-      "amplitude": 0.007137651335356164,
-      "phase": 81.21164486121069
+      "amplitude": 0.007,
+      "phase": 81.21
     },
     {
       "name": "MF",
-      "amplitude": 0.014841842126285401,
-      "phase": 111.68530256830252
+      "amplitude": 0.015,
+      "phase": 111.69
     },
     {
       "name": "SA",
-      "amplitude": 0.2013214703988511,
-      "phase": 294.1857961531664
+      "amplitude": 0.201,
+      "phase": 294.19
     },
     {
       "name": "SSA",
-      "amplitude": 0.07131833663851884,
-      "phase": 248.4406554437709
+      "amplitude": 0.071,
+      "phase": 248.44
     },
     {
       "name": "T2",
-      "amplitude": 0.00579533416686012,
-      "phase": 345.8765735690362
+      "amplitude": 0.006,
+      "phase": 345.88
     },
     {
       "name": "J1",
-      "amplitude": 0.0033515601532553073,
-      "phase": 289.5988413173878
+      "amplitude": 0.003,
+      "phase": 289.6
     },
     {
       "name": "L2",
-      "amplitude": 0.03141397081281974,
-      "phase": 168.82156176593514
+      "amplitude": 0.031,
+      "phase": 168.82
     },
     {
       "name": "R2",
-      "amplitude": 0.010268236699462736,
-      "phase": 253.28236232350145
+      "amplitude": 0.01,
+      "phase": 253.28
     },
     {
       "name": "2Q1",
-      "amplitude": 0.001988100273281258,
-      "phase": 244.69616858828306
+      "amplitude": 0.002,
+      "phase": 244.7
     },
     {
       "name": "MSF",
-      "amplitude": 0.06722840988504104,
-      "phase": 70.18880480396393
+      "amplitude": 0.067,
+      "phase": 70.19
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0025715703484556793,
-      "phase": 34.04281098241739
+      "amplitude": 0.003,
+      "phase": 34.04
     },
     {
       "name": "EP2",
-      "amplitude": 0.009767703120679852,
-      "phase": 210.5471536463024
+      "amplitude": 0.01,
+      "phase": 210.55
     },
     {
       "name": "M3",
-      "amplitude": 0.0011670714025403249,
-      "phase": 254.03148907182677
+      "amplitude": 0.001,
+      "phase": 254.03
     },
     {
       "name": "MU2",
-      "amplitude": 0.04669967993735191,
-      "phase": 245.0777321830784
+      "amplitude": 0.047,
+      "phase": 245.08
     },
     {
       "name": "MTM",
-      "amplitude": 0.005485784366787569,
-      "phase": 236.34778865469562
+      "amplitude": 0.005,
+      "phase": 236.35
     },
     {
       "name": "NU2",
-      "amplitude": 0.02344391843915838,
-      "phase": 108.80200771737839
+      "amplitude": 0.023,
+      "phase": 108.8
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.014692215675058592,
-      "phase": 171.9452419079139
+      "amplitude": 0.015,
+      "phase": 171.95
     },
     {
       "name": "MN4",
-      "amplitude": 0.020387639243734983,
-      "phase": 194.24724533056923
+      "amplitude": 0.02,
+      "phase": 194.25
     },
     {
       "name": "MS4",
-      "amplitude": 0.031883176100363106,
-      "phase": 296.1552665449732
+      "amplitude": 0.032,
+      "phase": 296.16
     },
     {
       "name": "N4",
-      "amplitude": 0.0038025264028849672,
-      "phase": 179.28781656955675
+      "amplitude": 0.004,
+      "phase": 179.29
     },
     {
       "name": "M6",
-      "amplitude": 0.002683346792374749,
-      "phase": 53.99863428354257
+      "amplitude": 0.003,
+      "phase": 54
     },
     {
       "name": "M8",
-      "amplitude": 0.006601991685273989,
-      "phase": 183.16506820133574
+      "amplitude": 0.007,
+      "phase": 183.17
     },
     {
       "name": "S4",
-      "amplitude": 0.0015221414678108713,
-      "phase": 89.31110003776712
+      "amplitude": 0.002,
+      "phase": 89.31
     },
     {
       "name": "OO1",
-      "amplitude": 0.0007579544029669639,
-      "phase": 311.23839642596266
+      "amplitude": 0.001,
+      "phase": 311.24
     },
     {
       "name": "S3",
-      "amplitude": 0.00029493932514318693,
-      "phase": 93.2645214497573
+      "amplitude": 0,
+      "phase": 93.26
     },
     {
       "name": "MA2",
-      "amplitude": 0.04420733196293664,
-      "phase": 17.38692449373417
+      "amplitude": 0.044,
+      "phase": 17.39
     },
     {
       "name": "MB2",
-      "amplitude": 0.04900250374162511,
-      "phase": 262.5685638268452
+      "amplitude": 0.049,
+      "phase": 262.57
     },
     {
       "name": "T3",
-      "amplitude": 0.0003874868766809177,
-      "phase": 239.84424702741626
+      "amplitude": 0,
+      "phase": 239.84
     },
     {
       "name": "R3",
-      "amplitude": 0.0016304177392655504,
-      "phase": 251.70807249922103
+      "amplitude": 0.002,
+      "phase": 251.71
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0025409139341061753,
-      "phase": 331.50320830595746
+      "amplitude": 0.003,
+      "phase": 331.5
     },
     {
       "name": "SGM",
-      "amplitude": 0.0037546960115419498,
-      "phase": 142.38820949946364
+      "amplitude": 0.004,
+      "phase": 142.39
     },
     {
       "name": "3L2",
-      "amplitude": 0.0017599350950964238,
-      "phase": 97.27051609940139
+      "amplitude": 0.002,
+      "phase": 97.27
     },
     {
       "name": "3N2",
-      "amplitude": 0.00910806628932092,
-      "phase": 268.38443664750025
+      "amplitude": 0.009,
+      "phase": 268.38
     },
     {
       "name": "2SM2",
-      "amplitude": 0.008305292437954135,
-      "phase": 93.80587853592084
+      "amplitude": 0.008,
+      "phase": 93.81
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0019400093804323162,
-      "phase": 140.31345203044623
+      "amplitude": 0.002,
+      "phase": 140.31
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0014971506218265027,
-      "phase": 210.19790049295847
+      "amplitude": 0.001,
+      "phase": 210.2
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0018961193882165114,
-      "phase": 84.00184761814523
+      "amplitude": 0.002,
+      "phase": 84
     }
   ],
   "epoch": {

--- a/data/ticon/brokdorf-5970050-deu-wsv.json
+++ b/data/ticon/brokdorf-5970050-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2344347398394337,
-      "phase": 27.877676981736215
+      "amplitude": 1.234,
+      "phase": 27.88
     },
     {
       "name": "N2",
-      "amplitude": 0.19014320860381106,
-      "phase": 1.6874238892308426
+      "amplitude": 0.19,
+      "phase": 1.69
     },
     {
       "name": "S2",
-      "amplitude": 0.29048389905843824,
-      "phase": 98.82692115533075
+      "amplitude": 0.29,
+      "phase": 98.83
     },
     {
       "name": "K2",
-      "amplitude": 0.08704847455014408,
-      "phase": 96.993284932079
+      "amplitude": 0.087,
+      "phase": 96.99
     },
     {
       "name": "2N2",
-      "amplitude": 0.020105752626340193,
-      "phase": 339.27144983367634
+      "amplitude": 0.02,
+      "phase": 339.27
     },
     {
       "name": "S1",
-      "amplitude": 0.01568435600753005,
-      "phase": 72.8735208883819
+      "amplitude": 0.016,
+      "phase": 72.87
     },
     {
       "name": "K1",
-      "amplitude": 0.07177996289236468,
-      "phase": 71.78084175930286
+      "amplitude": 0.072,
+      "phase": 71.78
     },
     {
       "name": "P1",
-      "amplitude": 0.03030953754829906,
-      "phase": 69.58811988777734
+      "amplitude": 0.03,
+      "phase": 69.59
     },
     {
       "name": "O1",
-      "amplitude": 0.09101492725242101,
-      "phase": 277.0327674118703
+      "amplitude": 0.091,
+      "phase": 277.03
     },
     {
       "name": "Q1",
-      "amplitude": 0.027119408472289778,
-      "phase": 217.51350209016772
+      "amplitude": 0.027,
+      "phase": 217.51
     },
     {
       "name": "M1",
-      "amplitude": 0.0021543305655807856,
-      "phase": 125.9600215518816
+      "amplitude": 0.002,
+      "phase": 125.96
     },
     {
       "name": "M4",
-      "amplitude": 0.12912581299488082,
-      "phase": 280.3511780556426
+      "amplitude": 0.129,
+      "phase": 280.35
     },
     {
       "name": "MM",
-      "amplitude": 0.01782481544249255,
-      "phase": 145.84419105176812
+      "amplitude": 0.018,
+      "phase": 145.84
     },
     {
       "name": "MF",
-      "amplitude": 0.013767266997402975,
-      "phase": 112.19566035874692
+      "amplitude": 0.014,
+      "phase": 112.2
     },
     {
       "name": "SA",
-      "amplitude": 0.08180406500572118,
-      "phase": 225.66506796639828
+      "amplitude": 0.082,
+      "phase": 225.67
     },
     {
       "name": "SSA",
-      "amplitude": 0.04878711929105766,
-      "phase": 215.47697225599123
+      "amplitude": 0.049,
+      "phase": 215.48
     },
     {
       "name": "T2",
-      "amplitude": 0.015264819578812679,
-      "phase": 84.43938651204485
+      "amplitude": 0.015,
+      "phase": 84.44
     },
     {
       "name": "J1",
-      "amplitude": 0.005176008991044269,
-      "phase": 201.89466334524576
+      "amplitude": 0.005,
+      "phase": 201.89
     },
     {
       "name": "L2",
-      "amplitude": 0.10652754130280623,
-      "phase": 48.848664472197356
+      "amplitude": 0.107,
+      "phase": 48.85
     },
     {
       "name": "R2",
-      "amplitude": 0.0049883615342509536,
-      "phase": 41.49053856466071
+      "amplitude": 0.005,
+      "phase": 41.49
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005869515726734698,
-      "phase": 156.6592299049703
+      "amplitude": 0.006,
+      "phase": 156.66
     },
     {
       "name": "MSF",
-      "amplitude": 0.052469758757936906,
-      "phase": 61.58785100143234
+      "amplitude": 0.052,
+      "phase": 61.59
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009458110383891138,
-      "phase": 47.95472090817509
+      "amplitude": 0.009,
+      "phase": 47.95
     },
     {
       "name": "EP2",
-      "amplitude": 0.03171072337625136,
-      "phase": 94.84019887756449
+      "amplitude": 0.032,
+      "phase": 94.84
     },
     {
       "name": "M3",
-      "amplitude": 0.002867151864801039,
-      "phase": 49.76332074820493
+      "amplitude": 0.003,
+      "phase": 49.76
     },
     {
       "name": "MU2",
-      "amplitude": 0.148852825420806,
-      "phase": 120.3833743880844
+      "amplitude": 0.149,
+      "phase": 120.38
     },
     {
       "name": "MTM",
-      "amplitude": 0.0047837536785147764,
-      "phase": 229.26660752499356
+      "amplitude": 0.005,
+      "phase": 229.27
     },
     {
       "name": "NU2",
-      "amplitude": 0.08030264446198865,
-      "phase": 347.0673199768837
+      "amplitude": 0.08,
+      "phase": 347.07
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04722680268905187,
-      "phase": 44.08187502198274
+      "amplitude": 0.047,
+      "phase": 44.08
     },
     {
       "name": "MN4",
-      "amplitude": 0.04334613653848903,
-      "phase": 256.8698030205473
+      "amplitude": 0.043,
+      "phase": 256.87
     },
     {
       "name": "MS4",
-      "amplitude": 0.07626512834659056,
-      "phase": 350.36077540292365
+      "amplitude": 0.076,
+      "phase": 350.36
     },
     {
       "name": "N4",
-      "amplitude": 0.008856082954686947,
-      "phase": 235.14380725869836
+      "amplitude": 0.009,
+      "phase": 235.14
     },
     {
       "name": "M6",
-      "amplitude": 0.07144278509433731,
-      "phase": 159.5188226917038
+      "amplitude": 0.071,
+      "phase": 159.52
     },
     {
       "name": "M8",
-      "amplitude": 0.01817104658279345,
-      "phase": 66.22106792167403
+      "amplitude": 0.018,
+      "phase": 66.22
     },
     {
       "name": "S4",
-      "amplitude": 0.007058621856727798,
-      "phase": 120.19215971310632
+      "amplitude": 0.007,
+      "phase": 120.19
     },
     {
       "name": "OO1",
-      "amplitude": 0.0029613343834725323,
-      "phase": 214.85740795056773
+      "amplitude": 0.003,
+      "phase": 214.86
     },
     {
       "name": "S3",
-      "amplitude": 0.0008100700554728809,
-      "phase": 262.33367829509643
+      "amplitude": 0.001,
+      "phase": 262.33
     },
     {
       "name": "MA2",
-      "amplitude": 0.030659241141471123,
-      "phase": 336.0647463689234
+      "amplitude": 0.031,
+      "phase": 336.06
     },
     {
       "name": "MB2",
-      "amplitude": 0.0291969271353795,
-      "phase": 70.69744563075938
+      "amplitude": 0.029,
+      "phase": 70.7
     },
     {
       "name": "T3",
-      "amplitude": 0.00021617519309175652,
-      "phase": 51.84086409074445
+      "amplitude": 0,
+      "phase": 51.84
     },
     {
       "name": "R3",
-      "amplitude": 0.0030809302718388127,
-      "phase": 79.890721425241
+      "amplitude": 0.003,
+      "phase": 79.89
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005752636742393456,
-      "phase": 219.73697174426252
+      "amplitude": 0.006,
+      "phase": 219.74
     },
     {
       "name": "SGM",
-      "amplitude": 0.0032705585473055557,
-      "phase": 65.01471468919243
+      "amplitude": 0.003,
+      "phase": 65.01
     },
     {
       "name": "3L2",
-      "amplitude": 0.003726836154983162,
-      "phase": 301.6711461169693
+      "amplitude": 0.004,
+      "phase": 301.67
     },
     {
       "name": "3N2",
-      "amplitude": 0.013248324641988237,
-      "phase": 189.78714612229223
+      "amplitude": 0.013,
+      "phase": 189.79
     },
     {
       "name": "2SM2",
-      "amplitude": 0.029003257781587737,
-      "phase": 326.4369019686499
+      "amplitude": 0.029,
+      "phase": 326.44
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06784687434348165,
-      "phase": 226.29251103929926
+      "amplitude": 0.068,
+      "phase": 226.29
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0040874333975655505,
-      "phase": 160.41434226581623
+      "amplitude": 0.004,
+      "phase": 160.41
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0032392428695618303,
-      "phase": 57.2151556296738
+      "amplitude": 0.003,
+      "phase": 57.22
     }
   ],
   "epoch": {

--- a/data/ticon/brouwershavensche_gat_08-brouwhvsgt08-nld-rws.json
+++ b/data/ticon/brouwershavensche_gat_08-brouwhvsgt08-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.06153289,
-      "phase": 55.10311300000001
+      "amplitude": 1.1,
+      "phase": 38.61
     },
     {
       "name": "N2",
-      "amplitude": 0.16787563,
-      "phase": 27.079458999999986
+      "amplitude": 0.173,
+      "phase": 10.79
     },
     {
       "name": "S2",
-      "amplitude": 0.27775896,
-      "phase": 111.65253999999999
+      "amplitude": 0.285,
+      "phase": 94.53
     },
     {
       "name": "K2",
-      "amplitude": 0.08088499,
-      "phase": 116.88419199999998
+      "amplitude": 0.084,
+      "phase": 95.7
     },
     {
       "name": "2N2",
-      "amplitude": 0.02737067,
-      "phase": 3.2393480000000068
+      "amplitude": 0.027,
+      "phase": 354.49
     },
     {
       "name": "S1",
-      "amplitude": 0.00828067,
-      "phase": 11.145155999999986
+      "amplitude": 0.009,
+      "phase": 303.6
     },
     {
       "name": "K1",
-      "amplitude": 0.0740634,
-      "phase": 354.846582
+      "amplitude": 0.074,
+      "phase": 346.23
     },
     {
       "name": "P1",
-      "amplitude": 0.03241513,
-      "phase": 338.50335
+      "amplitude": 0.033,
+      "phase": 331.84
     },
     {
       "name": "O1",
-      "amplitude": 0.10766574000000001,
-      "phase": 182.468667
+      "amplitude": 0.108,
+      "phase": 174.25
     },
     {
       "name": "Q1",
-      "amplitude": 0.04301433,
-      "phase": 131.311739
+      "amplitude": 0.043,
+      "phase": 123.3
     },
     {
       "name": "M1",
-      "amplitude": 0.0045992,
-      "phase": 324.166365
+      "amplitude": 0.006,
+      "phase": 352.24
     },
     {
       "name": "M4",
-      "amplitude": 0.13425452,
-      "phase": 110.49413800000002
+      "amplitude": 0.161,
+      "phase": 75.88
     },
     {
       "name": "MM",
-      "amplitude": 0.01174809,
-      "phase": 181.714368
+      "amplitude": 0.011,
+      "phase": 184.53
     },
     {
       "name": "MF",
-      "amplitude": 0.00493353,
-      "phase": 55.35424699999999
+      "amplitude": 0.005,
+      "phase": 55.94
     },
     {
       "name": "SA",
-      "amplitude": 0.09731674,
-      "phase": 218.716853
+      "amplitude": 0.102,
+      "phase": 218.75
     },
     {
       "name": "SSA",
-      "amplitude": 0.02493669,
-      "phase": 170.282826
+      "amplitude": 0.026,
+      "phase": 164.32
     },
     {
       "name": "T2",
-      "amplitude": 0.05198715,
-      "phase": 31.71297500000003
+      "amplitude": 0.017,
+      "phase": 76.22
     },
     {
       "name": "J1",
-      "amplitude": 0.0041826400000000005,
-      "phase": 74.64432199999999
+      "amplitude": 0.005,
+      "phase": 63.87
     },
     {
       "name": "L2",
-      "amplitude": 0.08149561999999999,
-      "phase": 81.299958
+      "amplitude": 0.083,
+      "phase": 63.24
     },
     {
       "name": "R2",
-      "amplitude": 0.03349923,
-      "phase": 209.592349
+      "amplitude": 0.002,
+      "phase": 98.28
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00638691,
-      "phase": 77.81794000000002
+      "amplitude": 0.007,
+      "phase": 72.73
     },
     {
       "name": "MSF",
-      "amplitude": 0.02755543,
-      "phase": 34.12332300000003
+      "amplitude": 0.027,
+      "phase": 34.48
     },
     {
       "name": "MSQM",
-      "amplitude": 0.012132369999999998,
-      "phase": 332.134059
+      "amplitude": 0.012,
+      "phase": 331.45
     },
     {
       "name": "EP2",
-      "amplitude": 0.01583346,
-      "phase": 149.43253000000004
+      "amplitude": 0.016,
+      "phase": 131.39
     },
     {
       "name": "M3",
-      "amplitude": 0.00260028,
-      "phase": 108.772719
+      "amplitude": 0.003,
+      "phase": 261.59
     },
     {
       "name": "MU2",
-      "amplitude": 0.09267265,
-      "phase": 175.05584199999998
+      "amplitude": 0.092,
+      "phase": 160.04
     },
     {
       "name": "MTM",
-      "amplitude": 0.0149554,
-      "phase": 229.82561
+      "amplitude": 0.015,
+      "phase": 222.45
     },
     {
       "name": "NU2",
-      "amplitude": 0.061097780000000004,
-      "phase": 33.81212399999998
+      "amplitude": 0.061,
+      "phase": 8.79
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03512855,
-      "phase": 68.60926699999999
+      "amplitude": 0.039,
+      "phase": 59.79
     },
     {
       "name": "MN4",
-      "amplitude": 0.047141999999999996,
-      "phase": 85.77631400000001
+      "amplitude": 0.055,
+      "phase": 51.52
     },
     {
       "name": "MS4",
-      "amplitude": 0.09067924,
-      "phase": 164.25269100000003
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03668587,
-      "phase": 193.104221
+      "amplitude": 0.107,
+      "phase": 132.04
     },
     {
       "name": "N4",
-      "amplitude": 0.01412193,
-      "phase": 55.481222
+      "amplitude": 0.016,
+      "phase": 29.24
     },
     {
       "name": "M6",
-      "amplitude": 0.06140871,
-      "phase": 73.02740699999998
+      "amplitude": 0.089,
+      "phase": 19.99
     },
     {
       "name": "M8",
-      "amplitude": 0.01021204,
-      "phase": 128.394672
+      "amplitude": 0.025,
+      "phase": 50.71
     },
     {
       "name": "S4",
-      "amplitude": 0.00928443,
-      "phase": 260.00394900000003
+      "amplitude": 0.01,
+      "phase": 228.66
     },
     {
       "name": "OO1",
-      "amplitude": 0.0020080899999999997,
-      "phase": 93.39380399999999
+      "amplitude": 0.002,
+      "phase": 80.95
     },
     {
       "name": "S3",
-      "amplitude": 0.00284777,
-      "phase": 46.99578300000002
+      "amplitude": 0,
+      "phase": 237.34
     },
     {
       "name": "MA2",
-      "amplitude": 0.19167095,
-      "phase": 35.93718799999999
+      "amplitude": 0.022,
+      "phase": 24.23
     },
     {
       "name": "MB2",
-      "amplitude": 0.16730136,
-      "phase": 246.98035299999998
+      "amplitude": 0.01,
+      "phase": 124.3
     },
     {
       "name": "T3",
-      "amplitude": 0.0014737,
-      "phase": 9.971827000000019
+      "amplitude": 0.002,
+      "phase": 192.41
     },
     {
       "name": "R3",
-      "amplitude": 0.008115869999999999,
-      "phase": 245.560949
+      "amplitude": 0.009,
+      "phase": 306.28
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00722058,
-      "phase": 121.621961
+      "amplitude": 0.008,
+      "phase": 119.36
     },
     {
       "name": "SGM",
-      "amplitude": 0.0032291900000000003,
-      "phase": 244.913122
+      "amplitude": 0.003,
+      "phase": 82.31
     },
     {
       "name": "3L2",
-      "amplitude": 0.005658600000000001,
-      "phase": 218.038181
+      "amplitude": 0.005,
+      "phase": 322.81
     },
     {
       "name": "3N2",
-      "amplitude": 0.00529976,
-      "phase": 99.15969999999999
+      "amplitude": 0.006,
+      "phase": 203.11
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02669352,
-      "phase": 341.715539
+      "amplitude": 0.029,
+      "phase": 330.29
     },
     {
       "name": "2MS6",
-      "amplitude": 0.059076449999999996,
-      "phase": 123.979375
+      "amplitude": 0.083,
+      "phase": 71.8
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0062482499999999995,
-      "phase": 234.076666
+      "amplitude": 0.008,
+      "phase": 277.83
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00765719,
-      "phase": 244.904949
+      "amplitude": 0.011,
+      "phase": 116.83
     }
   ],
   "epoch": {

--- a/data/ticon/brouwershavensche_gat_punt_02-brouwhvsgt02-nld-rws.json
+++ b/data/ticon/brouwershavensche_gat_punt_02-brouwhvsgt02-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.05227576,
-      "phase": 49.65695599999998
+      "amplitude": 1.087,
+      "phase": 33.61
     },
     {
       "name": "N2",
-      "amplitude": 0.16853902,
-      "phase": 22.649991999999997
+      "amplitude": 0.174,
+      "phase": 6.81
     },
     {
       "name": "S2",
-      "amplitude": 0.27605608,
-      "phase": 105.292464
+      "amplitude": 0.285,
+      "phase": 89
     },
     {
       "name": "K2",
-      "amplitude": 0.07808011,
-      "phase": 108.44343300000003
+      "amplitude": 0.084,
+      "phase": 89.1
     },
     {
       "name": "2N2",
-      "amplitude": 0.018442240000000002,
-      "phase": 354.901609
+      "amplitude": 0.019,
+      "phase": 339.45
     },
     {
       "name": "S1",
-      "amplitude": 0.006677840000000001,
-      "phase": 3.7821270000000027
+      "amplitude": 0.009,
+      "phase": 289.28
     },
     {
       "name": "K1",
-      "amplitude": 0.07387723,
-      "phase": 353.023502
+      "amplitude": 0.074,
+      "phase": 344.62
     },
     {
       "name": "P1",
-      "amplitude": 0.03206308,
-      "phase": 337.144543
+      "amplitude": 0.032,
+      "phase": 330.06
     },
     {
       "name": "O1",
-      "amplitude": 0.10864296,
-      "phase": 180.888607
+      "amplitude": 0.109,
+      "phase": 173.11
     },
     {
       "name": "Q1",
-      "amplitude": 0.03614224,
-      "phase": 126.891523
+      "amplitude": 0.036,
+      "phase": 119.43
     },
     {
       "name": "M1",
-      "amplitude": 0.0019389799999999999,
-      "phase": 333.305569
+      "amplitude": 0.002,
+      "phase": 8.29
     },
     {
       "name": "M4",
-      "amplitude": 0.12495312,
-      "phase": 101.52727700000003
+      "amplitude": 0.146,
+      "phase": 67.95
     },
     {
       "name": "MM",
-      "amplitude": 0.005743519999999999,
-      "phase": 154.86146400000007
+      "amplitude": 0.006,
+      "phase": 155.05
     },
     {
       "name": "MF",
-      "amplitude": 0.00445204,
-      "phase": 162.81995200000006
+      "amplitude": 0.004,
+      "phase": 162.98
     },
     {
       "name": "SA",
-      "amplitude": 0.07499492,
-      "phase": 208.610072
+      "amplitude": 0.075,
+      "phase": 208.65
     },
     {
       "name": "SSA",
-      "amplitude": 0.012015679999999999,
-      "phase": 157.43581399999994
+      "amplitude": 0.012,
+      "phase": 158.35
     },
     {
       "name": "T2",
-      "amplitude": 0.05158182,
-      "phase": 28.48244599999998
+      "amplitude": 0.016,
+      "phase": 81.94
     },
     {
       "name": "J1",
-      "amplitude": 0.0039203300000000005,
-      "phase": 86.82858599999997
+      "amplitude": 0.004,
+      "phase": 76.32
     },
     {
       "name": "L2",
-      "amplitude": 0.07924692,
-      "phase": 72.28489400000001
+      "amplitude": 0.082,
+      "phase": 55.93
     },
     {
       "name": "R2",
-      "amplitude": 0.03460437,
-      "phase": 203.140611
+      "amplitude": 0.002,
+      "phase": 96.47
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0053564400000000005,
-      "phase": 92.76835299999999
+      "amplitude": 0.005,
+      "phase": 87.41
     },
     {
       "name": "MSF",
-      "amplitude": 0.01983659,
-      "phase": 28.411451999999997
+      "amplitude": 0.02,
+      "phase": 27.94
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0026333,
-      "phase": 124.91154599999999
+      "amplitude": 0.003,
+      "phase": 127.74
     },
     {
       "name": "EP2",
-      "amplitude": 0.019053439999999998,
-      "phase": 147.373173
+      "amplitude": 0.019,
+      "phase": 133.09
     },
     {
       "name": "M3",
-      "amplitude": 0.00177574,
-      "phase": 138.970707
+      "amplitude": 0.002,
+      "phase": 294.6
     },
     {
       "name": "MU2",
-      "amplitude": 0.08289416,
-      "phase": 169.165524
+      "amplitude": 0.086,
+      "phase": 153.27
     },
     {
       "name": "MTM",
-      "amplitude": 0.00318274,
-      "phase": 226.956071
+      "amplitude": 0.003,
+      "phase": 226.45
     },
     {
       "name": "NU2",
-      "amplitude": 0.05986034,
-      "phase": 19.95223299999998
+      "amplitude": 0.062,
+      "phase": 4.04
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0358509,
-      "phase": 69.111221
+      "amplitude": 0.037,
+      "phase": 54.05
     },
     {
       "name": "MN4",
-      "amplitude": 0.044098750000000006,
-      "phase": 77.91308600000002
+      "amplitude": 0.051,
+      "phase": 44.89
     },
     {
       "name": "MS4",
-      "amplitude": 0.08323454,
-      "phase": 156.98040100000003
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03004533,
-      "phase": 193.876462
+      "amplitude": 0.097,
+      "phase": 124.66
     },
     {
       "name": "N4",
-      "amplitude": 0.008914410000000001,
-      "phase": 53.95267999999999
+      "amplitude": 0.01,
+      "phase": 21.02
     },
     {
       "name": "M6",
-      "amplitude": 0.051606139999999995,
-      "phase": 59.60054200000002
+      "amplitude": 0.071,
+      "phase": 8.04
     },
     {
       "name": "M8",
-      "amplitude": 0.00988022,
-      "phase": 106.27200299999998
+      "amplitude": 0.019,
+      "phase": 33.32
     },
     {
       "name": "S4",
-      "amplitude": 0.00818048,
-      "phase": 245.142481
+      "amplitude": 0.009,
+      "phase": 212.95
     },
     {
       "name": "OO1",
-      "amplitude": 0.00438633,
-      "phase": 135.186667
+      "amplitude": 0.004,
+      "phase": 126.47
     },
     {
       "name": "S3",
-      "amplitude": 0.00209555,
-      "phase": 40.481899
+      "amplitude": 0,
+      "phase": 26.66
     },
     {
       "name": "MA2",
-      "amplitude": 0.18357899,
-      "phase": 32.38551100000001
+      "amplitude": 0.016,
+      "phase": 0.47
     },
     {
       "name": "MB2",
-      "amplitude": 0.16688126,
-      "phase": 238.50865
+      "amplitude": 0.012,
+      "phase": 124.2
     },
     {
       "name": "T3",
-      "amplitude": 0.00104623,
-      "phase": 24.409943999999996
+      "amplitude": 0.001,
+      "phase": 203.46
     },
     {
       "name": "R3",
-      "amplitude": 0.00681813,
-      "phase": 239.543015
+      "amplitude": 0.007,
+      "phase": 302.91
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00798133,
-      "phase": 127.00690299999997
+      "amplitude": 0.008,
+      "phase": 121.54
     },
     {
       "name": "SGM",
-      "amplitude": 0.0023150799999999997,
-      "phase": 116.11883499999999
+      "amplitude": 0.003,
+      "phase": 288.42
     },
     {
       "name": "3L2",
-      "amplitude": 0.00060477,
-      "phase": 90.93106999999998
+      "amplitude": 0.001,
+      "phase": 207.22
     },
     {
       "name": "3N2",
-      "amplitude": 0.00186338,
-      "phase": 61.330465000000004
+      "amplitude": 0.01,
+      "phase": 214.41
     },
     {
       "name": "2SM2",
-      "amplitude": 0.026298279999999997,
-      "phase": 343.675157
+      "amplitude": 0.027,
+      "phase": 326.99
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04824689,
-      "phase": 110.61292300000002
+      "amplitude": 0.067,
+      "phase": 59.98
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0055813,
-      "phase": 219.344258
+      "amplitude": 0.007,
+      "phase": 266.62
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0073187999999999994,
-      "phase": 235.463874
+      "amplitude": 0.009,
+      "phase": 104.5
     }
   ],
   "epoch": {

--- a/data/ticon/brunsbttelmpm-5970094-deu-wsv.json
+++ b/data/ticon/brunsbttelmpm-5970094-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2713681969978594,
-      "phase": 14.409065898743847
+      "amplitude": 1.271,
+      "phase": 14.41
     },
     {
       "name": "N2",
-      "amplitude": 0.19735373994662547,
-      "phase": 347.1628995833925
+      "amplitude": 0.197,
+      "phase": 347.16
     },
     {
       "name": "S2",
-      "amplitude": 0.3092113002201747,
-      "phase": 84.01419220949344
+      "amplitude": 0.309,
+      "phase": 84.01
     },
     {
       "name": "K2",
-      "amplitude": 0.09331359615917734,
-      "phase": 81.70055068377309
+      "amplitude": 0.093,
+      "phase": 81.7
     },
     {
       "name": "2N2",
-      "amplitude": 0.01660254710211074,
-      "phase": 347.04612313442396
+      "amplitude": 0.017,
+      "phase": 347.05
     },
     {
       "name": "S1",
-      "amplitude": 0.0159357797697822,
-      "phase": 61.619289213234765
+      "amplitude": 0.016,
+      "phase": 61.62
     },
     {
       "name": "K1",
-      "amplitude": 0.07203694426852814,
-      "phase": 65.33507768930275
+      "amplitude": 0.072,
+      "phase": 65.34
     },
     {
       "name": "P1",
-      "amplitude": 0.03090700119251636,
-      "phase": 62.70690277218762
+      "amplitude": 0.031,
+      "phase": 62.71
     },
     {
       "name": "O1",
-      "amplitude": 0.09302030745420016,
-      "phase": 269.9140882616555
+      "amplitude": 0.093,
+      "phase": 269.91
     },
     {
       "name": "Q1",
-      "amplitude": 0.02883122464242896,
-      "phase": 215.20260463449216
+      "amplitude": 0.029,
+      "phase": 215.2
     },
     {
       "name": "M1",
-      "amplitude": 0.002158791243667123,
-      "phase": 130.83410448885274
+      "amplitude": 0.002,
+      "phase": 130.83
     },
     {
       "name": "M4",
-      "amplitude": 0.1304666019334179,
-      "phase": 257.8755634009817
+      "amplitude": 0.13,
+      "phase": 257.88
     },
     {
       "name": "MM",
-      "amplitude": 0.03762452751131708,
-      "phase": 100.0902577335583
+      "amplitude": 0.038,
+      "phase": 100.09
     },
     {
       "name": "MF",
-      "amplitude": 0.020919300838212432,
-      "phase": 121.05541799903813
+      "amplitude": 0.021,
+      "phase": 121.06
     },
     {
       "name": "SA",
-      "amplitude": 0.08467397360351911,
-      "phase": 241.91450630661848
+      "amplitude": 0.085,
+      "phase": 241.91
     },
     {
       "name": "SSA",
-      "amplitude": 0.06047134524810999,
-      "phase": 249.24896872337655
+      "amplitude": 0.06,
+      "phase": 249.25
     },
     {
       "name": "T2",
-      "amplitude": 0.01742489488070143,
-      "phase": 68.6175120334247
+      "amplitude": 0.017,
+      "phase": 68.62
     },
     {
       "name": "J1",
-      "amplitude": 0.005018611196692253,
-      "phase": 192.24106691743674
+      "amplitude": 0.005,
+      "phase": 192.24
     },
     {
       "name": "L2",
-      "amplitude": 0.1145839418648618,
-      "phase": 35.22515430760461
+      "amplitude": 0.115,
+      "phase": 35.23
     },
     {
       "name": "R2",
-      "amplitude": 0.004821535714223371,
-      "phase": 29.861060258745113
+      "amplitude": 0.005,
+      "phase": 29.86
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006977771991852648,
-      "phase": 122.06118499892449
+      "amplitude": 0.007,
+      "phase": 122.06
     },
     {
       "name": "MSF",
-      "amplitude": 0.05127468994413578,
-      "phase": 66.92713053769211
+      "amplitude": 0.051,
+      "phase": 66.93
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003800952263847363,
-      "phase": 213.75602708151723
+      "amplitude": 0.004,
+      "phase": 213.76
     },
     {
       "name": "EP2",
-      "amplitude": 0.03234559744034023,
-      "phase": 82.43028560868919
+      "amplitude": 0.032,
+      "phase": 82.43
     },
     {
       "name": "M3",
-      "amplitude": 0.0028385184058688866,
-      "phase": 28.31988465661425
+      "amplitude": 0.003,
+      "phase": 28.32
     },
     {
       "name": "MU2",
-      "amplitude": 0.14798822731849998,
-      "phase": 108.46166601438472
+      "amplitude": 0.148,
+      "phase": 108.46
     },
     {
       "name": "MTM",
-      "amplitude": 0.00646685391224758,
-      "phase": 251.30461444336598
+      "amplitude": 0.006,
+      "phase": 251.3
     },
     {
       "name": "NU2",
-      "amplitude": 0.08048670574592597,
-      "phase": 336.26807375202577
+      "amplitude": 0.08,
+      "phase": 336.27
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.047683651390556824,
-      "phase": 29.273300892433213
+      "amplitude": 0.048,
+      "phase": 29.27
     },
     {
       "name": "MN4",
-      "amplitude": 0.04475524462822126,
-      "phase": 233.2935284573472
+      "amplitude": 0.045,
+      "phase": 233.29
     },
     {
       "name": "MS4",
-      "amplitude": 0.07839139384994546,
-      "phase": 325.7496882121673
+      "amplitude": 0.078,
+      "phase": 325.75
     },
     {
       "name": "N4",
-      "amplitude": 0.00869326003479837,
-      "phase": 220.05319813216624
+      "amplitude": 0.009,
+      "phase": 220.05
     },
     {
       "name": "M6",
-      "amplitude": 0.06943572639468742,
-      "phase": 122.417606886432
+      "amplitude": 0.069,
+      "phase": 122.42
     },
     {
       "name": "M8",
-      "amplitude": 0.023250956860384014,
-      "phase": 28.571524221029904
+      "amplitude": 0.023,
+      "phase": 28.57
     },
     {
       "name": "S4",
-      "amplitude": 0.008571745383825746,
-      "phase": 95.46123432453999
+      "amplitude": 0.009,
+      "phase": 95.46
     },
     {
       "name": "OO1",
-      "amplitude": 0.004674439310217886,
-      "phase": 187.7526078447667
+      "amplitude": 0.005,
+      "phase": 187.75
     },
     {
       "name": "S3",
-      "amplitude": 0.0010799135827464412,
-      "phase": 274.4346867524335
+      "amplitude": 0.001,
+      "phase": 274.43
     },
     {
       "name": "MA2",
-      "amplitude": 0.031058466456835764,
-      "phase": 329.7040690401509
+      "amplitude": 0.031,
+      "phase": 329.7
     },
     {
       "name": "MB2",
-      "amplitude": 0.02892476246211141,
-      "phase": 65.80790339974533
+      "amplitude": 0.029,
+      "phase": 65.81
     },
     {
       "name": "T3",
-      "amplitude": 0.000578604669073754,
-      "phase": 107.83859107616183
+      "amplitude": 0.001,
+      "phase": 107.84
     },
     {
       "name": "R3",
-      "amplitude": 0.0035190860280893198,
-      "phase": 66.32706795044459
+      "amplitude": 0.004,
+      "phase": 66.33
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00601417048848017,
-      "phase": 229.7095582079522
+      "amplitude": 0.006,
+      "phase": 229.71
     },
     {
       "name": "SGM",
-      "amplitude": 0.004226557868834159,
-      "phase": 100.38408876030405
+      "amplitude": 0.004,
+      "phase": 100.38
     },
     {
       "name": "3L2",
-      "amplitude": 0.012868538739767496,
-      "phase": 297.6974110051308
+      "amplitude": 0.013,
+      "phase": 297.7
     },
     {
       "name": "3N2",
-      "amplitude": 0.015297535579051637,
-      "phase": 194.97774820901333
+      "amplitude": 0.015,
+      "phase": 194.98
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02989163369433865,
-      "phase": 308.21655062923077
+      "amplitude": 0.03,
+      "phase": 308.22
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06874532303692173,
-      "phase": 187.03483536977743
+      "amplitude": 0.069,
+      "phase": 187.03
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0046765753802183755,
-      "phase": 131.39241711093575
+      "amplitude": 0.005,
+      "phase": 131.39
     },
     {
       "name": "2MO5",
-      "amplitude": 0.003620336312812968,
-      "phase": 14.435612004244604
+      "amplitude": 0.004,
+      "phase": 14.44
     }
   ],
   "epoch": {

--- a/data/ticon/bsum-9510095-deu-wsv.json
+++ b/data/ticon/bsum-9510095-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.568807081831029,
-      "phase": 332.6183359108239
+      "amplitude": 1.569,
+      "phase": 332.62
     },
     {
       "name": "N2",
-      "amplitude": 0.2515743526062685,
-      "phase": 307.3342939147846
+      "amplitude": 0.252,
+      "phase": 307.33
     },
     {
       "name": "S2",
-      "amplitude": 0.42531622933354307,
-      "phase": 43.107244703363335
+      "amplitude": 0.425,
+      "phase": 43.11
     },
     {
       "name": "K2",
-      "amplitude": 0.1262295895833118,
-      "phase": 40.96362009901992
+      "amplitude": 0.126,
+      "phase": 40.96
     },
     {
       "name": "2N2",
-      "amplitude": 0.028660573217819264,
-      "phase": 285.3516809376833
+      "amplitude": 0.029,
+      "phase": 285.35
     },
     {
       "name": "S1",
-      "amplitude": 0.012904919354212596,
-      "phase": 14.590420506644023
+      "amplitude": 0.013,
+      "phase": 14.59
     },
     {
       "name": "K1",
-      "amplitude": 0.07148649291186396,
-      "phase": 33.07223450504574
+      "amplitude": 0.071,
+      "phase": 33.07
     },
     {
       "name": "P1",
-      "amplitude": 0.032136270199428864,
-      "phase": 37.516291900324575
+      "amplitude": 0.032,
+      "phase": 37.52
     },
     {
       "name": "O1",
-      "amplitude": 0.0945810875453507,
-      "phase": 243.59599573005295
+      "amplitude": 0.095,
+      "phase": 243.6
     },
     {
       "name": "Q1",
-      "amplitude": 0.030156303342089064,
-      "phase": 185.71810623168193
+      "amplitude": 0.03,
+      "phase": 185.72
     },
     {
       "name": "M1",
-      "amplitude": 0.00190861524209185,
-      "phase": 102.3975101350602
+      "amplitude": 0.002,
+      "phase": 102.4
     },
     {
       "name": "M4",
-      "amplitude": 0.06841911836417852,
-      "phase": 139.98240885400088
+      "amplitude": 0.068,
+      "phase": 139.98
     },
     {
       "name": "MM",
-      "amplitude": 0.02842524327869756,
-      "phase": 178.28252802766065
+      "amplitude": 0.028,
+      "phase": 178.28
     },
     {
       "name": "MF",
-      "amplitude": 0.011618092018485394,
-      "phase": 170.44780685189107
+      "amplitude": 0.012,
+      "phase": 170.45
     },
     {
       "name": "SA",
-      "amplitude": 0.11362243291878371,
-      "phase": 228.13010746589782
+      "amplitude": 0.114,
+      "phase": 228.13
     },
     {
       "name": "SSA",
-      "amplitude": 0.04736316032746098,
-      "phase": 208.62479927646234
+      "amplitude": 0.047,
+      "phase": 208.62
     },
     {
       "name": "T2",
-      "amplitude": 0.020210600291005586,
-      "phase": 28.8822750375071
+      "amplitude": 0.02,
+      "phase": 28.88
     },
     {
       "name": "J1",
-      "amplitude": 0.002513677092980154,
-      "phase": 176.49685514038174
+      "amplitude": 0.003,
+      "phase": 176.5
     },
     {
       "name": "L2",
-      "amplitude": 0.12432903983278876,
-      "phase": 349.77313781629385
+      "amplitude": 0.124,
+      "phase": 349.77
     },
     {
       "name": "R2",
-      "amplitude": 0.00518859287056456,
-      "phase": 1.8834063189575545
+      "amplitude": 0.005,
+      "phase": 1.88
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005974326959854738,
-      "phase": 126.07524761960258
+      "amplitude": 0.006,
+      "phase": 126.08
     },
     {
       "name": "MSF",
-      "amplitude": 0.00544405000092008,
-      "phase": 33.755770531085886
+      "amplitude": 0.005,
+      "phase": 33.76
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009727673155975163,
-      "phase": 53.665784430841484
+      "amplitude": 0.01,
+      "phase": 53.67
     },
     {
       "name": "EP2",
-      "amplitude": 0.03553031077989924,
-      "phase": 34.830303698963576
+      "amplitude": 0.036,
+      "phase": 34.83
     },
     {
       "name": "M3",
-      "amplitude": 0.005572307605444753,
-      "phase": 11.3477819952235
+      "amplitude": 0.006,
+      "phase": 11.35
     },
     {
       "name": "MU2",
-      "amplitude": 0.15397748419887564,
-      "phase": 57.856269887027054
+      "amplitude": 0.154,
+      "phase": 57.86
     },
     {
       "name": "MTM",
-      "amplitude": 0.00726612910042263,
-      "phase": 232.29372540170067
+      "amplitude": 0.007,
+      "phase": 232.29
     },
     {
       "name": "NU2",
-      "amplitude": 0.0892833764844661,
-      "phase": 290.60533439861194
+      "amplitude": 0.089,
+      "phase": 290.61
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05821816647098078,
-      "phase": 343.710902391477
+      "amplitude": 0.058,
+      "phase": 343.71
     },
     {
       "name": "MN4",
-      "amplitude": 0.020260487057967378,
-      "phase": 127.52929974424148
+      "amplitude": 0.02,
+      "phase": 127.53
     },
     {
       "name": "MS4",
-      "amplitude": 0.05839315411542586,
-      "phase": 214.24737623432875
+      "amplitude": 0.058,
+      "phase": 214.25
     },
     {
       "name": "N4",
-      "amplitude": 0.004355335473842398,
-      "phase": 114.3866764805527
+      "amplitude": 0.004,
+      "phase": 114.39
     },
     {
       "name": "M6",
-      "amplitude": 0.059190262086630835,
-      "phase": 97.50896736649543
+      "amplitude": 0.059,
+      "phase": 97.51
     },
     {
       "name": "M8",
-      "amplitude": 0.023644295497799398,
-      "phase": 275.248227871976
+      "amplitude": 0.024,
+      "phase": 275.25
     },
     {
       "name": "S4",
-      "amplitude": 0.009053841471837368,
-      "phase": 342.6629951136997
+      "amplitude": 0.009,
+      "phase": 342.66
     },
     {
       "name": "OO1",
-      "amplitude": 0.0025097569395506744,
-      "phase": 204.28123138916314
+      "amplitude": 0.003,
+      "phase": 204.28
     },
     {
       "name": "S3",
-      "amplitude": 0.0009382108460529952,
-      "phase": 204.07144290727706
+      "amplitude": 0.001,
+      "phase": 204.07
     },
     {
       "name": "MA2",
-      "amplitude": 0.05009196785066872,
-      "phase": 266.9515592341211
+      "amplitude": 0.05,
+      "phase": 266.95
     },
     {
       "name": "MB2",
-      "amplitude": 0.03072494176858296,
-      "phase": 42.09069280459738
+      "amplitude": 0.031,
+      "phase": 42.09
     },
     {
       "name": "T3",
-      "amplitude": 0.0011838551591332217,
-      "phase": 107.7567769003594
+      "amplitude": 0.001,
+      "phase": 107.76
     },
     {
       "name": "R3",
-      "amplitude": 0.0017122636686975402,
-      "phase": 46.1325656820091
+      "amplitude": 0.002,
+      "phase": 46.13
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005837438259582029,
-      "phase": 190.88323428239516
+      "amplitude": 0.006,
+      "phase": 190.88
     },
     {
       "name": "SGM",
-      "amplitude": 0.00222584101404571,
-      "phase": 57.00389208022574
+      "amplitude": 0.002,
+      "phase": 57
     },
     {
       "name": "3L2",
-      "amplitude": 0.004686862234568991,
-      "phase": 245.99217116327634
+      "amplitude": 0.005,
+      "phase": 245.99
     },
     {
       "name": "3N2",
-      "amplitude": 0.016263110815916002,
-      "phase": 138.1057283882792
+      "amplitude": 0.016,
+      "phase": 138.11
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04026701215010938,
-      "phase": 264.49151624348355
+      "amplitude": 0.04,
+      "phase": 264.49
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04959319748223358,
-      "phase": 155.02760913774603
+      "amplitude": 0.05,
+      "phase": 155.03
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0009669736479909592,
-      "phase": 265.4339741608576
+      "amplitude": 0.001,
+      "phase": 265.43
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005954812814189687,
-      "phase": 30.98800501603955
+      "amplitude": 0.006,
+      "phase": 30.99
     }
   ],
   "epoch": {

--- a/data/ticon/buttelerhrne-4960060-deu-wsv.json
+++ b/data/ticon/buttelerhrne-4960060-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.1952773347943988,
-      "phase": 46.21688224498723
+      "amplitude": 1.195,
+      "phase": 46.22
     },
     {
       "name": "N2",
-      "amplitude": 0.17808166184024957,
-      "phase": 22.78258609030064
+      "amplitude": 0.178,
+      "phase": 22.78
     },
     {
       "name": "S2",
-      "amplitude": 0.27528192013169994,
-      "phase": 127.15403195142954
+      "amplitude": 0.275,
+      "phase": 127.15
     },
     {
       "name": "K2",
-      "amplitude": 0.08206037172992323,
-      "phase": 125.43593030454912
+      "amplitude": 0.082,
+      "phase": 125.44
     },
     {
       "name": "2N2",
-      "amplitude": 0.01716159797706074,
-      "phase": 2.7807428752997225
+      "amplitude": 0.017,
+      "phase": 2.78
     },
     {
       "name": "S1",
-      "amplitude": 0.015157224975792975,
-      "phase": 82.67495632575071
+      "amplitude": 0.015,
+      "phase": 82.67
     },
     {
       "name": "K1",
-      "amplitude": 0.05922960033107127,
-      "phase": 87.48146661466427
+      "amplitude": 0.059,
+      "phase": 87.48
     },
     {
       "name": "P1",
-      "amplitude": 0.023163802780610483,
-      "phase": 87.55761548585338
+      "amplitude": 0.023,
+      "phase": 87.56
     },
     {
       "name": "O1",
-      "amplitude": 0.07340365791331084,
-      "phase": 292.6330733288795
+      "amplitude": 0.073,
+      "phase": 292.63
     },
     {
       "name": "Q1",
-      "amplitude": 0.019330808553028333,
-      "phase": 228.96405355639143
+      "amplitude": 0.019,
+      "phase": 228.96
     },
     {
       "name": "M1",
-      "amplitude": 0.0018810332556996835,
-      "phase": 150.07331541593447
+      "amplitude": 0.002,
+      "phase": 150.07
     },
     {
       "name": "M4",
-      "amplitude": 0.05565645965195469,
-      "phase": 10.943985059507213
+      "amplitude": 0.056,
+      "phase": 10.94
     },
     {
       "name": "MM",
-      "amplitude": 0.017319057745632895,
-      "phase": 64.15023304071849
+      "amplitude": 0.017,
+      "phase": 64.15
     },
     {
       "name": "MF",
-      "amplitude": 0.020787738148421,
-      "phase": 82.74257635548281
+      "amplitude": 0.021,
+      "phase": 82.74
     },
     {
       "name": "SA",
-      "amplitude": 0.08284751075998524,
-      "phase": 290.75267489602237
+      "amplitude": 0.083,
+      "phase": 290.75
     },
     {
       "name": "SSA",
-      "amplitude": 0.04990872799395964,
-      "phase": 231.09507585415304
+      "amplitude": 0.05,
+      "phase": 231.1
     },
     {
       "name": "T2",
-      "amplitude": 0.01498335637957204,
-      "phase": 98.77691684080048
+      "amplitude": 0.015,
+      "phase": 98.78
     },
     {
       "name": "J1",
-      "amplitude": 0.004821508970249417,
-      "phase": 212.46863723510552
+      "amplitude": 0.005,
+      "phase": 212.47
     },
     {
       "name": "L2",
-      "amplitude": 0.11418158960104798,
-      "phase": 60.3720905075084
+      "amplitude": 0.114,
+      "phase": 60.37
     },
     {
       "name": "R2",
-      "amplitude": 0.0044629949051794866,
-      "phase": 190.65407514868633
+      "amplitude": 0.004,
+      "phase": 190.65
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0035498662072530295,
-      "phase": 169.91685454631022
+      "amplitude": 0.004,
+      "phase": 169.92
     },
     {
       "name": "MSF",
-      "amplitude": 0.0930155152652481,
-      "phase": 66.27544416160055
+      "amplitude": 0.093,
+      "phase": 66.28
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007160626741069099,
-      "phase": 357.1664587708483
+      "amplitude": 0.007,
+      "phase": 357.17
     },
     {
       "name": "EP2",
-      "amplitude": 0.03646798156251084,
-      "phase": 105.94652929808433
+      "amplitude": 0.036,
+      "phase": 105.95
     },
     {
       "name": "M3",
-      "amplitude": 0.00260613211142891,
-      "phase": 123.49689956769015
+      "amplitude": 0.003,
+      "phase": 123.5
     },
     {
       "name": "MU2",
-      "amplitude": 0.17840828564812775,
-      "phase": 130.47889990016438
+      "amplitude": 0.178,
+      "phase": 130.48
     },
     {
       "name": "MTM",
-      "amplitude": 0.0024709290805173694,
-      "phase": 129.73998117325903
+      "amplitude": 0.002,
+      "phase": 129.74
     },
     {
       "name": "NU2",
-      "amplitude": 0.08491932749469763,
-      "phase": 356.33578435581177
+      "amplitude": 0.085,
+      "phase": 356.34
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05194017816407554,
-      "phase": 61.932016456144595
+      "amplitude": 0.052,
+      "phase": 61.93
     },
     {
       "name": "MN4",
-      "amplitude": 0.018917942257431673,
-      "phase": 347.3081471020085
+      "amplitude": 0.019,
+      "phase": 347.31
     },
     {
       "name": "MS4",
-      "amplitude": 0.02939851433637555,
-      "phase": 78.84636589305
+      "amplitude": 0.029,
+      "phase": 78.85
     },
     {
       "name": "N4",
-      "amplitude": 0.003692599617505973,
-      "phase": 323.8088165352437
+      "amplitude": 0.004,
+      "phase": 323.81
     },
     {
       "name": "M6",
-      "amplitude": 0.03922466368902847,
-      "phase": 149.1639517533829
+      "amplitude": 0.039,
+      "phase": 149.16
     },
     {
       "name": "M8",
-      "amplitude": 0.014954943183009724,
-      "phase": 86.01183418773661
+      "amplitude": 0.015,
+      "phase": 86.01
     },
     {
       "name": "S4",
-      "amplitude": 0.0027038497771235685,
-      "phase": 213.01366169636668
+      "amplitude": 0.003,
+      "phase": 213.01
     },
     {
       "name": "OO1",
-      "amplitude": 0.002307459329075919,
-      "phase": 246.69933897677257
+      "amplitude": 0.002,
+      "phase": 246.7
     },
     {
       "name": "S3",
-      "amplitude": 0.0013119352083060289,
-      "phase": 42.58581935272838
+      "amplitude": 0.001,
+      "phase": 42.59
     },
     {
       "name": "MA2",
-      "amplitude": 0.03753909561394131,
-      "phase": 357.4854261753127
+      "amplitude": 0.038,
+      "phase": 357.49
     },
     {
       "name": "MB2",
-      "amplitude": 0.02685245876069799,
-      "phase": 193.30230770088508
+      "amplitude": 0.027,
+      "phase": 193.3
     },
     {
       "name": "T3",
-      "amplitude": 0.001342148837242441,
-      "phase": 106.27332058483114
+      "amplitude": 0.001,
+      "phase": 106.27
     },
     {
       "name": "R3",
-      "amplitude": 0.004782066954057216,
-      "phase": 110.08082183219068
+      "amplitude": 0.005,
+      "phase": 110.08
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004825327968256842,
-      "phase": 238.7319394667433
+      "amplitude": 0.005,
+      "phase": 238.73
     },
     {
       "name": "SGM",
-      "amplitude": 0.006134521131409826,
-      "phase": 64.30104857674473
+      "amplitude": 0.006,
+      "phase": 64.3
     },
     {
       "name": "3L2",
-      "amplitude": 0.0032979052913359105,
-      "phase": 328.9751191927767
+      "amplitude": 0.003,
+      "phase": 328.98
     },
     {
       "name": "3N2",
-      "amplitude": 0.02037233404387183,
-      "phase": 194.95218019955828
+      "amplitude": 0.02,
+      "phase": 194.95
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03251789196513702,
-      "phase": 351.07577167226947
+      "amplitude": 0.033,
+      "phase": 351.08
     },
     {
       "name": "2MS6",
-      "amplitude": 0.038826784968795075,
-      "phase": 221.75642196702384
+      "amplitude": 0.039,
+      "phase": 221.76
     },
     {
       "name": "2MK5",
-      "amplitude": 0.002857700184221799,
-      "phase": 144.6939116475366
+      "amplitude": 0.003,
+      "phase": 144.69
     },
     {
       "name": "2MO5",
-      "amplitude": 0.001639279555971977,
-      "phase": 333.6676380846337
+      "amplitude": 0.002,
+      "phase": 333.67
     }
   ],
   "epoch": {

--- a/data/ticon/buxtehude-5950080-deu-wsv.json
+++ b/data/ticon/buxtehude-5950080-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.9955892831803254,
-      "phase": 110.33976399166045
+      "amplitude": 0.996,
+      "phase": 110.34
     },
     {
       "name": "N2",
-      "amplitude": 0.14234388574671483,
-      "phase": 83.61268925382109
+      "amplitude": 0.142,
+      "phase": 83.61
     },
     {
       "name": "S2",
-      "amplitude": 0.22436167908760635,
-      "phase": 190.4161406578394
+      "amplitude": 0.224,
+      "phase": 190.42
     },
     {
       "name": "K2",
-      "amplitude": 0.06873598762119558,
-      "phase": 193.36187077033156
+      "amplitude": 0.069,
+      "phase": 193.36
     },
     {
       "name": "2N2",
-      "amplitude": 0.013276160375831054,
-      "phase": 68.1056956860989
+      "amplitude": 0.013,
+      "phase": 68.11
     },
     {
       "name": "S1",
-      "amplitude": 0.01403934563132386,
-      "phase": 129.61962084613788
+      "amplitude": 0.014,
+      "phase": 129.62
     },
     {
       "name": "K1",
-      "amplitude": 0.04623030743328148,
-      "phase": 120.11444751641852
+      "amplitude": 0.046,
+      "phase": 120.11
     },
     {
       "name": "P1",
-      "amplitude": 0.018599839299453042,
-      "phase": 130.00630121063136
+      "amplitude": 0.019,
+      "phase": 130.01
     },
     {
       "name": "O1",
-      "amplitude": 0.056894208209299926,
-      "phase": 326.0316464792121
+      "amplitude": 0.057,
+      "phase": 326.03
     },
     {
       "name": "Q1",
-      "amplitude": 0.01375836779502619,
-      "phase": 253.58888889396997
+      "amplitude": 0.014,
+      "phase": 253.59
     },
     {
       "name": "M1",
-      "amplitude": 0.0021851107380566354,
-      "phase": 179.63082897957509
+      "amplitude": 0.002,
+      "phase": 179.63
     },
     {
       "name": "M4",
-      "amplitude": 0.15792926108258654,
-      "phase": 161.8190275307802
+      "amplitude": 0.158,
+      "phase": 161.82
     },
     {
       "name": "MM",
-      "amplitude": 0.006445882404272668,
-      "phase": 103.8793417671697
+      "amplitude": 0.006,
+      "phase": 103.88
     },
     {
       "name": "MF",
-      "amplitude": 0.016801515810467165,
-      "phase": 106.57124237780124
+      "amplitude": 0.017,
+      "phase": 106.57
     },
     {
       "name": "SA",
-      "amplitude": 0.06108786956181544,
-      "phase": 289.6877635377968
+      "amplitude": 0.061,
+      "phase": 289.69
     },
     {
       "name": "SSA",
-      "amplitude": 0.0277882961756647,
-      "phase": 233.27565598127018
+      "amplitude": 0.028,
+      "phase": 233.28
     },
     {
       "name": "T2",
-      "amplitude": 0.008632581627941092,
-      "phase": 183.95201217630952
+      "amplitude": 0.009,
+      "phase": 183.95
     },
     {
       "name": "J1",
-      "amplitude": 0.004009405237245136,
-      "phase": 277.2650376335186
+      "amplitude": 0.004,
+      "phase": 277.27
     },
     {
       "name": "L2",
-      "amplitude": 0.09776976247054078,
-      "phase": 128.1787154912367
+      "amplitude": 0.098,
+      "phase": 128.18
     },
     {
       "name": "R2",
-      "amplitude": 0.008335089390035228,
-      "phase": 191.82074026587836
+      "amplitude": 0.008,
+      "phase": 191.82
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0025899375113411726,
-      "phase": 179.98392465452025
+      "amplitude": 0.003,
+      "phase": 179.98
     },
     {
       "name": "MSF",
-      "amplitude": 0.05328805120268722,
-      "phase": 66.27025880118407
+      "amplitude": 0.053,
+      "phase": 66.27
     },
     {
       "name": "MSQM",
-      "amplitude": 0.005955474326441907,
-      "phase": 343.99351899839644
+      "amplitude": 0.006,
+      "phase": 343.99
     },
     {
       "name": "EP2",
-      "amplitude": 0.032965214916597346,
-      "phase": 171.3478481343726
+      "amplitude": 0.033,
+      "phase": 171.35
     },
     {
       "name": "M3",
-      "amplitude": 0.00303798958794939,
-      "phase": 237.57453566884467
+      "amplitude": 0.003,
+      "phase": 237.57
     },
     {
       "name": "MU2",
-      "amplitude": 0.14856242607931938,
-      "phase": 200.45657620618155
+      "amplitude": 0.149,
+      "phase": 200.46
     },
     {
       "name": "MTM",
-      "amplitude": 0.0034210504456523897,
-      "phase": 148.00422161885285
+      "amplitude": 0.003,
+      "phase": 148
     },
     {
       "name": "NU2",
-      "amplitude": 0.07081318493242984,
-      "phase": 63.930456914556544
+      "amplitude": 0.071,
+      "phase": 63.93
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04395018625064361,
-      "phase": 133.01346246284152
+      "amplitude": 0.044,
+      "phase": 133.01
     },
     {
       "name": "MN4",
-      "amplitude": 0.04861504303165349,
-      "phase": 135.99956747865156
+      "amplitude": 0.049,
+      "phase": 136
     },
     {
       "name": "MS4",
-      "amplitude": 0.07360412852686693,
-      "phase": 237.4430137940269
+      "amplitude": 0.074,
+      "phase": 237.44
     },
     {
       "name": "N4",
-      "amplitude": 0.009904982383494609,
-      "phase": 126.99422279176576
+      "amplitude": 0.01,
+      "phase": 126.99
     },
     {
       "name": "M6",
-      "amplitude": 0.02698641893469781,
-      "phase": 145.9638308567762
+      "amplitude": 0.027,
+      "phase": 145.96
     },
     {
       "name": "M8",
-      "amplitude": 0.008641261583820078,
-      "phase": 157.4730653326942
+      "amplitude": 0.009,
+      "phase": 157.47
     },
     {
       "name": "S4",
-      "amplitude": 0.003178503836770932,
-      "phase": 78.72068342758394
+      "amplitude": 0.003,
+      "phase": 78.72
     },
     {
       "name": "OO1",
-      "amplitude": 0.0018357991452613042,
-      "phase": 306.57606284922866
+      "amplitude": 0.002,
+      "phase": 306.58
     },
     {
       "name": "S3",
-      "amplitude": 0.001957505010585354,
-      "phase": 138.2061521453913
+      "amplitude": 0.002,
+      "phase": 138.21
     },
     {
       "name": "MA2",
-      "amplitude": 0.04123927819891019,
-      "phase": 23.263297014223212
+      "amplitude": 0.041,
+      "phase": 23.26
     },
     {
       "name": "MB2",
-      "amplitude": 0.03889169059554065,
-      "phase": 225.2140641574214
+      "amplitude": 0.039,
+      "phase": 225.21
     },
     {
       "name": "T3",
-      "amplitude": 0.0009196162562407041,
-      "phase": 137.06882265123193
+      "amplitude": 0.001,
+      "phase": 137.07
     },
     {
       "name": "R3",
-      "amplitude": 0.005965086577487398,
-      "phase": 181.83910722063462
+      "amplitude": 0.006,
+      "phase": 181.84
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004377270485833579,
-      "phase": 280.1259811309527
+      "amplitude": 0.004,
+      "phase": 280.13
     },
     {
       "name": "SGM",
-      "amplitude": 0.008104975242835792,
-      "phase": 101.70166304944166
+      "amplitude": 0.008,
+      "phase": 101.7
     },
     {
       "name": "3L2",
-      "amplitude": 0.004048192911344983,
-      "phase": 25.245617926829198
+      "amplitude": 0.004,
+      "phase": 25.25
     },
     {
       "name": "3N2",
-      "amplitude": 0.012780220152911581,
-      "phase": 239.28544157539358
+      "amplitude": 0.013,
+      "phase": 239.29
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02686086089938279,
-      "phase": 59.03945021578738
+      "amplitude": 0.027,
+      "phase": 59.04
     },
     {
       "name": "2MS6",
-      "amplitude": 0.025619913674875257,
-      "phase": 210.81215177192703
+      "amplitude": 0.026,
+      "phase": 210.81
     },
     {
       "name": "2MK5",
-      "amplitude": 0.010382422107658697,
-      "phase": 147.392579654035
+      "amplitude": 0.01,
+      "phase": 147.39
     },
     {
       "name": "2MO5",
-      "amplitude": 0.011404569810860039,
-      "phase": 355.9464312451154
+      "amplitude": 0.011,
+      "phase": 355.95
     }
   ],
   "epoch": {

--- a/data/ticon/cadzand-cadzd-nld-rws.json
+++ b/data/ticon/cadzand-cadzd-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.6126798299999998,
-      "phase": 32.73208199999999
+      "amplitude": 1.669,
+      "phase": 20.31
     },
     {
       "name": "N2",
-      "amplitude": 0.26599253,
-      "phase": 7.482792000000018
+      "amplitude": 0.276,
+      "phase": 355.48
     },
     {
       "name": "S2",
-      "amplitude": 0.45369186,
-      "phase": 87.858472
+      "amplitude": 0.468,
+      "phase": 75.43
     },
     {
       "name": "K2",
-      "amplitude": 0.13141276,
-      "phase": 89.72350599999999
+      "amplitude": 0.138,
+      "phase": 75.46
     },
     {
       "name": "2N2",
-      "amplitude": 0.03141318,
-      "phase": 338.73573
+      "amplitude": 0.035,
+      "phase": 327.74
     },
     {
       "name": "S1",
-      "amplitude": 0.005331519999999999,
-      "phase": 347.053381
+      "amplitude": 0.008,
+      "phase": 291.52
     },
     {
       "name": "K1",
-      "amplitude": 0.06419255,
-      "phase": 356.601121
+      "amplitude": 0.064,
+      "phase": 349.99
     },
     {
       "name": "P1",
-      "amplitude": 0.03118994,
-      "phase": 336.368841
+      "amplitude": 0.031,
+      "phase": 330.38
     },
     {
       "name": "O1",
-      "amplitude": 0.10321306999999999,
-      "phase": 178.81484999999998
+      "amplitude": 0.103,
+      "phase": 172.58
     },
     {
       "name": "Q1",
-      "amplitude": 0.03671067,
-      "phase": 125.17989999999998
+      "amplitude": 0.037,
+      "phase": 118.68
     },
     {
       "name": "M1",
-      "amplitude": 0.00147361,
-      "phase": 113.25145399999997
+      "amplitude": 0.003,
+      "phase": 341.02
     },
     {
       "name": "M4",
-      "amplitude": 0.10151707,
-      "phase": 59.45596899999998
+      "amplitude": 0.117,
+      "phase": 34.33
     },
     {
       "name": "MM",
-      "amplitude": 0.012983940000000001,
-      "phase": 131.267647
+      "amplitude": 0.013,
+      "phase": 128.27
     },
     {
       "name": "MF",
-      "amplitude": 0.00142873,
-      "phase": 221.27395
+      "amplitude": 0.002,
+      "phase": 218.27
     },
     {
       "name": "SA",
-      "amplitude": 0.08542992999999999,
-      "phase": 215.225888
+      "amplitude": 0.091,
+      "phase": 215.79
     },
     {
       "name": "SSA",
-      "amplitude": 0.02735777,
-      "phase": 159.62708199999997
+      "amplitude": 0.029,
+      "phase": 152.8
     },
     {
       "name": "T2",
-      "amplitude": 0.07285608,
-      "phase": 16.468548
+      "amplitude": 0.025,
+      "phase": 61.5
     },
     {
       "name": "J1",
-      "amplitude": 0.00427822,
-      "phase": 86.21316100000001
+      "amplitude": 0.004,
+      "phase": 78.28
     },
     {
       "name": "L2",
-      "amplitude": 0.10711140999999999,
-      "phase": 49.69302499999998
+      "amplitude": 0.111,
+      "phase": 38.78
     },
     {
       "name": "R2",
-      "amplitude": 0.04797014,
-      "phase": 183.185972
+      "amplitude": 0.009,
+      "phase": 116.13
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0060243599999999994,
-      "phase": 71.25040899999999
+      "amplitude": 0.006,
+      "phase": 64.64
     },
     {
       "name": "MSF",
-      "amplitude": 0.03630349,
-      "phase": 42.571031000000005
+      "amplitude": 0.037,
+      "phase": 41.9
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00387384,
-      "phase": 291.551533
+      "amplitude": 0.004,
+      "phase": 292.48
     },
     {
       "name": "EP2",
-      "amplitude": 0.023719260000000002,
-      "phase": 123.92678799999999
+      "amplitude": 0.024,
+      "phase": 111.76
     },
     {
       "name": "M3",
-      "amplitude": 0.00935673,
-      "phase": 117.81366100000002
+      "amplitude": 0.01,
+      "phase": 275.49
     },
     {
       "name": "MU2",
-      "amplitude": 0.11038803,
-      "phase": 144.18882099999996
+      "amplitude": 0.113,
+      "phase": 130.48
     },
     {
       "name": "MTM",
-      "amplitude": 0.0026270100000000004,
-      "phase": 230.166955
+      "amplitude": 0.002,
+      "phase": 206.73
     },
     {
       "name": "NU2",
-      "amplitude": 0.08235677000000001,
-      "phase": 2.413874000000021
+      "amplitude": 0.09,
+      "phase": 349.92
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04937481,
-      "phase": 43.241806999999994
+      "amplitude": 0.052,
+      "phase": 34.65
     },
     {
       "name": "MN4",
-      "amplitude": 0.03426579,
-      "phase": 34.92642699999999
+      "amplitude": 0.04,
+      "phase": 10.15
     },
     {
       "name": "MS4",
-      "amplitude": 0.07044972,
-      "phase": 120.623942
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03331807,
-      "phase": 174.54923899999994
+      "amplitude": 0.081,
+      "phase": 96.76
     },
     {
       "name": "N4",
-      "amplitude": 0.00722758,
-      "phase": 16.136685
+      "amplitude": 0.009,
+      "phase": 344.17
     },
     {
       "name": "M6",
-      "amplitude": 0.06778713,
-      "phase": 22.233145999999977
+      "amplitude": 0.097,
+      "phase": 345.43
     },
     {
       "name": "M8",
-      "amplitude": 0.01489776,
-      "phase": 357.499203
+      "amplitude": 0.031,
+      "phase": 311.29
     },
     {
       "name": "S4",
-      "amplitude": 0.00629676,
-      "phase": 220.481672
+      "amplitude": 0.007,
+      "phase": 195.18
     },
     {
       "name": "OO1",
-      "amplitude": 0.00377157,
-      "phase": 123.54193700000002
+      "amplitude": 0.003,
+      "phase": 128.47
     },
     {
       "name": "S3",
-      "amplitude": 0.00260242,
-      "phase": 41.446109999999976
+      "amplitude": 0.001,
+      "phase": 203.29
     },
     {
       "name": "MA2",
-      "amplitude": 0.22861896,
-      "phase": 18.622491000000025
+      "amplitude": 0.028,
+      "phase": 343.51
     },
     {
       "name": "MB2",
-      "amplitude": 0.21343178000000002,
-      "phase": 222.156462
+      "amplitude": 0.026,
+      "phase": 147.03
     },
     {
       "name": "T3",
-      "amplitude": 0.00190691,
-      "phase": 14.771108000000027
+      "amplitude": 0.002,
+      "phase": 186.21
     },
     {
       "name": "R3",
-      "amplitude": 0.00825416,
-      "phase": 235.771686
+      "amplitude": 0.009,
+      "phase": 305.04
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006743369999999999,
-      "phase": 112.84645699999999
+      "amplitude": 0.007,
+      "phase": 108.88
     },
     {
       "name": "SGM",
-      "amplitude": 0.00141654,
-      "phase": 204.010256
+      "amplitude": 0,
+      "phase": 353.98
     },
     {
       "name": "3L2",
-      "amplitude": 0.00600062,
-      "phase": 188.30689
+      "amplitude": 0.008,
+      "phase": 333.96
     },
     {
       "name": "3N2",
-      "amplitude": 0.01138058,
-      "phase": 326.188919
+      "amplitude": 0.009,
+      "phase": 169.97
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03564751,
-      "phase": 314.922182
+      "amplitude": 0.037,
+      "phase": 302.51
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06876153,
-      "phase": 72.47945900000002
+      "amplitude": 0.097,
+      "phase": 36.33
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00648706,
-      "phase": 85.79949299999998
+      "amplitude": 0.009,
+      "phase": 145.4
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005265929999999999,
-      "phase": 124.324343
+      "amplitude": 0.007,
+      "phase": 5.61
     }
   ],
   "epoch": {

--- a/data/ticon/cranz-5950070-deu-wsv.json
+++ b/data/ticon/cranz-5950070-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.5169034849785838,
-      "phase": 76.63668827860073
+      "amplitude": 1.517,
+      "phase": 76.64
     },
     {
       "name": "N2",
-      "amplitude": 0.22653288735620017,
-      "phase": 49.94919074260531
+      "amplitude": 0.227,
+      "phase": 49.95
     },
     {
       "name": "S2",
-      "amplitude": 0.3500769356188956,
-      "phase": 153.8635812139098
+      "amplitude": 0.35,
+      "phase": 153.86
     },
     {
       "name": "K2",
-      "amplitude": 0.1055895329998449,
-      "phase": 152.54043967613916
+      "amplitude": 0.106,
+      "phase": 152.54
     },
     {
       "name": "2N2",
-      "amplitude": 0.021751213455924123,
-      "phase": 31.00971389590086
+      "amplitude": 0.022,
+      "phase": 31.01
     },
     {
       "name": "S1",
-      "amplitude": 0.01989570252984317,
-      "phase": 97.09085928351146
+      "amplitude": 0.02,
+      "phase": 97.09
     },
     {
       "name": "K1",
-      "amplitude": 0.0717640273235057,
-      "phase": 96.02853248689775
+      "amplitude": 0.072,
+      "phase": 96.03
     },
     {
       "name": "P1",
-      "amplitude": 0.0305846970841415,
-      "phase": 93.99097002141633
+      "amplitude": 0.031,
+      "phase": 93.99
     },
     {
       "name": "O1",
-      "amplitude": 0.09016830634614242,
-      "phase": 301.90701510777467
+      "amplitude": 0.09,
+      "phase": 301.91
     },
     {
       "name": "Q1",
-      "amplitude": 0.026174782087437985,
-      "phase": 241.2604914437659
+      "amplitude": 0.026,
+      "phase": 241.26
     },
     {
       "name": "M1",
-      "amplitude": 0.0024303020194832857,
-      "phase": 152.98438470297663
+      "amplitude": 0.002,
+      "phase": 152.98
     },
     {
       "name": "M4",
-      "amplitude": 0.13087924988507255,
-      "phase": 52.157013691782254
+      "amplitude": 0.131,
+      "phase": 52.16
     },
     {
       "name": "MM",
-      "amplitude": 0.01593541441002317,
-      "phase": 139.5361100248232
+      "amplitude": 0.016,
+      "phase": 139.54
     },
     {
       "name": "MF",
-      "amplitude": 0.0128152379896945,
-      "phase": 112.69574394239356
+      "amplitude": 0.013,
+      "phase": 112.7
     },
     {
       "name": "SA",
-      "amplitude": 0.06768821017960426,
-      "phase": 244.31875098384003
+      "amplitude": 0.068,
+      "phase": 244.32
     },
     {
       "name": "SSA",
-      "amplitude": 0.04478565660697265,
-      "phase": 223.73033154865922
+      "amplitude": 0.045,
+      "phase": 223.73
     },
     {
       "name": "T2",
-      "amplitude": 0.021488202771327247,
-      "phase": 132.78392247120883
+      "amplitude": 0.021,
+      "phase": 132.78
     },
     {
       "name": "J1",
-      "amplitude": 0.005675409297257664,
-      "phase": 228.30521321371717
+      "amplitude": 0.006,
+      "phase": 228.31
     },
     {
       "name": "L2",
-      "amplitude": 0.1388941635722803,
-      "phase": 96.09206962746714
+      "amplitude": 0.139,
+      "phase": 96.09
     },
     {
       "name": "R2",
-      "amplitude": 0.002747985941293971,
-      "phase": 92.83358602240878
+      "amplitude": 0.003,
+      "phase": 92.83
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005603408849123433,
-      "phase": 173.11937172844512
+      "amplitude": 0.006,
+      "phase": 173.12
     },
     {
       "name": "MSF",
-      "amplitude": 0.05538684639603008,
-      "phase": 64.386897487581
+      "amplitude": 0.055,
+      "phase": 64.39
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00990266285523091,
-      "phase": 45.60151190285319
+      "amplitude": 0.01,
+      "phase": 45.6
     },
     {
       "name": "EP2",
-      "amplitude": 0.04291600874991488,
-      "phase": 141.0647052288789
+      "amplitude": 0.043,
+      "phase": 141.06
     },
     {
       "name": "M3",
-      "amplitude": 0.003276298854126595,
-      "phase": 146.76000967527938
+      "amplitude": 0.003,
+      "phase": 146.76
     },
     {
       "name": "MU2",
-      "amplitude": 0.20690794715382801,
-      "phase": 166.75241374393715
+      "amplitude": 0.207,
+      "phase": 166.75
     },
     {
       "name": "MTM",
-      "amplitude": 0.0029391045078038048,
-      "phase": 207.18728776639918
+      "amplitude": 0.003,
+      "phase": 207.19
     },
     {
       "name": "NU2",
-      "amplitude": 0.1045503328572671,
-      "phase": 32.345437224128204
+      "amplitude": 0.105,
+      "phase": 32.35
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06164416798485515,
-      "phase": 94.68577074460109
+      "amplitude": 0.062,
+      "phase": 94.69
     },
     {
       "name": "MN4",
-      "amplitude": 0.04401350251370734,
-      "phase": 26.95738169547633
+      "amplitude": 0.044,
+      "phase": 26.96
     },
     {
       "name": "MS4",
-      "amplitude": 0.07345532077182058,
-      "phase": 125.16331032148844
+      "amplitude": 0.073,
+      "phase": 125.16
     },
     {
       "name": "N4",
-      "amplitude": 0.008626651118696347,
-      "phase": 6.341952821337543
+      "amplitude": 0.009,
+      "phase": 6.34
     },
     {
       "name": "M6",
-      "amplitude": 0.07166488268149743,
-      "phase": 308.35989701895693
+      "amplitude": 0.072,
+      "phase": 308.36
     },
     {
       "name": "M8",
-      "amplitude": 0.019033050043723018,
-      "phase": 265.9744332598348
+      "amplitude": 0.019,
+      "phase": 265.97
     },
     {
       "name": "S4",
-      "amplitude": 0.0064027790665940965,
-      "phase": 252.7296487432231
+      "amplitude": 0.006,
+      "phase": 252.73
     },
     {
       "name": "OO1",
-      "amplitude": 0.003008222043708752,
-      "phase": 231.2478773421944
+      "amplitude": 0.003,
+      "phase": 231.25
     },
     {
       "name": "S3",
-      "amplitude": 0.0012056868100069453,
-      "phase": 30.58098505216327
+      "amplitude": 0.001,
+      "phase": 30.58
     },
     {
       "name": "MA2",
-      "amplitude": 0.04687988542257412,
-      "phase": 39.31613147605117
+      "amplitude": 0.047,
+      "phase": 39.32
     },
     {
       "name": "MB2",
-      "amplitude": 0.014801790749352077,
-      "phase": 118.7268305186646
+      "amplitude": 0.015,
+      "phase": 118.73
     },
     {
       "name": "T3",
-      "amplitude": 0.00132046116682385,
-      "phase": 152.54420424430646
+      "amplitude": 0.001,
+      "phase": 152.54
     },
     {
       "name": "R3",
-      "amplitude": 0.005573074291189494,
-      "phase": 157.05303211292062
+      "amplitude": 0.006,
+      "phase": 157.05
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005891885588728876,
-      "phase": 248.39710500736055
+      "amplitude": 0.006,
+      "phase": 248.4
     },
     {
       "name": "SGM",
-      "amplitude": 0.004480005745331164,
-      "phase": 76.69095184455091
+      "amplitude": 0.004,
+      "phase": 76.69
     },
     {
       "name": "3L2",
-      "amplitude": 0.004212134554578109,
-      "phase": 348.58750866100104
+      "amplitude": 0.004,
+      "phase": 348.59
     },
     {
       "name": "3N2",
-      "amplitude": 0.017494193342198962,
-      "phase": 236.25466990201562
+      "amplitude": 0.017,
+      "phase": 236.25
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03784986292081845,
-      "phase": 23.906894442978796
+      "amplitude": 0.038,
+      "phase": 23.91
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0652442957474671,
-      "phase": 20.628394447523192
+      "amplitude": 0.065,
+      "phase": 20.63
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005695837130273505,
-      "phase": 297.09335398009944
+      "amplitude": 0.006,
+      "phase": 297.09
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004561455883666119,
-      "phase": 164.45106636170476
+      "amplitude": 0.005,
+      "phase": 164.45
     }
   ],
   "epoch": {

--- a/data/ticon/cuxhavensteubenhft-5990020-deu-wsv.json
+++ b/data/ticon/cuxhavensteubenhft-5990020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3705699032330232,
-      "phase": 340.9462833088711
+      "amplitude": 1.371,
+      "phase": 340.95
     },
     {
       "name": "N2",
-      "amplitude": 0.2164541576496699,
-      "phase": 315.408916884884
+      "amplitude": 0.216,
+      "phase": 315.41
     },
     {
       "name": "S2",
-      "amplitude": 0.35459389673322816,
-      "phase": 50.79630632062771
+      "amplitude": 0.355,
+      "phase": 50.8
     },
     {
       "name": "K2",
-      "amplitude": 0.10605006035720975,
-      "phase": 48.747859577715644
+      "amplitude": 0.106,
+      "phase": 48.75
     },
     {
       "name": "2N2",
-      "amplitude": 0.023489537291561554,
-      "phase": 294.9576548792553
+      "amplitude": 0.023,
+      "phase": 294.96
     },
     {
       "name": "S1",
-      "amplitude": 0.012666172950247079,
-      "phase": 45.23154588624891
+      "amplitude": 0.013,
+      "phase": 45.23
     },
     {
       "name": "K1",
-      "amplitude": 0.07187520332885133,
-      "phase": 42.89172737629087
+      "amplitude": 0.072,
+      "phase": 42.89
     },
     {
       "name": "P1",
-      "amplitude": 0.030736920564051095,
-      "phase": 44.99976185015737
+      "amplitude": 0.031,
+      "phase": 45
     },
     {
       "name": "O1",
-      "amplitude": 0.09335247593562841,
-      "phase": 250.69121939028318
+      "amplitude": 0.093,
+      "phase": 250.69
     },
     {
       "name": "Q1",
-      "amplitude": 0.028582005297628426,
-      "phase": 192.29755109704138
+      "amplitude": 0.029,
+      "phase": 192.3
     },
     {
       "name": "M1",
-      "amplitude": 0.001927438433363434,
-      "phase": 101.97007184138124
+      "amplitude": 0.002,
+      "phase": 101.97
     },
     {
       "name": "M4",
-      "amplitude": 0.11205404947770592,
-      "phase": 208.53376548565777
+      "amplitude": 0.112,
+      "phase": 208.53
     },
     {
       "name": "MM",
-      "amplitude": 0.020888946923227753,
-      "phase": 162.83987449664335
+      "amplitude": 0.021,
+      "phase": 162.84
     },
     {
       "name": "MF",
-      "amplitude": 0.009908361316335677,
-      "phase": 144.08563893566793
+      "amplitude": 0.01,
+      "phase": 144.09
     },
     {
       "name": "SA",
-      "amplitude": 0.09678732558141709,
-      "phase": 223.76174873665096
+      "amplitude": 0.097,
+      "phase": 223.76
     },
     {
       "name": "SSA",
-      "amplitude": 0.040760941403075485,
-      "phase": 209.79216264325308
+      "amplitude": 0.041,
+      "phase": 209.79
     },
     {
       "name": "T2",
-      "amplitude": 0.018045665757583006,
-      "phase": 31.82399798716466
+      "amplitude": 0.018,
+      "phase": 31.82
     },
     {
       "name": "J1",
-      "amplitude": 0.003387365063472868,
-      "phase": 176.23664932064457
+      "amplitude": 0.003,
+      "phase": 176.24
     },
     {
       "name": "L2",
-      "amplitude": 0.11043796930499922,
-      "phase": 359.30913557034825
+      "amplitude": 0.11,
+      "phase": 359.31
     },
     {
       "name": "R2",
-      "amplitude": 0.00320637987690086,
-      "phase": 9.453691073650589
+      "amplitude": 0.003,
+      "phase": 9.45
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005973806205454571,
-      "phase": 132.9582368762754
+      "amplitude": 0.006,
+      "phase": 132.96
     },
     {
       "name": "MSF",
-      "amplitude": 0.02664624965234073,
-      "phase": 55.13336095475785
+      "amplitude": 0.027,
+      "phase": 55.13
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008912177596596486,
-      "phase": 57.439636461417535
+      "amplitude": 0.009,
+      "phase": 57.44
     },
     {
       "name": "EP2",
-      "amplitude": 0.03232123604519621,
-      "phase": 45.83385561277083
+      "amplitude": 0.032,
+      "phase": 45.83
     },
     {
       "name": "M3",
-      "amplitude": 0.004084528387691124,
-      "phase": 3.2155148661464636
+      "amplitude": 0.004,
+      "phase": 3.22
     },
     {
       "name": "MU2",
-      "amplitude": 0.14289118168569936,
-      "phase": 70.23441507568646
+      "amplitude": 0.143,
+      "phase": 70.23
     },
     {
       "name": "MTM",
-      "amplitude": 0.004983297688441608,
-      "phase": 230.45548325713364
+      "amplitude": 0.005,
+      "phase": 230.46
     },
     {
       "name": "NU2",
-      "amplitude": 0.08063092205034472,
-      "phase": 300.1439193956716
+      "amplitude": 0.081,
+      "phase": 300.14
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05188567278129424,
-      "phase": 353.40074048319684
+      "amplitude": 0.052,
+      "phase": 353.4
     },
     {
       "name": "MN4",
-      "amplitude": 0.03903312890585581,
-      "phase": 186.5283960132245
+      "amplitude": 0.039,
+      "phase": 186.53
     },
     {
       "name": "MS4",
-      "amplitude": 0.0715533050732496,
-      "phase": 272.9667980110275
+      "amplitude": 0.072,
+      "phase": 272.97
     },
     {
       "name": "N4",
-      "amplitude": 0.008264939065349974,
-      "phase": 166.23418609519638
+      "amplitude": 0.008,
+      "phase": 166.23
     },
     {
       "name": "M6",
-      "amplitude": 0.06967601791315585,
-      "phase": 54.23694997194485
+      "amplitude": 0.07,
+      "phase": 54.24
     },
     {
       "name": "M8",
-      "amplitude": 0.010937383519369098,
-      "phase": 299.99817509444097
+      "amplitude": 0.011,
+      "phase": 300
     },
     {
       "name": "S4",
-      "amplitude": 0.007819069222465138,
-      "phase": 28.894978818557206
+      "amplitude": 0.008,
+      "phase": 28.89
     },
     {
       "name": "OO1",
-      "amplitude": 0.0027807058478655023,
-      "phase": 197.1349201054179
+      "amplitude": 0.003,
+      "phase": 197.13
     },
     {
       "name": "S3",
-      "amplitude": 0.0009543759542563566,
-      "phase": 222.6823482017794
+      "amplitude": 0.001,
+      "phase": 222.68
     },
     {
       "name": "MA2",
-      "amplitude": 0.04322362926085636,
-      "phase": 284.4845684770078
+      "amplitude": 0.043,
+      "phase": 284.48
     },
     {
       "name": "MB2",
-      "amplitude": 0.027033546064835087,
-      "phase": 43.15858688572513
+      "amplitude": 0.027,
+      "phase": 43.16
     },
     {
       "name": "T3",
-      "amplitude": 0.0002031393253302414,
-      "phase": 266.8711696290444
+      "amplitude": 0,
+      "phase": 266.87
     },
     {
       "name": "R3",
-      "amplitude": 0.0031918565450810544,
-      "phase": 21.274680383939824
+      "amplitude": 0.003,
+      "phase": 21.27
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005971747670604558,
-      "phase": 194.17453902550372
+      "amplitude": 0.006,
+      "phase": 194.17
     },
     {
       "name": "SGM",
-      "amplitude": 0.0024655519942914155,
-      "phase": 53.89695579020167
+      "amplitude": 0.002,
+      "phase": 53.9
     },
     {
       "name": "3L2",
-      "amplitude": 0.003979093579620233,
-      "phase": 260.04634422293964
+      "amplitude": 0.004,
+      "phase": 260.05
     },
     {
       "name": "3N2",
-      "amplitude": 0.01516900958566818,
-      "phase": 141.66147808563676
+      "amplitude": 0.015,
+      "phase": 141.66
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03472449590549942,
-      "phase": 273.5479482690917
+      "amplitude": 0.035,
+      "phase": 273.55
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06787599098184563,
-      "phase": 117.57910435971553
+      "amplitude": 0.068,
+      "phase": 117.58
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004114083046230885,
-      "phase": 64.99783910466135
+      "amplitude": 0.004,
+      "phase": 65
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0031309964068650118,
-      "phase": 326.24785142274595
+      "amplitude": 0.003,
+      "phase": 326.25
     }
   ],
   "epoch": {

--- a/data/ticon/dagebll-9570040-deu-wsv.json
+++ b/data/ticon/dagebll-9570040-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2910727843244667,
-      "phase": 15.358338432237588
+      "amplitude": 1.291,
+      "phase": 15.36
     },
     {
       "name": "N2",
-      "amplitude": 0.20429951144475983,
-      "phase": 350.46681992254844
+      "amplitude": 0.204,
+      "phase": 350.47
     },
     {
       "name": "S2",
-      "amplitude": 0.3220613785732159,
-      "phase": 89.84155871131617
+      "amplitude": 0.322,
+      "phase": 89.84
     },
     {
       "name": "K2",
-      "amplitude": 0.0967571863231937,
-      "phase": 88.42013466912096
+      "amplitude": 0.097,
+      "phase": 88.42
     },
     {
       "name": "2N2",
-      "amplitude": 0.023118977267154766,
-      "phase": 329.43183951612787
+      "amplitude": 0.023,
+      "phase": 329.43
     },
     {
       "name": "S1",
-      "amplitude": 0.012694318348184557,
-      "phase": 26.2283732745272
+      "amplitude": 0.013,
+      "phase": 26.23
     },
     {
       "name": "K1",
-      "amplitude": 0.06510299538845264,
-      "phase": 57.15340706691438
+      "amplitude": 0.065,
+      "phase": 57.15
     },
     {
       "name": "P1",
-      "amplitude": 0.02954519202245174,
-      "phase": 56.83453113709021
+      "amplitude": 0.03,
+      "phase": 56.83
     },
     {
       "name": "O1",
-      "amplitude": 0.08940099042023808,
-      "phase": 265.59475683380845
+      "amplitude": 0.089,
+      "phase": 265.59
     },
     {
       "name": "Q1",
-      "amplitude": 0.028468319936660547,
-      "phase": 206.98945922807044
+      "amplitude": 0.028,
+      "phase": 206.99
     },
     {
       "name": "M1",
-      "amplitude": 0.0020732891467837174,
-      "phase": 123.79047426814645
+      "amplitude": 0.002,
+      "phase": 123.79
     },
     {
       "name": "M4",
-      "amplitude": 0.1416024712910345,
-      "phase": 248.33991675803412
+      "amplitude": 0.142,
+      "phase": 248.34
     },
     {
       "name": "MM",
-      "amplitude": 0.027310581580802375,
-      "phase": 174.73186165030654
+      "amplitude": 0.027,
+      "phase": 174.73
     },
     {
       "name": "MF",
-      "amplitude": 0.009673507021018274,
-      "phase": 153.73528117085232
+      "amplitude": 0.01,
+      "phase": 153.74
     },
     {
       "name": "SA",
-      "amplitude": 0.12683300894754237,
-      "phase": 231.0672511605731
+      "amplitude": 0.127,
+      "phase": 231.07
     },
     {
       "name": "SSA",
-      "amplitude": 0.049712923687070615,
-      "phase": 211.5701436296957
+      "amplitude": 0.05,
+      "phase": 211.57
     },
     {
       "name": "T2",
-      "amplitude": 0.016464672538351845,
-      "phase": 62.10339496312827
+      "amplitude": 0.016,
+      "phase": 62.1
     },
     {
       "name": "J1",
-      "amplitude": 0.0036099723030649745,
-      "phase": 196.48561681380778
+      "amplitude": 0.004,
+      "phase": 196.49
     },
     {
       "name": "L2",
-      "amplitude": 0.11060018855014286,
-      "phase": 33.07895991405803
+      "amplitude": 0.111,
+      "phase": 33.08
     },
     {
       "name": "R2",
-      "amplitude": 0.0011349455478576167,
-      "phase": 78.82754746018924
+      "amplitude": 0.001,
+      "phase": 78.83
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005577680672880106,
-      "phase": 145.6501257688696
+      "amplitude": 0.006,
+      "phase": 145.65
     },
     {
       "name": "MSF",
-      "amplitude": 0.018326876575585484,
-      "phase": 47.91416212618299
+      "amplitude": 0.018,
+      "phase": 47.91
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008059046282634964,
-      "phase": 49.95418354399567
+      "amplitude": 0.008,
+      "phase": 49.95
     },
     {
       "name": "EP2",
-      "amplitude": 0.03533813173462621,
-      "phase": 78.55043259755985
+      "amplitude": 0.035,
+      "phase": 78.55
     },
     {
       "name": "M3",
-      "amplitude": 0.0011893705257304957,
-      "phase": 69.05956634352827
+      "amplitude": 0.001,
+      "phase": 69.06
     },
     {
       "name": "MU2",
-      "amplitude": 0.15473401248994492,
-      "phase": 100.2612133477358
+      "amplitude": 0.155,
+      "phase": 100.26
     },
     {
       "name": "MTM",
-      "amplitude": 0.006803035342027488,
-      "phase": 235.87047477140175
+      "amplitude": 0.007,
+      "phase": 235.87
     },
     {
       "name": "NU2",
-      "amplitude": 0.07869471505027914,
-      "phase": 331.1593726697318
+      "amplitude": 0.079,
+      "phase": 331.16
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05210252475599922,
-      "phase": 28.0005371554563
+      "amplitude": 0.052,
+      "phase": 28
     },
     {
       "name": "MN4",
-      "amplitude": 0.04761362394046174,
-      "phase": 221.19282384683456
+      "amplitude": 0.048,
+      "phase": 221.19
     },
     {
       "name": "MS4",
-      "amplitude": 0.07975530904800797,
-      "phase": 322.5366681180099
+      "amplitude": 0.08,
+      "phase": 322.54
     },
     {
       "name": "N4",
-      "amplitude": 0.009920292187437839,
-      "phase": 196.53643270109112
+      "amplitude": 0.01,
+      "phase": 196.54
     },
     {
       "name": "M6",
-      "amplitude": 0.06267929915705348,
-      "phase": 86.88237183637222
+      "amplitude": 0.063,
+      "phase": 86.88
     },
     {
       "name": "M8",
-      "amplitude": 0.013192494844308539,
-      "phase": 324.2182697309419
+      "amplitude": 0.013,
+      "phase": 324.22
     },
     {
       "name": "S4",
-      "amplitude": 0.006744552482018949,
-      "phase": 103.42259676711251
+      "amplitude": 0.007,
+      "phase": 103.42
     },
     {
       "name": "OO1",
-      "amplitude": 0.002633255090831492,
-      "phase": 234.7953613911518
+      "amplitude": 0.003,
+      "phase": 234.8
     },
     {
       "name": "S3",
-      "amplitude": 0.0005569689772861037,
-      "phase": 196.5983346782405
+      "amplitude": 0.001,
+      "phase": 196.6
     },
     {
       "name": "MA2",
-      "amplitude": 0.04507604632506381,
-      "phase": 323.53374087819486
+      "amplitude": 0.045,
+      "phase": 323.53
     },
     {
       "name": "MB2",
-      "amplitude": 0.017263706451478365,
-      "phase": 90.61858086254063
+      "amplitude": 0.017,
+      "phase": 90.62
     },
     {
       "name": "T3",
-      "amplitude": 0.0005332607134778445,
-      "phase": 285.9548691468077
+      "amplitude": 0.001,
+      "phase": 285.95
     },
     {
       "name": "R3",
-      "amplitude": 0.0029433729173566963,
-      "phase": 54.59735866333
+      "amplitude": 0.003,
+      "phase": 54.6
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006283760221875953,
-      "phase": 208.34433853567745
+      "amplitude": 0.006,
+      "phase": 208.34
     },
     {
       "name": "SGM",
-      "amplitude": 0.0020888757166792706,
-      "phase": 58.60745758160215
+      "amplitude": 0.002,
+      "phase": 58.61
     },
     {
       "name": "3L2",
-      "amplitude": 0.0036176382382335772,
-      "phase": 292.25871429817494
+      "amplitude": 0.004,
+      "phase": 292.26
     },
     {
       "name": "3N2",
-      "amplitude": 0.013008900294545026,
-      "phase": 171.20166886228515
+      "amplitude": 0.013,
+      "phase": 171.2
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03527036580775396,
-      "phase": 312.391625441113
+      "amplitude": 0.035,
+      "phase": 312.39
     },
     {
       "name": "2MS6",
-      "amplitude": 0.056820445090578646,
-      "phase": 154.79700239750355
+      "amplitude": 0.057,
+      "phase": 154.8
     },
     {
       "name": "2MK5",
-      "amplitude": 0.006575759910517245,
-      "phase": 129.02487843425195
+      "amplitude": 0.007,
+      "phase": 129.02
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006462630199412508,
-      "phase": 325.57966142941694
+      "amplitude": 0.006,
+      "phase": 325.58
     }
   ],
   "epoch": {

--- a/data/ticon/dreyschloot-3880010-deu-wsv.json
+++ b/data/ticon/dreyschloot-3880010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.35024080703393956,
-      "phase": 52.75929543103376
+      "amplitude": 0.35,
+      "phase": 52.76
     },
     {
       "name": "N2",
-      "amplitude": 0.050632406606178855,
-      "phase": 32.1792625660637
+      "amplitude": 0.051,
+      "phase": 32.18
     },
     {
       "name": "S2",
-      "amplitude": 0.07147797325371762,
-      "phase": 137.17322874271628
+      "amplitude": 0.071,
+      "phase": 137.17
     },
     {
       "name": "K2",
-      "amplitude": 0.0245048882924582,
-      "phase": 135.03065797963473
+      "amplitude": 0.025,
+      "phase": 135.03
     },
     {
       "name": "2N2",
-      "amplitude": 0.004730072889731444,
-      "phase": 12.509254876187583
+      "amplitude": 0.005,
+      "phase": 12.51
     },
     {
       "name": "S1",
-      "amplitude": 0.02807234961843793,
-      "phase": 108.02609657436932
+      "amplitude": 0.028,
+      "phase": 108.03
     },
     {
       "name": "K1",
-      "amplitude": 0.007639489513999503,
-      "phase": 61.18013602918592
+      "amplitude": 0.008,
+      "phase": 61.18
     },
     {
       "name": "P1",
-      "amplitude": 0.011514590427326893,
-      "phase": 206.33309717736503
+      "amplitude": 0.012,
+      "phase": 206.33
     },
     {
       "name": "O1",
-      "amplitude": 0.0064304674781943405,
-      "phase": 291.3650421936535
+      "amplitude": 0.006,
+      "phase": 291.37
     },
     {
       "name": "Q1",
-      "amplitude": 0.002234021730568035,
-      "phase": 177.45157332489282
+      "amplitude": 0.002,
+      "phase": 177.45
     },
     {
       "name": "M1",
-      "amplitude": 0.0005617374043677806,
-      "phase": 241.15903058364916
+      "amplitude": 0.001,
+      "phase": 241.16
     },
     {
       "name": "M4",
-      "amplitude": 0.0472799824366351,
-      "phase": 6.195484139114512
+      "amplitude": 0.047,
+      "phase": 6.2
     },
     {
       "name": "MM",
-      "amplitude": 0.005076133701497152,
-      "phase": 317.04377628323107
+      "amplitude": 0.005,
+      "phase": 317.04
     },
     {
       "name": "MF",
-      "amplitude": 0.013697200599989849,
-      "phase": 172.28726776364545
+      "amplitude": 0.014,
+      "phase": 172.29
     },
     {
       "name": "SA",
-      "amplitude": 0.04263365086293764,
-      "phase": 93.557951455394
+      "amplitude": 0.043,
+      "phase": 93.56
     },
     {
       "name": "SSA",
-      "amplitude": 0.017541941497692372,
-      "phase": 250.58520521915432
+      "amplitude": 0.018,
+      "phase": 250.59
     },
     {
       "name": "T2",
-      "amplitude": 0.0055301824931717515,
-      "phase": 277.6510782146026
+      "amplitude": 0.006,
+      "phase": 277.65
     },
     {
       "name": "J1",
-      "amplitude": 0.004755415769188226,
-      "phase": 31.63746202398829
+      "amplitude": 0.005,
+      "phase": 31.64
     },
     {
       "name": "L2",
-      "amplitude": 0.03684558890678633,
-      "phase": 67.80998527747386
+      "amplitude": 0.037,
+      "phase": 67.81
     },
     {
       "name": "R2",
-      "amplitude": 0.006764166218417787,
-      "phase": 118.53755563525516
+      "amplitude": 0.007,
+      "phase": 118.54
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0012632915938791973,
-      "phase": 125.12915823219919
+      "amplitude": 0.001,
+      "phase": 125.13
     },
     {
       "name": "MSF",
-      "amplitude": 0.008218661291107274,
-      "phase": 44.73666300360276
+      "amplitude": 0.008,
+      "phase": 44.74
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009179846172989515,
-      "phase": 299.96396923204753
+      "amplitude": 0.009,
+      "phase": 299.96
     },
     {
       "name": "EP2",
-      "amplitude": 0.013007841563671402,
-      "phase": 128.46810676210453
+      "amplitude": 0.013,
+      "phase": 128.47
     },
     {
       "name": "M3",
-      "amplitude": 0.0003181998882801144,
-      "phase": 149.06707664853514
+      "amplitude": 0,
+      "phase": 149.07
     },
     {
       "name": "MU2",
-      "amplitude": 0.06188650060221921,
-      "phase": 143.8092395556431
+      "amplitude": 0.062,
+      "phase": 143.81
     },
     {
       "name": "MTM",
-      "amplitude": 0.0016440373148652921,
-      "phase": 35.488417769161
+      "amplitude": 0.002,
+      "phase": 35.49
     },
     {
       "name": "NU2",
-      "amplitude": 0.02661200568951789,
-      "phase": 6.371074784323582
+      "amplitude": 0.027,
+      "phase": 6.37
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.018277676510244555,
-      "phase": 71.9682150827474
+      "amplitude": 0.018,
+      "phase": 71.97
     },
     {
       "name": "MN4",
-      "amplitude": 0.014169188992630002,
-      "phase": 341.33975388699946
+      "amplitude": 0.014,
+      "phase": 341.34
     },
     {
       "name": "MS4",
-      "amplitude": 0.022886127292760315,
-      "phase": 85.51674468871272
+      "amplitude": 0.023,
+      "phase": 85.52
     },
     {
       "name": "N4",
-      "amplitude": 0.002514437335594763,
-      "phase": 328.47389439999796
+      "amplitude": 0.003,
+      "phase": 328.47
     },
     {
       "name": "M6",
-      "amplitude": 0.010257352252561481,
-      "phase": 200.91832039056877
+      "amplitude": 0.01,
+      "phase": 200.92
     },
     {
       "name": "M8",
-      "amplitude": 0.00703722336252483,
-      "phase": 150.71935215513543
+      "amplitude": 0.007,
+      "phase": 150.72
     },
     {
       "name": "S4",
-      "amplitude": 0.002950413219908508,
-      "phase": 255.2508330727082
+      "amplitude": 0.003,
+      "phase": 255.25
     },
     {
       "name": "OO1",
-      "amplitude": 0.003659408728647063,
-      "phase": 3.3022766283281726
+      "amplitude": 0.004,
+      "phase": 3.3
     },
     {
       "name": "S3",
-      "amplitude": 0.0042392885557545985,
-      "phase": 305.7928368534748
+      "amplitude": 0.004,
+      "phase": 305.79
     },
     {
       "name": "MA2",
-      "amplitude": 0.04015845259205093,
-      "phase": 307.7725529818134
+      "amplitude": 0.04,
+      "phase": 307.77
     },
     {
       "name": "MB2",
-      "amplitude": 0.035684973058019064,
-      "phase": 165.985333947943
+      "amplitude": 0.036,
+      "phase": 165.99
     },
     {
       "name": "T3",
-      "amplitude": 0.00252140954469159,
-      "phase": 211.96131944240602
+      "amplitude": 0.003,
+      "phase": 211.96
     },
     {
       "name": "R3",
-      "amplitude": 0.003824564934135979,
-      "phase": 30.839785526870287
+      "amplitude": 0.004,
+      "phase": 30.84
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00047802895339172524,
-      "phase": 158.31896770628998
+      "amplitude": 0,
+      "phase": 158.32
     },
     {
       "name": "SGM",
-      "amplitude": 0.010007986804167842,
-      "phase": 88.29800913784362
+      "amplitude": 0.01,
+      "phase": 88.3
     },
     {
       "name": "3L2",
-      "amplitude": 0.002917705349620171,
-      "phase": 295.9879302795491
+      "amplitude": 0.003,
+      "phase": 295.99
     },
     {
       "name": "3N2",
-      "amplitude": 0.004818838814236163,
-      "phase": 98.61212462455427
+      "amplitude": 0.005,
+      "phase": 98.61
     },
     {
       "name": "2SM2",
-      "amplitude": 0.009227643919459282,
-      "phase": 353.80375807925907
+      "amplitude": 0.009,
+      "phase": 353.8
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00863634647911038,
-      "phase": 276.89747457176446
+      "amplitude": 0.009,
+      "phase": 276.9
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0009623875469458972,
-      "phase": 290.7675603433496
+      "amplitude": 0.001,
+      "phase": 290.77
     },
     {
       "name": "2MO5",
-      "amplitude": 0.001502537476740996,
-      "phase": 155.08899773555368
+      "amplitude": 0.002,
+      "phase": 155.09
     }
   ],
   "epoch": {

--- a/data/ticon/dukegat-3990020-deu-wsv.json
+++ b/data/ticon/dukegat-3990020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2251447733691438,
-      "phase": 290.87348496704084
+      "amplitude": 1.225,
+      "phase": 290.87
     },
     {
       "name": "N2",
-      "amplitude": 0.19552419394785717,
-      "phase": 267.0870896171005
+      "amplitude": 0.196,
+      "phase": 267.09
     },
     {
       "name": "S2",
-      "amplitude": 0.30755629564394177,
-      "phase": 359.17322711680805
+      "amplitude": 0.308,
+      "phase": 359.17
     },
     {
       "name": "K2",
-      "amplitude": 0.09360020965196277,
-      "phase": 356.7521586699679
+      "amplitude": 0.094,
+      "phase": 356.75
     },
     {
       "name": "2N2",
-      "amplitude": 0.022016638279246475,
-      "phase": 245.32614471533614
+      "amplitude": 0.022,
+      "phase": 245.33
     },
     {
       "name": "S1",
-      "amplitude": 0.009229132524049595,
-      "phase": 19.581131505993312
+      "amplitude": 0.009,
+      "phase": 19.58
     },
     {
       "name": "K1",
-      "amplitude": 0.07224569552171424,
-      "phase": 17.78897726513452
+      "amplitude": 0.072,
+      "phase": 17.79
     },
     {
       "name": "P1",
-      "amplitude": 0.028712767057869047,
-      "phase": 23.91002586081669
+      "amplitude": 0.029,
+      "phase": 23.91
     },
     {
       "name": "O1",
-      "amplitude": 0.08966697359296294,
-      "phase": 225.1206743918683
+      "amplitude": 0.09,
+      "phase": 225.12
     },
     {
       "name": "Q1",
-      "amplitude": 0.029008689137356714,
-      "phase": 165.59317535279388
+      "amplitude": 0.029,
+      "phase": 165.59
     },
     {
       "name": "M1",
-      "amplitude": 0.0014464112032719666,
-      "phase": 83.7502749479674
+      "amplitude": 0.001,
+      "phase": 83.75
     },
     {
       "name": "M4",
-      "amplitude": 0.11889015213984766,
-      "phase": 58.37513792668051
+      "amplitude": 0.119,
+      "phase": 58.38
     },
     {
       "name": "MM",
-      "amplitude": 0.022699876622146724,
-      "phase": 159.43420347266942
+      "amplitude": 0.023,
+      "phase": 159.43
     },
     {
       "name": "MF",
-      "amplitude": 0.00870834885581183,
-      "phase": 166.64143708049005
+      "amplitude": 0.009,
+      "phase": 166.64
     },
     {
       "name": "SA",
-      "amplitude": 0.09138355978869449,
-      "phase": 226.2301039848205
+      "amplitude": 0.091,
+      "phase": 226.23
     },
     {
       "name": "SSA",
-      "amplitude": 0.03364802683806122,
-      "phase": 206.84501841066162
+      "amplitude": 0.034,
+      "phase": 206.85
     },
     {
       "name": "T2",
-      "amplitude": 0.01756356713612785,
-      "phase": 325.09178951721333
+      "amplitude": 0.018,
+      "phase": 325.09
     },
     {
       "name": "J1",
-      "amplitude": 0.0015338278195168433,
-      "phase": 110.78640641715663
+      "amplitude": 0.002,
+      "phase": 110.79
     },
     {
       "name": "L2",
-      "amplitude": 0.0983690847097564,
-      "phase": 306.5788079757993
+      "amplitude": 0.098,
+      "phase": 306.58
     },
     {
       "name": "R2",
-      "amplitude": 0.001374219624171592,
-      "phase": 194.58981529463813
+      "amplitude": 0.001,
+      "phase": 194.59
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00599954696539408,
-      "phase": 115.89190301091526
+      "amplitude": 0.006,
+      "phase": 115.89
     },
     {
       "name": "MSF",
-      "amplitude": 0.009947964646353379,
-      "phase": 42.75591024048373
+      "amplitude": 0.01,
+      "phase": 42.76
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007205094685400167,
-      "phase": 73.85503428125355
+      "amplitude": 0.007,
+      "phase": 73.86
     },
     {
       "name": "EP2",
-      "amplitude": 0.027527615638660324,
-      "phase": 0.1314409636508458
+      "amplitude": 0.028,
+      "phase": 0.13
     },
     {
       "name": "M3",
-      "amplitude": 0.002848712953633881,
-      "phase": 286.1964395191011
+      "amplitude": 0.003,
+      "phase": 286.2
     },
     {
       "name": "MU2",
-      "amplitude": 0.12627660364449286,
-      "phase": 19.020769541254197
+      "amplitude": 0.126,
+      "phase": 19.02
     },
     {
       "name": "MTM",
-      "amplitude": 0.005607087709779737,
-      "phase": 247.3107444197755
+      "amplitude": 0.006,
+      "phase": 247.31
     },
     {
       "name": "NU2",
-      "amplitude": 0.07205150716598176,
-      "phase": 249.5067796220224
+      "amplitude": 0.072,
+      "phase": 249.51
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04526075463614618,
-      "phase": 302.6839001744747
+      "amplitude": 0.045,
+      "phase": 302.68
     },
     {
       "name": "MN4",
-      "amplitude": 0.03878680103171036,
-      "phase": 34.51162211108277
+      "amplitude": 0.039,
+      "phase": 34.51
     },
     {
       "name": "MS4",
-      "amplitude": 0.07463248559919938,
-      "phase": 132.24980941783053
+      "amplitude": 0.075,
+      "phase": 132.25
     },
     {
       "name": "N4",
-      "amplitude": 0.007627575927032047,
-      "phase": 9.412429505486841
+      "amplitude": 0.008,
+      "phase": 9.41
     },
     {
       "name": "M6",
-      "amplitude": 0.049089491043505504,
-      "phase": 221.79317350033108
+      "amplitude": 0.049,
+      "phase": 221.79
     },
     {
       "name": "M8",
-      "amplitude": 0.011331522601193552,
-      "phase": 18.045325653037764
+      "amplitude": 0.011,
+      "phase": 18.05
     },
     {
       "name": "S4",
-      "amplitude": 0.006944353818150983,
-      "phase": 270.5096764602652
+      "amplitude": 0.007,
+      "phase": 270.51
     },
     {
       "name": "OO1",
-      "amplitude": 0.002717388452769126,
-      "phase": 190.8033101939671
+      "amplitude": 0.003,
+      "phase": 190.8
     },
     {
       "name": "S3",
-      "amplitude": 0.00040744253664723646,
-      "phase": 76.00973516767903
+      "amplitude": 0,
+      "phase": 76.01
     },
     {
       "name": "MA2",
-      "amplitude": 0.05157007249933365,
-      "phase": 251.90744556113384
+      "amplitude": 0.052,
+      "phase": 251.91
     },
     {
       "name": "MB2",
-      "amplitude": 0.004055401052437254,
-      "phase": 76.19611988652076
+      "amplitude": 0.004,
+      "phase": 76.2
     },
     {
       "name": "T3",
-      "amplitude": 0.001065697206756199,
-      "phase": 339.8195260634788
+      "amplitude": 0.001,
+      "phase": 339.82
     },
     {
       "name": "R3",
-      "amplitude": 0.0032831361633288867,
-      "phase": 347.2617710958872
+      "amplitude": 0.003,
+      "phase": 347.26
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005460481255872057,
-      "phase": 169.52725232911894
+      "amplitude": 0.005,
+      "phase": 169.53
     },
     {
       "name": "SGM",
-      "amplitude": 0.002868058764059932,
-      "phase": 50.51188970629164
+      "amplitude": 0.003,
+      "phase": 50.51
     },
     {
       "name": "3L2",
-      "amplitude": 0.003630500540420629,
-      "phase": 193.78642077315354
+      "amplitude": 0.004,
+      "phase": 193.79
     },
     {
       "name": "3N2",
-      "amplitude": 0.011371109551131898,
-      "phase": 98.2872777654253
+      "amplitude": 0.011,
+      "phase": 98.29
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02915272494719914,
-      "phase": 221.92300437682601
+      "amplitude": 0.029,
+      "phase": 221.92
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04625165381064386,
-      "phase": 287.7106541903653
+      "amplitude": 0.046,
+      "phase": 287.71
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005453601499745392,
-      "phase": 255.47084603815864
+      "amplitude": 0.005,
+      "phase": 255.47
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0025621247653219562,
-      "phase": 117.7526250370235
+      "amplitude": 0.003,
+      "phase": 117.75
     }
   ],
   "epoch": {

--- a/data/ticon/dwarsgat-9460020-deu-wsv.json
+++ b/data/ticon/dwarsgat-9460020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.5314757467228606,
-      "phase": 323.5035528640908
+      "amplitude": 1.531,
+      "phase": 323.5
     },
     {
       "name": "N2",
-      "amplitude": 0.24187346458430722,
-      "phase": 298.4597337857105
+      "amplitude": 0.242,
+      "phase": 298.46
     },
     {
       "name": "S2",
-      "amplitude": 0.40109945928249463,
-      "phase": 34.622002940469656
+      "amplitude": 0.401,
+      "phase": 34.62
     },
     {
       "name": "K2",
-      "amplitude": 0.11934637668779348,
-      "phase": 32.15133917097427
+      "amplitude": 0.119,
+      "phase": 32.15
     },
     {
       "name": "2N2",
-      "amplitude": 0.02667165027995631,
-      "phase": 279.4532539262982
+      "amplitude": 0.027,
+      "phase": 279.45
     },
     {
       "name": "S1",
-      "amplitude": 0.012094084629284494,
-      "phase": 26.03049165173394
+      "amplitude": 0.012,
+      "phase": 26.03
     },
     {
       "name": "K1",
-      "amplitude": 0.07185391343246543,
-      "phase": 26.875082807683555
+      "amplitude": 0.072,
+      "phase": 26.88
     },
     {
       "name": "P1",
-      "amplitude": 0.030249604115469158,
-      "phase": 33.50447267405565
+      "amplitude": 0.03,
+      "phase": 33.5
     },
     {
       "name": "O1",
-      "amplitude": 0.09335243568012633,
-      "phase": 237.12731909147715
+      "amplitude": 0.093,
+      "phase": 237.13
     },
     {
       "name": "Q1",
-      "amplitude": 0.029254803862865084,
-      "phase": 179.44250800543887
+      "amplitude": 0.029,
+      "phase": 179.44
     },
     {
       "name": "M1",
-      "amplitude": 0.001729228200553096,
-      "phase": 91.85909794339858
+      "amplitude": 0.002,
+      "phase": 91.86
     },
     {
       "name": "M4",
-      "amplitude": 0.056116297026996824,
-      "phase": 128.2879041735972
+      "amplitude": 0.056,
+      "phase": 128.29
     },
     {
       "name": "MM",
-      "amplitude": 0.023572754895736722,
-      "phase": 176.75946096641394
+      "amplitude": 0.024,
+      "phase": 176.76
     },
     {
       "name": "MF",
-      "amplitude": 0.010485932975714802,
-      "phase": 179.27788864419063
+      "amplitude": 0.01,
+      "phase": 179.28
     },
     {
       "name": "SA",
-      "amplitude": 0.10183783579611409,
-      "phase": 222.46260223767212
+      "amplitude": 0.102,
+      "phase": 222.46
     },
     {
       "name": "SSA",
-      "amplitude": 0.036370124495204104,
-      "phase": 206.70727593649812
+      "amplitude": 0.036,
+      "phase": 206.71
     },
     {
       "name": "T2",
-      "amplitude": 0.022163304895002046,
-      "phase": 9.398632841464973
+      "amplitude": 0.022,
+      "phase": 9.4
     },
     {
       "name": "J1",
-      "amplitude": 0.0019477458251056503,
-      "phase": 149.57638800613688
+      "amplitude": 0.002,
+      "phase": 149.58
     },
     {
       "name": "L2",
-      "amplitude": 0.12411298320576407,
-      "phase": 340.49849796628445
+      "amplitude": 0.124,
+      "phase": 340.5
     },
     {
       "name": "R2",
-      "amplitude": 0.0024715643646880947,
-      "phase": 311.63032300011577
+      "amplitude": 0.002,
+      "phase": 311.63
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005953891151077429,
-      "phase": 123.20917580997752
+      "amplitude": 0.006,
+      "phase": 123.21
     },
     {
       "name": "MSF",
-      "amplitude": 0.002158842359640231,
-      "phase": 357.3354861801899
+      "amplitude": 0.002,
+      "phase": 357.34
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008585956537501247,
-      "phase": 65.92660467555095
+      "amplitude": 0.009,
+      "phase": 65.93
     },
     {
       "name": "EP2",
-      "amplitude": 0.03499625971100498,
-      "phase": 25.965898063174734
+      "amplitude": 0.035,
+      "phase": 25.97
     },
     {
       "name": "M3",
-      "amplitude": 0.0044655908276737466,
-      "phase": 351.8185437554288
+      "amplitude": 0.004,
+      "phase": 351.82
     },
     {
       "name": "MU2",
-      "amplitude": 0.15784342444028773,
-      "phase": 48.65873260339447
+      "amplitude": 0.158,
+      "phase": 48.66
     },
     {
       "name": "MTM",
-      "amplitude": 0.005137038292819564,
-      "phase": 241.15287480667678
+      "amplitude": 0.005,
+      "phase": 241.15
     },
     {
       "name": "NU2",
-      "amplitude": 0.08848661518189217,
-      "phase": 281.2843075127725
+      "amplitude": 0.088,
+      "phase": 281.28
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05922819503186777,
-      "phase": 335.36078261202124
+      "amplitude": 0.059,
+      "phase": 335.36
     },
     {
       "name": "MN4",
-      "amplitude": 0.017466787073405213,
-      "phase": 116.87124084868475
+      "amplitude": 0.017,
+      "phase": 116.87
     },
     {
       "name": "MS4",
-      "amplitude": 0.04720465424280636,
-      "phase": 210.1702606529203
+      "amplitude": 0.047,
+      "phase": 210.17
     },
     {
       "name": "N4",
-      "amplitude": 0.004565955819718211,
-      "phase": 103.02332181811028
+      "amplitude": 0.005,
+      "phase": 103.02
     },
     {
       "name": "M6",
-      "amplitude": 0.06061606615706121,
-      "phase": 335.42114323865457
+      "amplitude": 0.061,
+      "phase": 335.42
     },
     {
       "name": "M8",
-      "amplitude": 0.008527532268570701,
-      "phase": 176.89369636277502
+      "amplitude": 0.009,
+      "phase": 176.89
     },
     {
       "name": "S4",
-      "amplitude": 0.008937372767184386,
-      "phase": 340.61057176547325
+      "amplitude": 0.009,
+      "phase": 340.61
     },
     {
       "name": "OO1",
-      "amplitude": 0.0024055493352173186,
-      "phase": 193.38334416195408
+      "amplitude": 0.002,
+      "phase": 193.38
     },
     {
       "name": "S3",
-      "amplitude": 0.00042208872644889197,
-      "phase": 221.26258035838202
+      "amplitude": 0,
+      "phase": 221.26
     },
     {
       "name": "MA2",
-      "amplitude": 0.05691770964586874,
-      "phase": 274.6431766607825
+      "amplitude": 0.057,
+      "phase": 274.64
     },
     {
       "name": "MB2",
-      "amplitude": 0.017862701095223612,
-      "phase": 32.663618442365475
+      "amplitude": 0.018,
+      "phase": 32.66
     },
     {
       "name": "T3",
-      "amplitude": 0.0003606779223600032,
-      "phase": 54.932577504404094
+      "amplitude": 0,
+      "phase": 54.93
     },
     {
       "name": "R3",
-      "amplitude": 0.0034742433883382454,
-      "phase": 34.93422476350145
+      "amplitude": 0.003,
+      "phase": 34.93
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005800099034362909,
-      "phase": 184.96253279660127
+      "amplitude": 0.006,
+      "phase": 184.96
     },
     {
       "name": "SGM",
-      "amplitude": 0.002098154119883177,
-      "phase": 51.789716535233595
+      "amplitude": 0.002,
+      "phase": 51.79
     },
     {
       "name": "3L2",
-      "amplitude": 0.004349264766266416,
-      "phase": 236.97865380364664
+      "amplitude": 0.004,
+      "phase": 236.98
     },
     {
       "name": "3N2",
-      "amplitude": 0.019729608351943886,
-      "phase": 128.6466860459779
+      "amplitude": 0.02,
+      "phase": 128.65
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04007030740011489,
-      "phase": 255.79226147096188
+      "amplitude": 0.04,
+      "phase": 255.79
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06324866872372956,
-      "phase": 40.134140487953005
+      "amplitude": 0.063,
+      "phase": 40.13
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005331376101251276,
-      "phase": 350.9815964957224
+      "amplitude": 0.005,
+      "phase": 350.98
     },
     {
       "name": "2MO5",
-      "amplitude": 0.002856522002569241,
-      "phase": 208.13474347127686
+      "amplitude": 0.003,
+      "phase": 208.13
     }
   ],
   "epoch": {

--- a/data/ticon/eckernfrde-9610045-deu-wsv.json
+++ b/data/ticon/eckernfrde-9610045-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.046784264852749925,
-      "phase": 110.35111581172822
+      "amplitude": 0.047,
+      "phase": 110.35
     },
     {
       "name": "N2",
-      "amplitude": 0.01361060902022951,
-      "phase": 58.45682081285503
+      "amplitude": 0.014,
+      "phase": 58.46
     },
     {
       "name": "S2",
-      "amplitude": 0.012377202666457284,
-      "phase": 50.79183288995017
+      "amplitude": 0.012,
+      "phase": 50.79
     },
     {
       "name": "K2",
-      "amplitude": 0.003078713685732897,
-      "phase": 28.78489836617672
+      "amplitude": 0.003,
+      "phase": 28.78
     },
     {
       "name": "2N2",
-      "amplitude": 0.0019713772490066337,
-      "phase": 25.538537651204024
+      "amplitude": 0.002,
+      "phase": 25.54
     },
     {
       "name": "S1",
-      "amplitude": 0.007452814584803393,
-      "phase": 187.14470593907794
+      "amplitude": 0.007,
+      "phase": 187.14
     },
     {
       "name": "K1",
-      "amplitude": 0.01997456802675805,
-      "phase": 211.31510901955863
+      "amplitude": 0.02,
+      "phase": 211.32
     },
     {
       "name": "P1",
-      "amplitude": 0.00771862600072965,
-      "phase": 244.45189588094672
+      "amplitude": 0.008,
+      "phase": 244.45
     },
     {
       "name": "O1",
-      "amplitude": 0.017346754416468733,
-      "phase": 105.22424193358671
+      "amplitude": 0.017,
+      "phase": 105.22
     },
     {
       "name": "Q1",
-      "amplitude": 0.0050309663956105595,
-      "phase": 308.15137729728303
+      "amplitude": 0.005,
+      "phase": 308.15
     },
     {
       "name": "M1",
-      "amplitude": 0.0001576915922486422,
-      "phase": 151.67187463332232
+      "amplitude": 0,
+      "phase": 151.67
     },
     {
       "name": "M4",
-      "amplitude": 0.0022016880510940555,
-      "phase": 192.47631690791553
+      "amplitude": 0.002,
+      "phase": 192.48
     },
     {
       "name": "MM",
-      "amplitude": 0.011702701757823987,
-      "phase": 295.4368837153342
+      "amplitude": 0.012,
+      "phase": 295.44
     },
     {
       "name": "MF",
-      "amplitude": 0.011008251179287224,
-      "phase": 248.70502121317782
+      "amplitude": 0.011,
+      "phase": 248.71
     },
     {
       "name": "SA",
-      "amplitude": 0.03334190394231737,
-      "phase": 174.24607544520688
+      "amplitude": 0.033,
+      "phase": 174.25
     },
     {
       "name": "SSA",
-      "amplitude": 0.013602886792720788,
-      "phase": 282.5011906694475
+      "amplitude": 0.014,
+      "phase": 282.5
     },
     {
       "name": "T2",
-      "amplitude": 0.0009731853084589554,
-      "phase": 55.87594490400636
+      "amplitude": 0.001,
+      "phase": 55.88
     },
     {
       "name": "J1",
-      "amplitude": 0.0010970889526428873,
-      "phase": 133.58560549193191
+      "amplitude": 0.001,
+      "phase": 133.59
     },
     {
       "name": "L2",
-      "amplitude": 0.004611109026509889,
-      "phase": 210.42987943520268
+      "amplitude": 0.005,
+      "phase": 210.43
     },
     {
       "name": "R2",
-      "amplitude": 0.001016379050939279,
-      "phase": 127.60820515290607
+      "amplitude": 0.001,
+      "phase": 127.61
     },
     {
       "name": "2Q1",
-      "amplitude": 0.001415910206951877,
-      "phase": 274.299742105557
+      "amplitude": 0.001,
+      "phase": 274.3
     },
     {
       "name": "MSF",
-      "amplitude": 0.0030095539016289324,
-      "phase": 231.03953488936727
+      "amplitude": 0.003,
+      "phase": 231.04
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004678778890013126,
-      "phase": 217.66124859719994
+      "amplitude": 0.005,
+      "phase": 217.66
     },
     {
       "name": "EP2",
-      "amplitude": 0.002711980699020654,
-      "phase": 238.7653168993835
+      "amplitude": 0.003,
+      "phase": 238.77
     },
     {
       "name": "M3",
-      "amplitude": 0.0005789270843821171,
-      "phase": 325.5124092779522
+      "amplitude": 0.001,
+      "phase": 325.51
     },
     {
       "name": "MU2",
-      "amplitude": 0.011709591376180368,
-      "phase": 279.6055554404476
+      "amplitude": 0.012,
+      "phase": 279.61
     },
     {
       "name": "MTM",
-      "amplitude": 0.003776290057696305,
-      "phase": 343.0583254927686
+      "amplitude": 0.004,
+      "phase": 343.06
     },
     {
       "name": "NU2",
-      "amplitude": 0.004834361814588219,
-      "phase": 95.96041164900475
+      "amplitude": 0.005,
+      "phase": 95.96
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0026390120427533465,
-      "phase": 203.9853090841882
+      "amplitude": 0.003,
+      "phase": 203.99
     },
     {
       "name": "MN4",
-      "amplitude": 0.000627539264980297,
-      "phase": 139.1379103186855
+      "amplitude": 0.001,
+      "phase": 139.14
     },
     {
       "name": "MS4",
-      "amplitude": 0.0004531098298179897,
-      "phase": 339.0887982793566
+      "amplitude": 0,
+      "phase": 339.09
     },
     {
       "name": "N4",
-      "amplitude": 0.000094486753800356,
-      "phase": 116.63546510904439
+      "amplitude": 0,
+      "phase": 116.64
     },
     {
       "name": "M6",
-      "amplitude": 0.0002842655804750875,
-      "phase": 299.96548974440617
+      "amplitude": 0,
+      "phase": 299.97
     },
     {
       "name": "M8",
-      "amplitude": 0.00001898555039771274,
-      "phase": 103.25284666873551
+      "amplitude": 0,
+      "phase": 103.25
     },
     {
       "name": "S4",
-      "amplitude": 0.0002592656664734445,
-      "phase": 284.71279671048393
+      "amplitude": 0,
+      "phase": 284.71
     },
     {
       "name": "OO1",
-      "amplitude": 0.0017141796111589459,
-      "phase": 125.09157441761602
+      "amplitude": 0.002,
+      "phase": 125.09
     },
     {
       "name": "S3",
-      "amplitude": 0.00021070016631492575,
-      "phase": 192.35467015077296
+      "amplitude": 0,
+      "phase": 192.35
     },
     {
       "name": "MA2",
-      "amplitude": 0.006770821513211889,
-      "phase": 100.48598995000754
+      "amplitude": 0.007,
+      "phase": 100.49
     },
     {
       "name": "MB2",
-      "amplitude": 0.0070508852499621385,
-      "phase": 263.930658512133
+      "amplitude": 0.007,
+      "phase": 263.93
     },
     {
       "name": "T3",
-      "amplitude": 0.00017721526196326425,
-      "phase": 174.36130485258536
+      "amplitude": 0,
+      "phase": 174.36
     },
     {
       "name": "R3",
-      "amplitude": 0.00024165608330703388,
-      "phase": 258.02259955088346
+      "amplitude": 0,
+      "phase": 258.02
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0009131255355920512,
-      "phase": 277.1734251120073
+      "amplitude": 0.001,
+      "phase": 277.17
     },
     {
       "name": "SGM",
-      "amplitude": 0.0030883615442480554,
-      "phase": 215.599265789513
+      "amplitude": 0.003,
+      "phase": 215.6
     },
     {
       "name": "3L2",
-      "amplitude": 0.0004980453876301282,
-      "phase": 353.45712566279957
+      "amplitude": 0,
+      "phase": 353.46
     },
     {
       "name": "3N2",
-      "amplitude": 0.0014373725249995563,
-      "phase": 20.552106116854986
+      "amplitude": 0.001,
+      "phase": 20.55
     },
     {
       "name": "2SM2",
-      "amplitude": 0.001825834179841081,
-      "phase": 168.0574817632562
+      "amplitude": 0.002,
+      "phase": 168.06
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00033520153939429977,
-      "phase": 358.16960474687056
+      "amplitude": 0,
+      "phase": 358.17
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0001533735544564907,
-      "phase": 121.9694390068882
+      "amplitude": 0,
+      "phase": 121.97
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0001730760802306025,
-      "phase": 259.37173819815996
+      "amplitude": 0,
+      "phase": 259.37
     }
   ],
   "epoch": {

--- a/data/ticon/eemshaven-eemshvn-nld-rws.json
+++ b/data/ticon/eemshaven-eemshvn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.14733727,
-      "phase": 300.004462
+      "amplitude": 1.192,
+      "phase": 283.86
     },
     {
       "name": "N2",
-      "amplitude": 0.17744765999999998,
-      "phase": 275.389904
+      "amplitude": 0.187,
+      "phase": 259.67
     },
     {
       "name": "S2",
-      "amplitude": 0.29714023,
-      "phase": 7.16491000000002
+      "amplitude": 0.305,
+      "phase": 350.81
     },
     {
       "name": "K2",
-      "amplitude": 0.08697938000000001,
-      "phase": 8.719313
+      "amplitude": 0.09,
+      "phase": 349.74
     },
     {
       "name": "2N2",
-      "amplitude": 0.02973173,
-      "phase": 237.881483
+      "amplitude": 0.032,
+      "phase": 229.37
     },
     {
       "name": "S1",
-      "amplitude": 0.01006248,
-      "phase": 51.527964
+      "amplitude": 0.009,
+      "phase": 354.71
     },
     {
       "name": "K1",
-      "amplitude": 0.06973406,
-      "phase": 23.098950000000002
+      "amplitude": 0.07,
+      "phase": 14.56
     },
     {
       "name": "P1",
-      "amplitude": 0.030220220000000002,
-      "phase": 24.02167700000001
+      "amplitude": 0.031,
+      "phase": 16.78
     },
     {
       "name": "O1",
-      "amplitude": 0.08980373999999999,
-      "phase": 227.550586
+      "amplitude": 0.09,
+      "phase": 220.44
     },
     {
       "name": "Q1",
-      "amplitude": 0.0329761,
-      "phase": 173.15131199999996
+      "amplitude": 0.033,
+      "phase": 166.15
     },
     {
       "name": "M1",
-      "amplitude": 0.00133925,
-      "phase": 216.133479
+      "amplitude": 0.002,
+      "phase": 9.3
     },
     {
       "name": "M4",
-      "amplitude": 0.0757476,
-      "phase": 77.60612000000003
+      "amplitude": 0.09,
+      "phase": 44.55
     },
     {
       "name": "MM",
-      "amplitude": 0.012812269999999999,
-      "phase": 138.704563
+      "amplitude": 0.013,
+      "phase": 136.74
     },
     {
       "name": "MF",
-      "amplitude": 0.00863846,
-      "phase": 172.76372300000003
+      "amplitude": 0.009,
+      "phase": 175.95
     },
     {
       "name": "SA",
-      "amplitude": 0.10657306,
-      "phase": 219.17849
+      "amplitude": 0.116,
+      "phase": 219.53
     },
     {
       "name": "SSA",
-      "amplitude": 0.03365891,
-      "phase": 199.801978
+      "amplitude": 0.033,
+      "phase": 189.87
     },
     {
       "name": "T2",
-      "amplitude": 0.06077499,
-      "phase": 284.281311
+      "amplitude": 0.014,
+      "phase": 317.17
     },
     {
       "name": "J1",
-      "amplitude": 0.00315389,
-      "phase": 94.72004200000003
+      "amplitude": 0.003,
+      "phase": 93.02
     },
     {
       "name": "L2",
-      "amplitude": 0.0858792,
-      "phase": 319.400225
+      "amplitude": 0.09,
+      "phase": 301.98
     },
     {
       "name": "R2",
-      "amplitude": 0.03129291,
-      "phase": 107.22141199999999
+      "amplitude": 0.002,
+      "phase": 266.3
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00879612,
-      "phase": 100.11371400000002
+      "amplitude": 0.009,
+      "phase": 99.28
     },
     {
       "name": "MSF",
-      "amplitude": 0.027795040000000003,
-      "phase": 34.873243
+      "amplitude": 0.028,
+      "phase": 35.61
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0077658499999999995,
-      "phase": 6.492718000000025
+      "amplitude": 0.007,
+      "phase": 7.61
     },
     {
       "name": "EP2",
-      "amplitude": 0.01862204,
-      "phase": 9.105214999999987
+      "amplitude": 0.02,
+      "phase": 348.75
     },
     {
       "name": "M3",
-      "amplitude": 0.00327169,
-      "phase": 100.27940899999999
+      "amplitude": 0.004,
+      "phase": 261.13
     },
     {
       "name": "MU2",
-      "amplitude": 0.11701147,
-      "phase": 33.27608299999997
+      "amplitude": 0.119,
+      "phase": 17.06
     },
     {
       "name": "MTM",
-      "amplitude": 0.01851557,
-      "phase": 264.95385
+      "amplitude": 0.019,
+      "phase": 258.43
     },
     {
       "name": "NU2",
-      "amplitude": 0.06822326000000001,
-      "phase": 266.43382099999997
+      "amplitude": 0.072,
+      "phase": 245.62
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.041673840000000004,
-      "phase": 310.034756
+      "amplitude": 0.045,
+      "phase": 294.18
     },
     {
       "name": "MN4",
-      "amplitude": 0.02268405,
-      "phase": 53.90799800000002
+      "amplitude": 0.027,
+      "phase": 20.78
     },
     {
       "name": "MS4",
-      "amplitude": 0.05056109,
-      "phase": 148.18458699999996
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.030661800000000003,
-      "phase": 98.195583
+      "amplitude": 0.059,
+      "phase": 117.78
     },
     {
       "name": "N4",
-      "amplitude": 0.00679148,
-      "phase": 14.593255999999997
+      "amplitude": 0.009,
+      "phase": 345.02
     },
     {
       "name": "M6",
-      "amplitude": 0.03281585,
-      "phase": 265.687976
+      "amplitude": 0.049,
+      "phase": 212.02
     },
     {
       "name": "M8",
-      "amplitude": 0.00553373,
-      "phase": 78.37260700000002
+      "amplitude": 0.012,
+      "phase": 1.26
     },
     {
       "name": "S4",
-      "amplitude": 0.00662957,
-      "phase": 273.37021400000003
+      "amplitude": 0.006,
+      "phase": 249.11
     },
     {
       "name": "OO1",
-      "amplitude": 0.00284495,
-      "phase": 140.606016
+      "amplitude": 0.003,
+      "phase": 127.2
     },
     {
       "name": "S3",
-      "amplitude": 0.00092205,
-      "phase": 116.532467
+      "amplitude": 0,
+      "phase": 310.46
     },
     {
       "name": "MA2",
-      "amplitude": 0.23340175,
-      "phase": 279.941864
+      "amplitude": 0.052,
+      "phase": 252.21
     },
     {
       "name": "MB2",
-      "amplitude": 0.18653224999999998,
-      "phase": 128.14892399999997
+      "amplitude": 0.015,
+      "phase": 19.31
     },
     {
       "name": "T3",
-      "amplitude": 0.00112211,
-      "phase": 218.768011
+      "amplitude": 0.001,
+      "phase": 14.54
     },
     {
       "name": "R3",
-      "amplitude": 0.0040098600000000005,
-      "phase": 277.29042300000003
+      "amplitude": 0.004,
+      "phase": 337.48
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00670426,
-      "phase": 148.473473
+      "amplitude": 0.007,
+      "phase": 148.36
     },
     {
       "name": "SGM",
-      "amplitude": 0.00373245,
-      "phase": 271.130303
+      "amplitude": 0.003,
+      "phase": 95.37
     },
     {
       "name": "3L2",
-      "amplitude": 0.00867591,
-      "phase": 127.52439099999998
+      "amplitude": 0.011,
+      "phase": 209.46
     },
     {
       "name": "3N2",
-      "amplitude": 0.00275217,
-      "phase": 75.99332800000002
+      "amplitude": 0.012,
+      "phase": 121.88
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02605951,
-      "phase": 223.268
+      "amplitude": 0.027,
+      "phase": 212.19
     },
     {
       "name": "2MS6",
-      "amplitude": 0.03153164,
-      "phase": 327.49881700000003
+      "amplitude": 0.046,
+      "phase": 275.28
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0041756,
-      "phase": 201.698333
+      "amplitude": 0.005,
+      "phase": 239.1
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0021442600000000003,
-      "phase": 236.164516
+      "amplitude": 0.003,
+      "phase": 105.79
     }
   ],
   "epoch": {

--- a/data/ticon/eidersperrwerkap-9530010-deu-wsv.json
+++ b/data/ticon/eidersperrwerkap-9530010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3678306275560383,
-      "phase": 348.3958948045007
+      "amplitude": 1.368,
+      "phase": 348.4
     },
     {
       "name": "N2",
-      "amplitude": 0.2181928812517053,
-      "phase": 323.13780056334184
+      "amplitude": 0.218,
+      "phase": 323.14
     },
     {
       "name": "S2",
-      "amplitude": 0.35116870082326335,
-      "phase": 59.99034012738787
+      "amplitude": 0.351,
+      "phase": 59.99
     },
     {
       "name": "K2",
-      "amplitude": 0.1045752395230405,
-      "phase": 58.86019090747163
+      "amplitude": 0.105,
+      "phase": 58.86
     },
     {
       "name": "2N2",
-      "amplitude": 0.023601265880070273,
-      "phase": 298.91300131006415
+      "amplitude": 0.024,
+      "phase": 298.91
     },
     {
       "name": "S1",
-      "amplitude": 0.010670021566011644,
-      "phase": 18.33286296163709
+      "amplitude": 0.011,
+      "phase": 18.33
     },
     {
       "name": "K1",
-      "amplitude": 0.07447593309918078,
-      "phase": 48.0166554783508
+      "amplitude": 0.074,
+      "phase": 48.02
     },
     {
       "name": "P1",
-      "amplitude": 0.031254314941719305,
-      "phase": 47.397335176185834
+      "amplitude": 0.031,
+      "phase": 47.4
     },
     {
       "name": "O1",
-      "amplitude": 0.09367789115984979,
-      "phase": 256.1046386543852
+      "amplitude": 0.094,
+      "phase": 256.1
     },
     {
       "name": "Q1",
-      "amplitude": 0.028810023515317817,
-      "phase": 196.00865518712294
+      "amplitude": 0.029,
+      "phase": 196.01
     },
     {
       "name": "M1",
-      "amplitude": 0.0020353112772471,
-      "phase": 100.92418062313692
+      "amplitude": 0.002,
+      "phase": 100.92
     },
     {
       "name": "M4",
-      "amplitude": 0.14981700888570684,
-      "phase": 202.7897071483166
+      "amplitude": 0.15,
+      "phase": 202.79
     },
     {
       "name": "MM",
-      "amplitude": 0.025958032994922147,
-      "phase": 143.02428030555598
+      "amplitude": 0.026,
+      "phase": 143.02
     },
     {
       "name": "MF",
-      "amplitude": 0.018227121654929703,
-      "phase": 111.58080143086727
+      "amplitude": 0.018,
+      "phase": 111.58
     },
     {
       "name": "SA",
-      "amplitude": 0.12162226532511132,
-      "phase": 226.1552342131008
+      "amplitude": 0.122,
+      "phase": 226.16
     },
     {
       "name": "SSA",
-      "amplitude": 0.06542953631963919,
-      "phase": 220.3211510518545
+      "amplitude": 0.065,
+      "phase": 220.32
     },
     {
       "name": "T2",
-      "amplitude": 0.020187186144094895,
-      "phase": 48.98127077778753
+      "amplitude": 0.02,
+      "phase": 48.98
     },
     {
       "name": "J1",
-      "amplitude": 0.004781820697880493,
-      "phase": 180.49232821554068
+      "amplitude": 0.005,
+      "phase": 180.49
     },
     {
       "name": "L2",
-      "amplitude": 0.11223390109755325,
-      "phase": 5.274504435862241
+      "amplitude": 0.112,
+      "phase": 5.27
     },
     {
       "name": "R2",
-      "amplitude": 0.006311931014839301,
-      "phase": 47.25047396737608
+      "amplitude": 0.006,
+      "phase": 47.25
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005534342153506468,
-      "phase": 133.17860016236796
+      "amplitude": 0.006,
+      "phase": 133.18
     },
     {
       "name": "MSF",
-      "amplitude": 0.046024416877493896,
-      "phase": 56.72346831751054
+      "amplitude": 0.046,
+      "phase": 56.72
     },
     {
       "name": "MSQM",
-      "amplitude": 0.011516464501427685,
-      "phase": 19.69184220452661
+      "amplitude": 0.012,
+      "phase": 19.69
     },
     {
       "name": "EP2",
-      "amplitude": 0.03185981018027061,
-      "phase": 54.46615030414148
+      "amplitude": 0.032,
+      "phase": 54.47
     },
     {
       "name": "M3",
-      "amplitude": 0.003462842094017528,
-      "phase": 9.359412234864408
+      "amplitude": 0.003,
+      "phase": 9.36
     },
     {
       "name": "MU2",
-      "amplitude": 0.14631293709371032,
-      "phase": 73.82845274226167
+      "amplitude": 0.146,
+      "phase": 73.83
     },
     {
       "name": "MTM",
-      "amplitude": 0.002827597089541176,
-      "phase": 231.48061303951417
+      "amplitude": 0.003,
+      "phase": 231.48
     },
     {
       "name": "NU2",
-      "amplitude": 0.077758068397792,
-      "phase": 304.13630253393217
+      "amplitude": 0.078,
+      "phase": 304.14
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.050147007207615654,
-      "phase": 0.7955107641003565
+      "amplitude": 0.05,
+      "phase": 0.8
     },
     {
       "name": "MN4",
-      "amplitude": 0.05050625432974186,
-      "phase": 180.14254629292606
+      "amplitude": 0.051,
+      "phase": 180.14
     },
     {
       "name": "MS4",
-      "amplitude": 0.0960729664848128,
-      "phase": 273.9963840662839
+      "amplitude": 0.096,
+      "phase": 274
     },
     {
       "name": "N4",
-      "amplitude": 0.010851085270678858,
-      "phase": 164.707369793545
+      "amplitude": 0.011,
+      "phase": 164.71
     },
     {
       "name": "M6",
-      "amplitude": 0.06010033088111186,
-      "phase": 68.41890907483247
+      "amplitude": 0.06,
+      "phase": 68.42
     },
     {
       "name": "M8",
-      "amplitude": 0.028564704327971747,
-      "phase": 310.34614034219794
+      "amplitude": 0.029,
+      "phase": 310.35
     },
     {
       "name": "S4",
-      "amplitude": 0.010638954202649155,
-      "phase": 37.05081515915771
+      "amplitude": 0.011,
+      "phase": 37.05
     },
     {
       "name": "OO1",
-      "amplitude": 0.0023203451907184863,
-      "phase": 185.72895677726177
+      "amplitude": 0.002,
+      "phase": 185.73
     },
     {
       "name": "S3",
-      "amplitude": 0.0036139713802655848,
-      "phase": 181.6355185376478
+      "amplitude": 0.004,
+      "phase": 181.64
     },
     {
       "name": "MA2",
-      "amplitude": 0.03559528337502161,
-      "phase": 300.69578597484997
+      "amplitude": 0.036,
+      "phase": 300.7
     },
     {
       "name": "MB2",
-      "amplitude": 0.02603932224130147,
-      "phase": 89.24964746166523
+      "amplitude": 0.026,
+      "phase": 89.25
     },
     {
       "name": "T3",
-      "amplitude": 0.00046610802556493246,
-      "phase": 318.5104866182327
+      "amplitude": 0,
+      "phase": 318.51
     },
     {
       "name": "R3",
-      "amplitude": 0.0046338349409203415,
-      "phase": 22.51408803835119
+      "amplitude": 0.005,
+      "phase": 22.51
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005924923046879236,
-      "phase": 198.50583618280422
+      "amplitude": 0.006,
+      "phase": 198.51
     },
     {
       "name": "SGM",
-      "amplitude": 0.0030421300581841607,
-      "phase": 71.27382962930108
+      "amplitude": 0.003,
+      "phase": 71.27
     },
     {
       "name": "3L2",
-      "amplitude": 0.003128500377448272,
-      "phase": 308.9352522868121
+      "amplitude": 0.003,
+      "phase": 308.94
     },
     {
       "name": "3N2",
-      "amplitude": 0.018369802814437175,
-      "phase": 157.64905292536696
+      "amplitude": 0.018,
+      "phase": 157.65
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03587582287814671,
-      "phase": 285.80768831493907
+      "amplitude": 0.036,
+      "phase": 285.81
     },
     {
       "name": "2MS6",
-      "amplitude": 0.061068593695632445,
-      "phase": 132.01709038631088
+      "amplitude": 0.061,
+      "phase": 132.02
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004359134882845298,
-      "phase": 96.46054963932909
+      "amplitude": 0.004,
+      "phase": 96.46
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006234018265520993,
-      "phase": 354.6538605587034
+      "amplitude": 0.006,
+      "phase": 354.65
     }
   ],
   "epoch": {

--- a/data/ticon/eidersperrwerkbp-9520081-deu-wsv.json
+++ b/data/ticon/eidersperrwerkbp-9520081-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.0618885267901945,
-      "phase": 6.0239077290534055
+      "amplitude": 1.062,
+      "phase": 6.02
     },
     {
       "name": "N2",
-      "amplitude": 0.16948379874865052,
-      "phase": 341.873817875644
+      "amplitude": 0.169,
+      "phase": 341.87
     },
     {
       "name": "S2",
-      "amplitude": 0.2808914224057049,
-      "phase": 82.8113470095571
+      "amplitude": 0.281,
+      "phase": 82.81
     },
     {
       "name": "K2",
-      "amplitude": 0.08485448083915777,
-      "phase": 80.6449240092333
+      "amplitude": 0.085,
+      "phase": 80.64
     },
     {
       "name": "2N2",
-      "amplitude": 0.022710949429698462,
-      "phase": 331.73949095756075
+      "amplitude": 0.023,
+      "phase": 331.74
     },
     {
       "name": "S1",
-      "amplitude": 0.021303634222819515,
-      "phase": 307.9881199760763
+      "amplitude": 0.021,
+      "phase": 307.99
     },
     {
       "name": "K1",
-      "amplitude": 0.06354881593142048,
-      "phase": 43.97147243234457
+      "amplitude": 0.064,
+      "phase": 43.97
     },
     {
       "name": "P1",
-      "amplitude": 0.03118964899487665,
-      "phase": 32.30069742096953
+      "amplitude": 0.031,
+      "phase": 32.3
     },
     {
       "name": "O1",
-      "amplitude": 0.08206239137478677,
-      "phase": 260.59196605773377
+      "amplitude": 0.082,
+      "phase": 260.59
     },
     {
       "name": "Q1",
-      "amplitude": 0.023266957008633626,
-      "phase": 208.6525752099871
+      "amplitude": 0.023,
+      "phase": 208.65
     },
     {
       "name": "M1",
-      "amplitude": 0.0009542116657803182,
-      "phase": 137.52774831739532
+      "amplitude": 0.001,
+      "phase": 137.53
     },
     {
       "name": "M4",
-      "amplitude": 0.1029155745148261,
-      "phase": 203.40739390948312
+      "amplitude": 0.103,
+      "phase": 203.41
     },
     {
       "name": "MM",
-      "amplitude": 0.02675671875324611,
-      "phase": 141.674661934641
+      "amplitude": 0.027,
+      "phase": 141.67
     },
     {
       "name": "MF",
-      "amplitude": 0.01186557272446478,
-      "phase": 151.2678841606941
+      "amplitude": 0.012,
+      "phase": 151.27
     },
     {
       "name": "SA",
-      "amplitude": 0.129469497850235,
-      "phase": 136.553911991198
+      "amplitude": 0.129,
+      "phase": 136.55
     },
     {
       "name": "SSA",
-      "amplitude": 0.009214415609565646,
-      "phase": 55.70480974907491
+      "amplitude": 0.009,
+      "phase": 55.7
     },
     {
       "name": "T2",
-      "amplitude": 0.010450740896177712,
-      "phase": 26.824889009628123
+      "amplitude": 0.01,
+      "phase": 26.82
     },
     {
       "name": "J1",
-      "amplitude": 0.0038441872869348238,
-      "phase": 170.72461905335592
+      "amplitude": 0.004,
+      "phase": 170.72
     },
     {
       "name": "L2",
-      "amplitude": 0.08826651349093935,
-      "phase": 18.783199687192507
+      "amplitude": 0.088,
+      "phase": 18.78
     },
     {
       "name": "R2",
-      "amplitude": 0.0037627598592194773,
-      "phase": 34.55184964200248
+      "amplitude": 0.004,
+      "phase": 34.55
     },
     {
       "name": "2Q1",
-      "amplitude": 0.008296700890896088,
-      "phase": 176.7834310723165
+      "amplitude": 0.008,
+      "phase": 176.78
     },
     {
       "name": "MSF",
-      "amplitude": 0.031992738357145764,
-      "phase": 109.64297053982341
+      "amplitude": 0.032,
+      "phase": 109.64
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0031001311245485398,
-      "phase": 144.81124411784947
+      "amplitude": 0.003,
+      "phase": 144.81
     },
     {
       "name": "EP2",
-      "amplitude": 0.03583819727294524,
-      "phase": 74.43914331136193
+      "amplitude": 0.036,
+      "phase": 74.44
     },
     {
       "name": "M3",
-      "amplitude": 0.0008191150789189419,
-      "phase": 117.79261846478107
+      "amplitude": 0.001,
+      "phase": 117.79
     },
     {
       "name": "MU2",
-      "amplitude": 0.12455367934444182,
-      "phase": 85.9457123323636
+      "amplitude": 0.125,
+      "phase": 85.95
     },
     {
       "name": "MTM",
-      "amplitude": 0.010843396742544541,
-      "phase": 100.2891968172583
+      "amplitude": 0.011,
+      "phase": 100.29
     },
     {
       "name": "NU2",
-      "amplitude": 0.06494986124241418,
-      "phase": 328.432450018528
+      "amplitude": 0.065,
+      "phase": 328.43
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.038679850442776116,
-      "phase": 27.268079547191007
+      "amplitude": 0.039,
+      "phase": 27.27
     },
     {
       "name": "MN4",
-      "amplitude": 0.03238587343849072,
-      "phase": 179.00584397338423
+      "amplitude": 0.032,
+      "phase": 179.01
     },
     {
       "name": "MS4",
-      "amplitude": 0.06451580976872279,
-      "phase": 277.8913598329812
+      "amplitude": 0.065,
+      "phase": 277.89
     },
     {
       "name": "N4",
-      "amplitude": 0.006397007860474693,
-      "phase": 159.55495740546507
+      "amplitude": 0.006,
+      "phase": 159.55
     },
     {
       "name": "M6",
-      "amplitude": 0.023598896384397536,
-      "phase": 96.3079260066279
+      "amplitude": 0.024,
+      "phase": 96.31
     },
     {
       "name": "M8",
-      "amplitude": 0.006307925578432842,
-      "phase": 342.47429209890856
+      "amplitude": 0.006,
+      "phase": 342.47
     },
     {
       "name": "S4",
-      "amplitude": 0.00598692317782554,
-      "phase": 63.84415450559203
+      "amplitude": 0.006,
+      "phase": 63.84
     },
     {
       "name": "OO1",
-      "amplitude": 0.0038392155504028114,
-      "phase": 341.4507589445259
+      "amplitude": 0.004,
+      "phase": 341.45
     },
     {
       "name": "S3",
-      "amplitude": 0.005929711467258653,
-      "phase": 67.12539189760167
+      "amplitude": 0.006,
+      "phase": 67.13
     },
     {
       "name": "MA2",
-      "amplitude": 0.0731466868032074,
-      "phase": 292.7166402669311
+      "amplitude": 0.073,
+      "phase": 292.72
     },
     {
       "name": "MB2",
-      "amplitude": 0.05610839888419919,
-      "phase": 96.02821588119872
+      "amplitude": 0.056,
+      "phase": 96.03
     },
     {
       "name": "T3",
-      "amplitude": 0.0017067410800532912,
-      "phase": 248.036769262686
+      "amplitude": 0.002,
+      "phase": 248.04
     },
     {
       "name": "R3",
-      "amplitude": 0.003541741630750329,
-      "phase": 317.7498836809691
+      "amplitude": 0.004,
+      "phase": 317.75
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00502528314633859,
-      "phase": 206.1859261880705
+      "amplitude": 0.005,
+      "phase": 206.19
     },
     {
       "name": "SGM",
-      "amplitude": 0.009094478196188617,
-      "phase": 80.62907004077022
+      "amplitude": 0.009,
+      "phase": 80.63
     },
     {
       "name": "3L2",
-      "amplitude": 0.008540173702931798,
-      "phase": 283.5372374601986
+      "amplitude": 0.009,
+      "phase": 283.54
     },
     {
       "name": "3N2",
-      "amplitude": 0.004129226013751875,
-      "phase": 164.95200169414545
+      "amplitude": 0.004,
+      "phase": 164.95
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02982053439578841,
-      "phase": 298.2994565085833
+      "amplitude": 0.03,
+      "phase": 298.3
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02552922966390058,
-      "phase": 160.6631846004426
+      "amplitude": 0.026,
+      "phase": 160.66
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0010394732379855117,
-      "phase": 91.66402908411476
+      "amplitude": 0.001,
+      "phase": 91.66
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0019194576394163004,
-      "phase": 48.00617510195855
+      "amplitude": 0.002,
+      "phase": 48.01
     }
   ],
   "epoch": {

--- a/data/ticon/elmshornhafen-5970022-deu-wsv.json
+++ b/data/ticon/elmshornhafen-5970022-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.677528606500629,
-      "phase": 73.3671914411101
+      "amplitude": 0.678,
+      "phase": 73.37
     },
     {
       "name": "N2",
-      "amplitude": 0.10105302909209994,
-      "phase": 41.333547894543415
+      "amplitude": 0.101,
+      "phase": 41.33
     },
     {
       "name": "S2",
-      "amplitude": 0.16006124015677328,
-      "phase": 147.2792578768241
+      "amplitude": 0.16,
+      "phase": 147.28
     },
     {
       "name": "K2",
-      "amplitude": 0.04804400077413847,
-      "phase": 157.30020181124428
+      "amplitude": 0.048,
+      "phase": 157.3
     },
     {
       "name": "2N2",
-      "amplitude": 0.006564346149929558,
-      "phase": 20.13658577475121
+      "amplitude": 0.007,
+      "phase": 20.14
     },
     {
       "name": "S1",
-      "amplitude": 0.012539053374279515,
-      "phase": 85.84449092900195
+      "amplitude": 0.013,
+      "phase": 85.84
     },
     {
       "name": "K1",
-      "amplitude": 0.05344656788683335,
-      "phase": 113.07227832607117
+      "amplitude": 0.053,
+      "phase": 113.07
     },
     {
       "name": "P1",
-      "amplitude": 0.01759366698069113,
-      "phase": 93.64465903150312
+      "amplitude": 0.018,
+      "phase": 93.64
     },
     {
       "name": "O1",
-      "amplitude": 0.060051865266896265,
-      "phase": 312.450400790786
+      "amplitude": 0.06,
+      "phase": 312.45
     },
     {
       "name": "Q1",
-      "amplitude": 0.017507912420412733,
-      "phase": 248.292204715945
+      "amplitude": 0.018,
+      "phase": 248.29
     },
     {
       "name": "M1",
-      "amplitude": 0.0019967551264867844,
-      "phase": 139.47636954653217
+      "amplitude": 0.002,
+      "phase": 139.48
     },
     {
       "name": "M4",
-      "amplitude": 0.15467391322326338,
-      "phase": 124.14310485116778
+      "amplitude": 0.155,
+      "phase": 124.14
     },
     {
       "name": "MM",
-      "amplitude": 0.016222976395005785,
-      "phase": 82.607389811845
+      "amplitude": 0.016,
+      "phase": 82.61
     },
     {
       "name": "MF",
-      "amplitude": 0.016271067448987393,
-      "phase": 104.96147400759202
+      "amplitude": 0.016,
+      "phase": 104.96
     },
     {
       "name": "SA",
-      "amplitude": 0.13551187319121175,
-      "phase": 290.63269870762053
+      "amplitude": 0.136,
+      "phase": 290.63
     },
     {
       "name": "SSA",
-      "amplitude": 0.04913672342566956,
-      "phase": 251.84868085289168
+      "amplitude": 0.049,
+      "phase": 251.85
     },
     {
       "name": "T2",
-      "amplitude": 0.0038401095957173044,
-      "phase": 216.43062204545532
+      "amplitude": 0.004,
+      "phase": 216.43
     },
     {
       "name": "J1",
-      "amplitude": 0.006737701201834939,
-      "phase": 211.20471351577137
+      "amplitude": 0.007,
+      "phase": 211.2
     },
     {
       "name": "L2",
-      "amplitude": 0.06726054610179703,
-      "phase": 86.26028000691616
+      "amplitude": 0.067,
+      "phase": 86.26
     },
     {
       "name": "R2",
-      "amplitude": 0.009180683496443099,
-      "phase": 167.04090258128963
+      "amplitude": 0.009,
+      "phase": 167.04
     },
     {
       "name": "2Q1",
-      "amplitude": 0.002945243640440244,
-      "phase": 167.26690201656993
+      "amplitude": 0.003,
+      "phase": 167.27
     },
     {
       "name": "MSF",
-      "amplitude": 0.06423892369780256,
-      "phase": 64.21767788146519
+      "amplitude": 0.064,
+      "phase": 64.22
     },
     {
       "name": "MSQM",
-      "amplitude": 0.010635936169628848,
-      "phase": 262.4467181784506
+      "amplitude": 0.011,
+      "phase": 262.45
     },
     {
       "name": "EP2",
-      "amplitude": 0.0205680324526918,
-      "phase": 125.93161234605998
+      "amplitude": 0.021,
+      "phase": 125.93
     },
     {
       "name": "M3",
-      "amplitude": 0.0018885498721373647,
-      "phase": 177.10417210271441
+      "amplitude": 0.002,
+      "phase": 177.1
     },
     {
       "name": "MU2",
-      "amplitude": 0.07876327227519886,
-      "phase": 164.1525016922535
+      "amplitude": 0.079,
+      "phase": 164.15
     },
     {
       "name": "MTM",
-      "amplitude": 0.007393588160704054,
-      "phase": 221.57615452094015
+      "amplitude": 0.007,
+      "phase": 221.58
     },
     {
       "name": "NU2",
-      "amplitude": 0.044203556242078966,
-      "phase": 26.220409398948618
+      "amplitude": 0.044,
+      "phase": 26.22
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.025886852844052784,
-      "phase": 86.9195769815334
+      "amplitude": 0.026,
+      "phase": 86.92
     },
     {
       "name": "MN4",
-      "amplitude": 0.04748612711769201,
-      "phase": 96.12537975312057
+      "amplitude": 0.047,
+      "phase": 96.13
     },
     {
       "name": "MS4",
-      "amplitude": 0.070963387548795,
-      "phase": 195.03241408123964
+      "amplitude": 0.071,
+      "phase": 195.03
     },
     {
       "name": "N4",
-      "amplitude": 0.0076809852050652785,
-      "phase": 92.33199245883259
+      "amplitude": 0.008,
+      "phase": 92.33
     },
     {
       "name": "M6",
-      "amplitude": 0.015327119991840088,
-      "phase": 126.39849099860277
+      "amplitude": 0.015,
+      "phase": 126.4
     },
     {
       "name": "M8",
-      "amplitude": 0.0074635564512951875,
-      "phase": 357.2600795430329
+      "amplitude": 0.007,
+      "phase": 357.26
     },
     {
       "name": "S4",
-      "amplitude": 0.0026740490263340013,
-      "phase": 10.816451444467816
+      "amplitude": 0.003,
+      "phase": 10.82
     },
     {
       "name": "OO1",
-      "amplitude": 0.002339076396284138,
-      "phase": 238.1918901590567
+      "amplitude": 0.002,
+      "phase": 238.19
     },
     {
       "name": "S3",
-      "amplitude": 0.0010960703506475969,
-      "phase": 100.22101499050734
+      "amplitude": 0.001,
+      "phase": 100.22
     },
     {
       "name": "MA2",
-      "amplitude": 0.042189096491934294,
-      "phase": 314.76452380358756
+      "amplitude": 0.042,
+      "phase": 314.76
     },
     {
       "name": "MB2",
-      "amplitude": 0.03999416681892871,
-      "phase": 177.0417975535745
+      "amplitude": 0.04,
+      "phase": 177.04
     },
     {
       "name": "T3",
-      "amplitude": 0.0012669644911999641,
-      "phase": 123.35007338611626
+      "amplitude": 0.001,
+      "phase": 123.35
     },
     {
       "name": "R3",
-      "amplitude": 0.004621370921325548,
-      "phase": 175.42869353539868
+      "amplitude": 0.005,
+      "phase": 175.43
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004127476251109853,
-      "phase": 272.4044810762044
+      "amplitude": 0.004,
+      "phase": 272.4
     },
     {
       "name": "SGM",
-      "amplitude": 0.005882756006272143,
-      "phase": 103.42959587998939
+      "amplitude": 0.006,
+      "phase": 103.43
     },
     {
       "name": "3L2",
-      "amplitude": 0.002193234466351301,
-      "phase": 8.247787991866403
+      "amplitude": 0.002,
+      "phase": 8.25
     },
     {
       "name": "3N2",
-      "amplitude": 0.018042948282788393,
-      "phase": 210.9408206641594
+      "amplitude": 0.018,
+      "phase": 210.94
     },
     {
       "name": "2SM2",
-      "amplitude": 0.014010099295265295,
-      "phase": 17.624034757815934
+      "amplitude": 0.014,
+      "phase": 17.62
     },
     {
       "name": "2MS6",
-      "amplitude": 0.010522069425845524,
-      "phase": 189.14726067312637
+      "amplitude": 0.011,
+      "phase": 189.15
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00867263271355047,
-      "phase": 116.18651041607865
+      "amplitude": 0.009,
+      "phase": 116.19
     },
     {
       "name": "2MO5",
-      "amplitude": 0.010228051587775233,
-      "phase": 318.4317400278377
+      "amplitude": 0.01,
+      "phase": 318.43
     }
   ],
   "epoch": {

--- a/data/ticon/elsfleth-4970010-deu-wsv.json
+++ b/data/ticon/elsfleth-4970010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.682643808106547,
-      "phase": 16.968174106879303
+      "amplitude": 1.683,
+      "phase": 16.97
     },
     {
       "name": "N2",
-      "amplitude": 0.2577982657682393,
-      "phase": 353.0972454746888
+      "amplitude": 0.258,
+      "phase": 353.1
     },
     {
       "name": "S2",
-      "amplitude": 0.41816815223833387,
-      "phase": 96.0113060866986
+      "amplitude": 0.418,
+      "phase": 96.01
     },
     {
       "name": "K2",
-      "amplitude": 0.12335807189603895,
-      "phase": 93.5954532548696
+      "amplitude": 0.123,
+      "phase": 93.6
     },
     {
       "name": "2N2",
-      "amplitude": 0.02701507286857937,
-      "phase": 332.3335168738285
+      "amplitude": 0.027,
+      "phase": 332.33
     },
     {
       "name": "S1",
-      "amplitude": 0.01591435883443854,
-      "phase": 79.1524949880669
+      "amplitude": 0.016,
+      "phase": 79.15
     },
     {
       "name": "K1",
-      "amplitude": 0.0687834471866825,
-      "phase": 62.42048396287157
+      "amplitude": 0.069,
+      "phase": 62.42
     },
     {
       "name": "P1",
-      "amplitude": 0.030004225082605356,
-      "phase": 67.83527985575995
+      "amplitude": 0.03,
+      "phase": 67.84
     },
     {
       "name": "O1",
-      "amplitude": 0.08807241007092957,
-      "phase": 269.0775365157451
+      "amplitude": 0.088,
+      "phase": 269.08
     },
     {
       "name": "Q1",
-      "amplitude": 0.024902537589711123,
-      "phase": 208.63881478646468
+      "amplitude": 0.025,
+      "phase": 208.64
     },
     {
       "name": "M1",
-      "amplitude": 0.0023751803325435935,
-      "phase": 127.21159165162982
+      "amplitude": 0.002,
+      "phase": 127.21
     },
     {
       "name": "M4",
-      "amplitude": 0.07942773007029912,
-      "phase": 241.7105932008986
+      "amplitude": 0.079,
+      "phase": 241.71
     },
     {
       "name": "MM",
-      "amplitude": 0.012088872807007588,
-      "phase": 123.8400175730975
+      "amplitude": 0.012,
+      "phase": 123.84
     },
     {
       "name": "MF",
-      "amplitude": 0.012174220823795961,
-      "phase": 105.97684054556743
+      "amplitude": 0.012,
+      "phase": 105.98
     },
     {
       "name": "SA",
-      "amplitude": 0.057988848773270735,
-      "phase": 240.7758999953689
+      "amplitude": 0.058,
+      "phase": 240.78
     },
     {
       "name": "SSA",
-      "amplitude": 0.04553917567405616,
-      "phase": 223.12456229125178
+      "amplitude": 0.046,
+      "phase": 223.12
     },
     {
       "name": "T2",
-      "amplitude": 0.026772073635465285,
-      "phase": 67.93895198971302
+      "amplitude": 0.027,
+      "phase": 67.94
     },
     {
       "name": "J1",
-      "amplitude": 0.0036768753783088144,
-      "phase": 189.50517219773272
+      "amplitude": 0.004,
+      "phase": 189.51
     },
     {
       "name": "L2",
-      "amplitude": 0.15158144393668044,
-      "phase": 31.276639414766805
+      "amplitude": 0.152,
+      "phase": 31.28
     },
     {
       "name": "R2",
-      "amplitude": 0.0024672203640950957,
-      "phase": 298.5269515407061
+      "amplitude": 0.002,
+      "phase": 298.53
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005270613087397182,
-      "phase": 150.05978000998982
+      "amplitude": 0.005,
+      "phase": 150.06
     },
     {
       "name": "MSF",
-      "amplitude": 0.049093085569584846,
-      "phase": 64.92156276445303
+      "amplitude": 0.049,
+      "phase": 64.92
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008327787945172091,
-      "phase": 39.82896048186973
+      "amplitude": 0.008,
+      "phase": 39.83
     },
     {
       "name": "EP2",
-      "amplitude": 0.046556659593618835,
-      "phase": 75.0427359888248
+      "amplitude": 0.047,
+      "phase": 75.04
     },
     {
       "name": "M3",
-      "amplitude": 0.004053327897261873,
-      "phase": 87.59318045574594
+      "amplitude": 0.004,
+      "phase": 87.59
     },
     {
       "name": "MU2",
-      "amplitude": 0.22447055449321823,
-      "phase": 98.51050219545414
+      "amplitude": 0.224,
+      "phase": 98.51
     },
     {
       "name": "MTM",
-      "amplitude": 0.002353754449566098,
-      "phase": 231.24029662798085
+      "amplitude": 0.002,
+      "phase": 231.24
     },
     {
       "name": "NU2",
-      "amplitude": 0.1093857793164699,
-      "phase": 328.9934944389128
+      "amplitude": 0.109,
+      "phase": 328.99
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07127900217841562,
-      "phase": 30.864711858612623
+      "amplitude": 0.071,
+      "phase": 30.86
     },
     {
       "name": "MN4",
-      "amplitude": 0.024706243588287626,
-      "phase": 222.12719379057853
+      "amplitude": 0.025,
+      "phase": 222.13
     },
     {
       "name": "MS4",
-      "amplitude": 0.05965203804506058,
-      "phase": 319.8274525098441
+      "amplitude": 0.06,
+      "phase": 319.83
     },
     {
       "name": "N4",
-      "amplitude": 0.005105251644724698,
-      "phase": 202.42309792406274
+      "amplitude": 0.005,
+      "phase": 202.42
     },
     {
       "name": "M6",
-      "amplitude": 0.07774776650208116,
-      "phase": 90.95379384626415
+      "amplitude": 0.078,
+      "phase": 90.95
     },
     {
       "name": "M8",
-      "amplitude": 0.02067190723022467,
-      "phase": 1.6548044131981783
+      "amplitude": 0.021,
+      "phase": 1.65
     },
     {
       "name": "S4",
-      "amplitude": 0.008474816431791193,
-      "phase": 104.4156754386222
+      "amplitude": 0.008,
+      "phase": 104.42
     },
     {
       "name": "OO1",
-      "amplitude": 0.0026330374098150772,
-      "phase": 217.3567426659858
+      "amplitude": 0.003,
+      "phase": 217.36
     },
     {
       "name": "S3",
-      "amplitude": 0.0006598806884118503,
-      "phase": 310.03429625896894
+      "amplitude": 0.001,
+      "phase": 310.03
     },
     {
       "name": "MA2",
-      "amplitude": 0.062305666980841154,
-      "phase": 348.30357597122395
+      "amplitude": 0.062,
+      "phase": 348.3
     },
     {
       "name": "MB2",
-      "amplitude": 0.0009895268341772005,
-      "phase": 164.02346207313008
+      "amplitude": 0.001,
+      "phase": 164.02
     },
     {
       "name": "T3",
-      "amplitude": 0.0005070370652209373,
-      "phase": 36.52635878444971
+      "amplitude": 0.001,
+      "phase": 36.53
     },
     {
       "name": "R3",
-      "amplitude": 0.004302916207627608,
-      "phase": 85.70760855156868
+      "amplitude": 0.004,
+      "phase": 85.71
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005434616198892519,
-      "phase": 214.9438061908201
+      "amplitude": 0.005,
+      "phase": 214.94
     },
     {
       "name": "SGM",
-      "amplitude": 0.004735845832125844,
-      "phase": 41.074272688026156
+      "amplitude": 0.005,
+      "phase": 41.07
     },
     {
       "name": "3L2",
-      "amplitude": 0.0036354592186966976,
-      "phase": 294.4758046714926
+      "amplitude": 0.004,
+      "phase": 294.48
     },
     {
       "name": "3N2",
-      "amplitude": 0.02453231954086439,
-      "phase": 173.7431216247353
+      "amplitude": 0.025,
+      "phase": 173.74
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04582396589593363,
-      "phase": 317.8847223922564
+      "amplitude": 0.046,
+      "phase": 317.88
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0819516578407632,
-      "phase": 163.2632942592361
+      "amplitude": 0.082,
+      "phase": 163.26
     },
     {
       "name": "2MK5",
-      "amplitude": 0.008775844142017984,
-      "phase": 99.87562028689223
+      "amplitude": 0.009,
+      "phase": 99.88
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006159358240543313,
-      "phase": 292.56172443841956
+      "amplitude": 0.006,
+      "phase": 292.56
     }
   ],
   "epoch": {

--- a/data/ticon/elsflethohrt-4960080-deu-wsv.json
+++ b/data/ticon/elsflethohrt-4960080-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.6446554581415989,
-      "phase": 21.498981544748233
+      "amplitude": 1.645,
+      "phase": 21.5
     },
     {
       "name": "N2",
-      "amplitude": 0.25033992832181995,
-      "phase": 357.7233046932785
+      "amplitude": 0.25,
+      "phase": 357.72
     },
     {
       "name": "S2",
-      "amplitude": 0.4048339648809583,
-      "phase": 100.98373336307839
+      "amplitude": 0.405,
+      "phase": 100.98
     },
     {
       "name": "K2",
-      "amplitude": 0.11983404480469065,
-      "phase": 98.49102887278764
+      "amplitude": 0.12,
+      "phase": 98.49
     },
     {
       "name": "2N2",
-      "amplitude": 0.02519147715383208,
-      "phase": 337.1526666901849
+      "amplitude": 0.025,
+      "phase": 337.15
     },
     {
       "name": "S1",
-      "amplitude": 0.017684086907247234,
-      "phase": 75.30644553741558
+      "amplitude": 0.018,
+      "phase": 75.31
     },
     {
       "name": "K1",
-      "amplitude": 0.06640595454663183,
-      "phase": 65.46466990621883
+      "amplitude": 0.066,
+      "phase": 65.46
     },
     {
       "name": "P1",
-      "amplitude": 0.028995924125001522,
-      "phase": 74.23616908667441
+      "amplitude": 0.029,
+      "phase": 74.24
     },
     {
       "name": "O1",
-      "amplitude": 0.08495839945446536,
-      "phase": 272.16272689819107
+      "amplitude": 0.085,
+      "phase": 272.16
     },
     {
       "name": "Q1",
-      "amplitude": 0.023742194127649177,
-      "phase": 210.20892648140426
+      "amplitude": 0.024,
+      "phase": 210.21
     },
     {
       "name": "M1",
-      "amplitude": 0.002211109315447635,
-      "phase": 132.039174259148
+      "amplitude": 0.002,
+      "phase": 132.04
     },
     {
       "name": "M4",
-      "amplitude": 0.08818367673508917,
-      "phase": 254.19962793646448
+      "amplitude": 0.088,
+      "phase": 254.2
     },
     {
       "name": "MM",
-      "amplitude": 0.011841141420421964,
-      "phase": 114.71023106764386
+      "amplitude": 0.012,
+      "phase": 114.71
     },
     {
       "name": "MF",
-      "amplitude": 0.012448259644058587,
-      "phase": 100.48765290314645
+      "amplitude": 0.012,
+      "phase": 100.49
     },
     {
       "name": "SA",
-      "amplitude": 0.047223525113866,
-      "phase": 238.22131456041112
+      "amplitude": 0.047,
+      "phase": 238.22
     },
     {
       "name": "SSA",
-      "amplitude": 0.04267079573595335,
-      "phase": 217.7090796463671
+      "amplitude": 0.043,
+      "phase": 217.71
     },
     {
       "name": "T2",
-      "amplitude": 0.024553511321734275,
-      "phase": 70.53520133277163
+      "amplitude": 0.025,
+      "phase": 70.54
     },
     {
       "name": "J1",
-      "amplitude": 0.0037347389934601033,
-      "phase": 193.45190661048926
+      "amplitude": 0.004,
+      "phase": 193.45
     },
     {
       "name": "L2",
-      "amplitude": 0.14957621530229945,
-      "phase": 35.85086369162468
+      "amplitude": 0.15,
+      "phase": 35.85
     },
     {
       "name": "R2",
-      "amplitude": 0.00156449704048818,
-      "phase": 3.842510068888373
+      "amplitude": 0.002,
+      "phase": 3.84
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004815177500749472,
-      "phase": 149.09197425431387
+      "amplitude": 0.005,
+      "phase": 149.09
     },
     {
       "name": "MSF",
-      "amplitude": 0.05411549656951617,
-      "phase": 65.39021151746294
+      "amplitude": 0.054,
+      "phase": 65.39
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0057714048962936495,
-      "phase": 32.15790555139256
+      "amplitude": 0.006,
+      "phase": 32.16
     },
     {
       "name": "EP2",
-      "amplitude": 0.046614070852347755,
-      "phase": 80.03585474559418
+      "amplitude": 0.047,
+      "phase": 80.04
     },
     {
       "name": "M3",
-      "amplitude": 0.003493436404706126,
-      "phase": 101.98946670315502
+      "amplitude": 0.003,
+      "phase": 101.99
     },
     {
       "name": "MU2",
-      "amplitude": 0.22373592101430034,
-      "phase": 103.52147615416243
+      "amplitude": 0.224,
+      "phase": 103.52
     },
     {
       "name": "MTM",
-      "amplitude": 0.0014126551784075943,
-      "phase": 167.15517728954387
+      "amplitude": 0.001,
+      "phase": 167.16
     },
     {
       "name": "NU2",
-      "amplitude": 0.10938015108849057,
-      "phase": 332.37195752971576
+      "amplitude": 0.109,
+      "phase": 332.37
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06904988371474644,
-      "phase": 35.11752815984738
+      "amplitude": 0.069,
+      "phase": 35.12
     },
     {
       "name": "MN4",
-      "amplitude": 0.027686210144045303,
-      "phase": 232.87685964059887
+      "amplitude": 0.028,
+      "phase": 232.88
     },
     {
       "name": "MS4",
-      "amplitude": 0.06379701787573078,
-      "phase": 331.0933491518693
+      "amplitude": 0.064,
+      "phase": 331.09
     },
     {
       "name": "N4",
-      "amplitude": 0.005736662666014864,
-      "phase": 212.0675278514187
+      "amplitude": 0.006,
+      "phase": 212.07
     },
     {
       "name": "M6",
-      "amplitude": 0.07811019477839928,
-      "phase": 105.36783944230922
+      "amplitude": 0.078,
+      "phase": 105.37
     },
     {
       "name": "M8",
-      "amplitude": 0.023686339059918116,
-      "phase": 14.418223362718834
+      "amplitude": 0.024,
+      "phase": 14.42
     },
     {
       "name": "S4",
-      "amplitude": 0.00816068024165767,
-      "phase": 112.45875840762926
+      "amplitude": 0.008,
+      "phase": 112.46
     },
     {
       "name": "OO1",
-      "amplitude": 0.002825331709199272,
-      "phase": 231.03953084331928
+      "amplitude": 0.003,
+      "phase": 231.04
     },
     {
       "name": "S3",
-      "amplitude": 0.0013480146535111489,
-      "phase": 340.92752549323757
+      "amplitude": 0.001,
+      "phase": 340.93
     },
     {
       "name": "MA2",
-      "amplitude": 0.06156811645708517,
-      "phase": 347.61263883738525
+      "amplitude": 0.062,
+      "phase": 347.61
     },
     {
       "name": "MB2",
-      "amplitude": 0.009662523321041889,
-      "phase": 141.61447726620793
+      "amplitude": 0.01,
+      "phase": 141.61
     },
     {
       "name": "T3",
-      "amplitude": 0.0007291049553260871,
-      "phase": 53.803538359225
+      "amplitude": 0.001,
+      "phase": 53.8
     },
     {
       "name": "R3",
-      "amplitude": 0.00519592508682326,
-      "phase": 80.11030597006322
+      "amplitude": 0.005,
+      "phase": 80.11
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005890256671182831,
-      "phase": 219.55374923481307
+      "amplitude": 0.006,
+      "phase": 219.55
     },
     {
       "name": "SGM",
-      "amplitude": 0.005480228099492379,
-      "phase": 43.02430363435002
+      "amplitude": 0.005,
+      "phase": 43.02
     },
     {
       "name": "3L2",
-      "amplitude": 0.004826324298653692,
-      "phase": 291.90469964449136
+      "amplitude": 0.005,
+      "phase": 291.9
     },
     {
       "name": "3N2",
-      "amplitude": 0.02269138654683805,
-      "phase": 172.75117346839056
+      "amplitude": 0.023,
+      "phase": 172.75
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04530540052742227,
-      "phase": 322.71624097041126
+      "amplitude": 0.045,
+      "phase": 322.72
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08234654893069157,
-      "phase": 178.04122017713655
+      "amplitude": 0.082,
+      "phase": 178.04
     },
     {
       "name": "2MK5",
-      "amplitude": 0.007681182206090249,
-      "phase": 109.95274980276957
+      "amplitude": 0.008,
+      "phase": 109.95
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004925009610702252,
-      "phase": 301.6653039718917
+      "amplitude": 0.005,
+      "phase": 301.67
     }
   ],
   "epoch": {

--- a/data/ticon/emdenneueseeschleuse-3970010-deu-wsv.json
+++ b/data/ticon/emdenneueseeschleuse-3970010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4521353637609566,
-      "phase": 311.65159207377286
+      "amplitude": 1.452,
+      "phase": 311.65
     },
     {
       "name": "N2",
-      "amplitude": 0.22997204832254017,
-      "phase": 288.7013430580346
+      "amplitude": 0.23,
+      "phase": 288.7
     },
     {
       "name": "S2",
-      "amplitude": 0.361627277072719,
-      "phase": 24.56690871550211
+      "amplitude": 0.362,
+      "phase": 24.57
     },
     {
       "name": "K2",
-      "amplitude": 0.10912251398169823,
-      "phase": 20.69260840167459
+      "amplitude": 0.109,
+      "phase": 20.69
     },
     {
       "name": "2N2",
-      "amplitude": 0.025251174308132073,
-      "phase": 268.2704139116652
+      "amplitude": 0.025,
+      "phase": 268.27
     },
     {
       "name": "S1",
-      "amplitude": 0.014513709494256528,
-      "phase": 38.08381253425358
+      "amplitude": 0.015,
+      "phase": 38.08
     },
     {
       "name": "K1",
-      "amplitude": 0.07458256059659543,
-      "phase": 31.036200951247963
+      "amplitude": 0.075,
+      "phase": 31.04
     },
     {
       "name": "P1",
-      "amplitude": 0.03206444698263811,
-      "phase": 36.001710115713024
+      "amplitude": 0.032,
+      "phase": 36
     },
     {
       "name": "O1",
-      "amplitude": 0.09098307961294141,
-      "phase": 236.75332358652128
+      "amplitude": 0.091,
+      "phase": 236.75
     },
     {
       "name": "Q1",
-      "amplitude": 0.028784841723142728,
-      "phase": 175.77437505637886
+      "amplitude": 0.029,
+      "phase": 175.77
     },
     {
       "name": "M1",
-      "amplitude": 0.0020160238073378407,
-      "phase": 86.7579013347787
+      "amplitude": 0.002,
+      "phase": 86.76
     },
     {
       "name": "M4",
-      "amplitude": 0.1798636746394528,
-      "phase": 83.03401603530097
+      "amplitude": 0.18,
+      "phase": 83.03
     },
     {
       "name": "MM",
-      "amplitude": 0.015589560593390634,
-      "phase": 153.00539937926033
+      "amplitude": 0.016,
+      "phase": 153.01
     },
     {
       "name": "MF",
-      "amplitude": 0.00841585290456676,
-      "phase": 155.62606088518373
+      "amplitude": 0.008,
+      "phase": 155.63
     },
     {
       "name": "SA",
-      "amplitude": 0.08675034938441897,
-      "phase": 219.7018381420431
+      "amplitude": 0.087,
+      "phase": 219.7
     },
     {
       "name": "SSA",
-      "amplitude": 0.03767536587916149,
-      "phase": 207.55367855261386
+      "amplitude": 0.038,
+      "phase": 207.55
     },
     {
       "name": "T2",
-      "amplitude": 0.021388602661987038,
-      "phase": 348.77773517300636
+      "amplitude": 0.021,
+      "phase": 348.78
     },
     {
       "name": "J1",
-      "amplitude": 0.002241208428032181,
-      "phase": 161.02398672743084
+      "amplitude": 0.002,
+      "phase": 161.02
     },
     {
       "name": "L2",
-      "amplitude": 0.12445138926465454,
-      "phase": 325.40015973957827
+      "amplitude": 0.124,
+      "phase": 325.4
     },
     {
       "name": "R2",
-      "amplitude": 0.006342213241371419,
-      "phase": 230.91196643201792
+      "amplitude": 0.006,
+      "phase": 230.91
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00590177266260457,
-      "phase": 121.98244266356102
+      "amplitude": 0.006,
+      "phase": 121.98
     },
     {
       "name": "MSF",
-      "amplitude": 0.018170737258511805,
-      "phase": 51.75016351822171
+      "amplitude": 0.018,
+      "phase": 51.75
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00836803582159485,
-      "phase": 69.74568712048574
+      "amplitude": 0.008,
+      "phase": 69.75
     },
     {
       "name": "EP2",
-      "amplitude": 0.03601912998121733,
-      "phase": 16.194844680911842
+      "amplitude": 0.036,
+      "phase": 16.19
     },
     {
       "name": "M3",
-      "amplitude": 0.0033323349247142936,
-      "phase": 354.73204280241777
+      "amplitude": 0.003,
+      "phase": 354.73
     },
     {
       "name": "MU2",
-      "amplitude": 0.16740145905314754,
-      "phase": 34.55828211794511
+      "amplitude": 0.167,
+      "phase": 34.56
     },
     {
       "name": "MTM",
-      "amplitude": 0.004420658420278177,
-      "phase": 260.3266243337041
+      "amplitude": 0.004,
+      "phase": 260.33
     },
     {
       "name": "NU2",
-      "amplitude": 0.08900909857618672,
-      "phase": 266.2849560532204
+      "amplitude": 0.089,
+      "phase": 266.28
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05721214914484793,
-      "phase": 324.4203511541316
+      "amplitude": 0.057,
+      "phase": 324.42
     },
     {
       "name": "MN4",
-      "amplitude": 0.05855267539117659,
-      "phase": 57.98754545975777
+      "amplitude": 0.059,
+      "phase": 57.99
     },
     {
       "name": "MS4",
-      "amplitude": 0.10585483537493358,
-      "phase": 162.3668148567291
+      "amplitude": 0.106,
+      "phase": 162.37
     },
     {
       "name": "N4",
-      "amplitude": 0.011652205439071696,
-      "phase": 36.88959349083507
+      "amplitude": 0.012,
+      "phase": 36.89
     },
     {
       "name": "M6",
-      "amplitude": 0.07873754583448556,
-      "phase": 282.7461892249829
+      "amplitude": 0.079,
+      "phase": 282.75
     },
     {
       "name": "M8",
-      "amplitude": 0.015510757492609313,
-      "phase": 70.44114867426322
+      "amplitude": 0.016,
+      "phase": 70.44
     },
     {
       "name": "S4",
-      "amplitude": 0.00983406255160632,
-      "phase": 311.7143611528126
+      "amplitude": 0.01,
+      "phase": 311.71
     },
     {
       "name": "OO1",
-      "amplitude": 0.003024733660073917,
-      "phase": 196.21054496205878
+      "amplitude": 0.003,
+      "phase": 196.21
     },
     {
       "name": "S3",
-      "amplitude": 0.00038828346267063695,
-      "phase": 24.066903250083897
+      "amplitude": 0,
+      "phase": 24.07
     },
     {
       "name": "MA2",
-      "amplitude": 0.06632545172701343,
-      "phase": 274.5004120747748
+      "amplitude": 0.066,
+      "phase": 274.5
     },
     {
       "name": "MB2",
-      "amplitude": 0.007420303651409558,
-      "phase": 224.64185385349552
+      "amplitude": 0.007,
+      "phase": 224.64
     },
     {
       "name": "T3",
-      "amplitude": 0.000813889233128863,
-      "phase": 68.55371239940143
+      "amplitude": 0.001,
+      "phase": 68.55
     },
     {
       "name": "R3",
-      "amplitude": 0.00320415545220939,
-      "phase": 16.446900559526625
+      "amplitude": 0.003,
+      "phase": 16.45
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0054165442778443375,
-      "phase": 184.95508566998353
+      "amplitude": 0.005,
+      "phase": 184.96
     },
     {
       "name": "SGM",
-      "amplitude": 0.0028979387533576598,
-      "phase": 56.619600615538786
+      "amplitude": 0.003,
+      "phase": 56.62
     },
     {
       "name": "3L2",
-      "amplitude": 0.003982779670898582,
-      "phase": 216.81118226755902
+      "amplitude": 0.004,
+      "phase": 216.81
     },
     {
       "name": "3N2",
-      "amplitude": 0.014219914666963833,
-      "phase": 133.8019734450915
+      "amplitude": 0.014,
+      "phase": 133.8
     },
     {
       "name": "2SM2",
-      "amplitude": 0.037322675852312096,
-      "phase": 246.81192551645086
+      "amplitude": 0.037,
+      "phase": 246.81
     },
     {
       "name": "2MS6",
-      "amplitude": 0.07493333771638394,
-      "phase": 349.64551419119715
+      "amplitude": 0.075,
+      "phase": 349.65
     },
     {
       "name": "2MK5",
-      "amplitude": 0.012344367089552112,
-      "phase": 321.97826941698247
+      "amplitude": 0.012,
+      "phase": 321.98
     },
     {
       "name": "2MO5",
-      "amplitude": 0.008914617713917909,
-      "phase": 165.4582377572724
+      "amplitude": 0.009,
+      "phase": 165.46
     }
   ],
   "epoch": {

--- a/data/ticon/emshrn-9340010-deu-wsv.json
+++ b/data/ticon/emshrn-9340010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.1778378213988852,
-      "phase": 282.5398242521257
+      "amplitude": 1.178,
+      "phase": 282.54
     },
     {
       "name": "N2",
-      "amplitude": 0.18904069657401595,
-      "phase": 258.04026757493335
+      "amplitude": 0.189,
+      "phase": 258.04
     },
     {
       "name": "S2",
-      "amplitude": 0.29954740963089577,
-      "phase": 349.1761042307508
+      "amplitude": 0.3,
+      "phase": 349.18
     },
     {
       "name": "K2",
-      "amplitude": 0.09072852267154945,
-      "phase": 347.0770967973029
+      "amplitude": 0.091,
+      "phase": 347.08
     },
     {
       "name": "2N2",
-      "amplitude": 0.020904639824725665,
-      "phase": 237.76481918106708
+      "amplitude": 0.021,
+      "phase": 237.76
     },
     {
       "name": "S1",
-      "amplitude": 0.009562852460541494,
-      "phase": 12.475224178836868
+      "amplitude": 0.01,
+      "phase": 12.48
     },
     {
       "name": "K1",
-      "amplitude": 0.07239296636941586,
-      "phase": 13.041260167448343
+      "amplitude": 0.072,
+      "phase": 13.04
     },
     {
       "name": "P1",
-      "amplitude": 0.0284132265957881,
-      "phase": 18.497057578944293
+      "amplitude": 0.028,
+      "phase": 18.5
     },
     {
       "name": "O1",
-      "amplitude": 0.09045481854339019,
-      "phase": 221.0689122008211
+      "amplitude": 0.09,
+      "phase": 221.07
     },
     {
       "name": "Q1",
-      "amplitude": 0.0295165417063256,
-      "phase": 161.87605032157012
+      "amplitude": 0.03,
+      "phase": 161.88
     },
     {
       "name": "M1",
-      "amplitude": 0.001625311140488323,
-      "phase": 72.18219264418866
+      "amplitude": 0.002,
+      "phase": 72.18
     },
     {
       "name": "M4",
-      "amplitude": 0.09263654127803521,
-      "phase": 38.178887360051874
+      "amplitude": 0.093,
+      "phase": 38.18
     },
     {
       "name": "MM",
-      "amplitude": 0.019770298530335823,
-      "phase": 171.07449575183682
+      "amplitude": 0.02,
+      "phase": 171.07
     },
     {
       "name": "MF",
-      "amplitude": 0.009512753523401998,
-      "phase": 164.13912578123768
+      "amplitude": 0.01,
+      "phase": 164.14
     },
     {
       "name": "SA",
-      "amplitude": 0.09274107920761697,
-      "phase": 223.5746213483237
+      "amplitude": 0.093,
+      "phase": 223.57
     },
     {
       "name": "SSA",
-      "amplitude": 0.03352252202713598,
-      "phase": 202.0441812778019
+      "amplitude": 0.034,
+      "phase": 202.04
     },
     {
       "name": "T2",
-      "amplitude": 0.01731880564317524,
-      "phase": 320.34687245061724
+      "amplitude": 0.017,
+      "phase": 320.35
     },
     {
       "name": "J1",
-      "amplitude": 0.001442530898863956,
-      "phase": 119.07626710467855
+      "amplitude": 0.001,
+      "phase": 119.08
     },
     {
       "name": "L2",
-      "amplitude": 0.09238117236972347,
-      "phase": 299.0306174643548
+      "amplitude": 0.092,
+      "phase": 299.03
     },
     {
       "name": "R2",
-      "amplitude": 0.0008996574379149774,
-      "phase": 259.4874211537772
+      "amplitude": 0.001,
+      "phase": 259.49
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006145776073709226,
-      "phase": 109.10171972026262
+      "amplitude": 0.006,
+      "phase": 109.1
     },
     {
       "name": "MSF",
-      "amplitude": 0.00859838436551057,
-      "phase": 55.4389272359914
+      "amplitude": 0.009,
+      "phase": 55.44
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0077436420298111425,
-      "phase": 68.27890586048073
+      "amplitude": 0.008,
+      "phase": 68.28
     },
     {
       "name": "EP2",
-      "amplitude": 0.02565213167938647,
-      "phase": 353.2074501722713
+      "amplitude": 0.026,
+      "phase": 353.21
     },
     {
       "name": "M3",
-      "amplitude": 0.003150312779152628,
-      "phase": 265.5566809832797
+      "amplitude": 0.003,
+      "phase": 265.56
     },
     {
       "name": "MU2",
-      "amplitude": 0.11570667102183477,
-      "phase": 13.16886968602796
+      "amplitude": 0.116,
+      "phase": 13.17
     },
     {
       "name": "MTM",
-      "amplitude": 0.005433598419494217,
-      "phase": 258.42529737972416
+      "amplitude": 0.005,
+      "phase": 258.43
     },
     {
       "name": "NU2",
-      "amplitude": 0.06844870000779263,
-      "phase": 242.42178475330726
+      "amplitude": 0.068,
+      "phase": 242.42
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04254984831158872,
-      "phase": 294.15113600405573
+      "amplitude": 0.043,
+      "phase": 294.15
     },
     {
       "name": "MN4",
-      "amplitude": 0.029571365213188292,
-      "phase": 13.664261552241385
+      "amplitude": 0.03,
+      "phase": 13.66
     },
     {
       "name": "MS4",
-      "amplitude": 0.06116210629467517,
-      "phase": 110.52121795782807
+      "amplitude": 0.061,
+      "phase": 110.52
     },
     {
       "name": "N4",
-      "amplitude": 0.005991723084148505,
-      "phase": 352.59753430076915
+      "amplitude": 0.006,
+      "phase": 352.6
     },
     {
       "name": "M6",
-      "amplitude": 0.04873761564381735,
-      "phase": 207.4282835519672
+      "amplitude": 0.049,
+      "phase": 207.43
     },
     {
       "name": "M8",
-      "amplitude": 0.013125136414308939,
-      "phase": 358.3156404830362
+      "amplitude": 0.013,
+      "phase": 358.32
     },
     {
       "name": "S4",
-      "amplitude": 0.005913103321864285,
-      "phase": 245.4482952877469
+      "amplitude": 0.006,
+      "phase": 245.45
     },
     {
       "name": "OO1",
-      "amplitude": 0.002623811418667515,
-      "phase": 175.8829416827898
+      "amplitude": 0.003,
+      "phase": 175.88
     },
     {
       "name": "S3",
-      "amplitude": 0.0002015099473131278,
-      "phase": 55.034918022034276
+      "amplitude": 0,
+      "phase": 55.03
     },
     {
       "name": "MA2",
-      "amplitude": 0.04468539049666594,
-      "phase": 246.72808360995236
+      "amplitude": 0.045,
+      "phase": 246.73
     },
     {
       "name": "MB2",
-      "amplitude": 0.007549109953685596,
-      "phase": 30.98680774457341
+      "amplitude": 0.008,
+      "phase": 30.99
     },
     {
       "name": "T3",
-      "amplitude": 0.0010261712135205799,
-      "phase": 334.5049101120444
+      "amplitude": 0.001,
+      "phase": 334.5
     },
     {
       "name": "R3",
-      "amplitude": 0.0029717324884949124,
-      "phase": 336.1767171880322
+      "amplitude": 0.003,
+      "phase": 336.18
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005547855030766661,
-      "phase": 169.68392087164307
+      "amplitude": 0.006,
+      "phase": 169.68
     },
     {
       "name": "SGM",
-      "amplitude": 0.003034607237403508,
-      "phase": 47.63130933195083
+      "amplitude": 0.003,
+      "phase": 47.63
     },
     {
       "name": "3L2",
-      "amplitude": 0.0036178808252769227,
-      "phase": 193.22949720357727
+      "amplitude": 0.004,
+      "phase": 193.23
     },
     {
       "name": "3N2",
-      "amplitude": 0.01120667857971582,
-      "phase": 86.08266898363945
+      "amplitude": 0.011,
+      "phase": 86.08
     },
     {
       "name": "2SM2",
-      "amplitude": 0.027562071256567903,
-      "phase": 211.55016072283408
+      "amplitude": 0.028,
+      "phase": 211.55
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04541929725891013,
-      "phase": 270.80547861623836
+      "amplitude": 0.045,
+      "phase": 270.81
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004706914090505354,
-      "phase": 234.8075918436021
+      "amplitude": 0.005,
+      "phase": 234.81
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0022670579486199567,
-      "phase": 119.31796405292414
+      "amplitude": 0.002,
+      "phase": 119.32
     }
   ],
   "epoch": {

--- a/data/ticon/esteinneressperrwerkbp-5950081-deu-wsv.json
+++ b/data/ticon/esteinneressperrwerkbp-5950081-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4510544634227243,
-      "phase": 77.16132755275277
+      "amplitude": 1.451,
+      "phase": 77.16
     },
     {
       "name": "N2",
-      "amplitude": 0.20737312103109337,
-      "phase": 50.96026390761216
+      "amplitude": 0.207,
+      "phase": 50.96
     },
     {
       "name": "S2",
-      "amplitude": 0.32484931705330644,
-      "phase": 155.47970055470785
+      "amplitude": 0.325,
+      "phase": 155.48
     },
     {
       "name": "K2",
-      "amplitude": 0.10477521262854347,
-      "phase": 154.96828563091128
+      "amplitude": 0.105,
+      "phase": 154.97
     },
     {
       "name": "2N2",
-      "amplitude": 0.025814599928615557,
-      "phase": 18.144186894224788
+      "amplitude": 0.026,
+      "phase": 18.14
     },
     {
       "name": "S1",
-      "amplitude": 0.02087617563080188,
-      "phase": 78.18078674427773
+      "amplitude": 0.021,
+      "phase": 78.18
     },
     {
       "name": "K1",
-      "amplitude": 0.0505106540571241,
-      "phase": 92.52224035246894
+      "amplitude": 0.051,
+      "phase": 92.52
     },
     {
       "name": "P1",
-      "amplitude": 0.023472306582008193,
-      "phase": 119.050058437227
+      "amplitude": 0.023,
+      "phase": 119.05
     },
     {
       "name": "O1",
-      "amplitude": 0.06827514277064697,
-      "phase": 299.64546705619966
+      "amplitude": 0.068,
+      "phase": 299.65
     },
     {
       "name": "Q1",
-      "amplitude": 0.020687218765884287,
-      "phase": 236.202200213232
+      "amplitude": 0.021,
+      "phase": 236.2
     },
     {
       "name": "M1",
-      "amplitude": 0.0015267453177242795,
-      "phase": 183.95491744831827
+      "amplitude": 0.002,
+      "phase": 183.95
     },
     {
       "name": "M4",
-      "amplitude": 0.13037302501853465,
-      "phase": 40.58761702959811
+      "amplitude": 0.13,
+      "phase": 40.59
     },
     {
       "name": "MM",
-      "amplitude": 0.014512299756076737,
-      "phase": 86.73976657340233
+      "amplitude": 0.015,
+      "phase": 86.74
     },
     {
       "name": "MF",
-      "amplitude": 0.027913962337341194,
-      "phase": 130.83856920402042
+      "amplitude": 0.028,
+      "phase": 130.84
     },
     {
       "name": "SA",
-      "amplitude": 0.05715514068463743,
-      "phase": 223.2110836316886
+      "amplitude": 0.057,
+      "phase": 223.21
     },
     {
       "name": "SSA",
-      "amplitude": 0.052892477868216714,
-      "phase": 216.17760047005123
+      "amplitude": 0.053,
+      "phase": 216.18
     },
     {
       "name": "T2",
-      "amplitude": 0.013393975501289412,
-      "phase": 145.91203566861338
+      "amplitude": 0.013,
+      "phase": 145.91
     },
     {
       "name": "J1",
-      "amplitude": 0.005446471306095852,
-      "phase": 269.07513452480816
+      "amplitude": 0.005,
+      "phase": 269.08
     },
     {
       "name": "L2",
-      "amplitude": 0.15682104459922946,
-      "phase": 88.18346992704778
+      "amplitude": 0.157,
+      "phase": 88.18
     },
     {
       "name": "R2",
-      "amplitude": 0.009809522860734493,
-      "phase": 116.9774158495909
+      "amplitude": 0.01,
+      "phase": 116.98
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0065122585425923035,
-      "phase": 138.95386002581688
+      "amplitude": 0.007,
+      "phase": 138.95
     },
     {
       "name": "MSF",
-      "amplitude": 0.038157845899353886,
-      "phase": 86.47237341821551
+      "amplitude": 0.038,
+      "phase": 86.47
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008598677175095618,
-      "phase": 9.454311119241368
+      "amplitude": 0.009,
+      "phase": 9.45
     },
     {
       "name": "EP2",
-      "amplitude": 0.04916150957292832,
-      "phase": 147.05060592053064
+      "amplitude": 0.049,
+      "phase": 147.05
     },
     {
       "name": "M3",
-      "amplitude": 0.0019007395026483821,
-      "phase": 91.89644793108471
+      "amplitude": 0.002,
+      "phase": 91.9
     },
     {
       "name": "MU2",
-      "amplitude": 0.22040248928568487,
-      "phase": 167.66108508133254
+      "amplitude": 0.22,
+      "phase": 167.66
     },
     {
       "name": "MTM",
-      "amplitude": 0.000781756521227604,
-      "phase": 157.54673929856858
+      "amplitude": 0.001,
+      "phase": 157.55
     },
     {
       "name": "NU2",
-      "amplitude": 0.1119365010164814,
-      "phase": 33.51772327918127
+      "amplitude": 0.112,
+      "phase": 33.52
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.060667201713788525,
-      "phase": 102.64749401330613
+      "amplitude": 0.061,
+      "phase": 102.65
     },
     {
       "name": "MN4",
-      "amplitude": 0.04195096543778936,
-      "phase": 9.218429879573307
+      "amplitude": 0.042,
+      "phase": 9.22
     },
     {
       "name": "MS4",
-      "amplitude": 0.07624181222346946,
-      "phase": 111.24540558354164
+      "amplitude": 0.076,
+      "phase": 111.25
     },
     {
       "name": "N4",
-      "amplitude": 0.007197857365982528,
-      "phase": 352.50170184492157
+      "amplitude": 0.007,
+      "phase": 352.5
     },
     {
       "name": "M6",
-      "amplitude": 0.07042344562043042,
-      "phase": 322.3313246771779
+      "amplitude": 0.07,
+      "phase": 322.33
     },
     {
       "name": "M8",
-      "amplitude": 0.015123667498610388,
-      "phase": 268.40412838415943
+      "amplitude": 0.015,
+      "phase": 268.4
     },
     {
       "name": "S4",
-      "amplitude": 0.005626302749154109,
-      "phase": 223.57346607538372
+      "amplitude": 0.006,
+      "phase": 223.57
     },
     {
       "name": "OO1",
-      "amplitude": 0.004163220897823256,
-      "phase": 214.66424756847974
+      "amplitude": 0.004,
+      "phase": 214.66
     },
     {
       "name": "S3",
-      "amplitude": 0.002718159138777363,
-      "phase": 3.6652565250852263
+      "amplitude": 0.003,
+      "phase": 3.67
     },
     {
       "name": "MA2",
-      "amplitude": 0.05521844009812178,
-      "phase": 8.023432813761303
+      "amplitude": 0.055,
+      "phase": 8.02
     },
     {
       "name": "MB2",
-      "amplitude": 0.042349469103221474,
-      "phase": 157.04134966159063
+      "amplitude": 0.042,
+      "phase": 157.04
     },
     {
       "name": "T3",
-      "amplitude": 0.0011207203891881183,
-      "phase": 282.198503896306
+      "amplitude": 0.001,
+      "phase": 282.2
     },
     {
       "name": "R3",
-      "amplitude": 0.009645337080786668,
-      "phase": 128.22637097949212
+      "amplitude": 0.01,
+      "phase": 128.23
     },
     {
       "name": "RHO1",
-      "amplitude": 0.007791848923371015,
-      "phase": 259.95240150542645
+      "amplitude": 0.008,
+      "phase": 259.95
     },
     {
       "name": "SGM",
-      "amplitude": 0.006526812379996025,
-      "phase": 79.31577177972508
+      "amplitude": 0.007,
+      "phase": 79.32
     },
     {
       "name": "3L2",
-      "amplitude": 0.04564662105895647,
-      "phase": 325.3021580124579
+      "amplitude": 0.046,
+      "phase": 325.3
     },
     {
       "name": "3N2",
-      "amplitude": 0.019783877884324237,
-      "phase": 168.35510882537494
+      "amplitude": 0.02,
+      "phase": 168.36
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0407941000260978,
-      "phase": 32.129368580038545
+      "amplitude": 0.041,
+      "phase": 32.13
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06706451989846028,
-      "phase": 37.26191235762775
+      "amplitude": 0.067,
+      "phase": 37.26
     },
     {
       "name": "2MK5",
-      "amplitude": 0.003213871638159878,
-      "phase": 11.119325060103733
+      "amplitude": 0.003,
+      "phase": 11.12
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006178685283893386,
-      "phase": 228.06937231817153
+      "amplitude": 0.006,
+      "phase": 228.07
     }
   ],
   "epoch": {

--- a/data/ticon/euro_platform-eurpfm-nld-rws.json
+++ b/data/ticon/euro_platform-eurpfm-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.7144237,
-      "phase": 41.81706200000002
+      "amplitude": 0.738,
+      "phase": 25.35
     },
     {
       "name": "N2",
-      "amplitude": 0.11239255,
-      "phase": 13.032118000000025
+      "amplitude": 0.116,
+      "phase": 356.87
     },
     {
       "name": "S2",
-      "amplitude": 0.17658107,
-      "phase": 97.98228699999999
+      "amplitude": 0.182,
+      "phase": 81.12
     },
     {
       "name": "K2",
-      "amplitude": 0.04945379,
-      "phase": 102.76448900000003
+      "amplitude": 0.054,
+      "phase": 81.63
     },
     {
       "name": "2N2",
-      "amplitude": 0.01337875,
-      "phase": 344.648705
+      "amplitude": 0.014,
+      "phase": 329.72
     },
     {
       "name": "S1",
-      "amplitude": 0.0068422000000000005,
-      "phase": 355.604671
+      "amplitude": 0.01,
+      "phase": 283.75
     },
     {
       "name": "K1",
-      "amplitude": 0.08070349,
-      "phase": 353.053917
+      "amplitude": 0.081,
+      "phase": 344.44
     },
     {
       "name": "P1",
-      "amplitude": 0.03281964,
-      "phase": 336.68406
+      "amplitude": 0.033,
+      "phase": 330
     },
     {
       "name": "O1",
-      "amplitude": 0.11148873999999999,
-      "phase": 181.928706
+      "amplitude": 0.111,
+      "phase": 173.96
     },
     {
       "name": "Q1",
-      "amplitude": 0.03727027,
-      "phase": 126.39819399999999
+      "amplitude": 0.037,
+      "phase": 118.58
     },
     {
       "name": "M1",
-      "amplitude": 0.0005944300000000001,
-      "phase": 331.714144
+      "amplitude": 0.002,
+      "phase": 8.6
     },
     {
       "name": "M4",
-      "amplitude": 0.08924599999999999,
-      "phase": 106.36924499999998
+      "amplitude": 0.104,
+      "phase": 72.55
     },
     {
       "name": "MM",
-      "amplitude": 0.0024721,
-      "phase": 130.34677299999998
+      "amplitude": 0.003,
+      "phase": 129.59
     },
     {
       "name": "MF",
-      "amplitude": 0.0048223300000000005,
-      "phase": 150.59826799999996
+      "amplitude": 0.005,
+      "phase": 149.32
     },
     {
       "name": "SA",
-      "amplitude": 0.08072053,
-      "phase": 213.781407
+      "amplitude": 0.081,
+      "phase": 213.65
     },
     {
       "name": "SSA",
-      "amplitude": 0.0080471,
-      "phase": 153.551377
+      "amplitude": 0.008,
+      "phase": 152.81
     },
     {
       "name": "T2",
-      "amplitude": 0.03193312,
-      "phase": 20.311484000000007
+      "amplitude": 0.011,
+      "phase": 77.56
     },
     {
       "name": "J1",
-      "amplitude": 0.00428329,
-      "phase": 93.086612
+      "amplitude": 0.004,
+      "phase": 83.39
     },
     {
       "name": "L2",
-      "amplitude": 0.055605140000000004,
-      "phase": 67.59526599999998
+      "amplitude": 0.057,
+      "phase": 50.83
     },
     {
       "name": "R2",
-      "amplitude": 0.021924769999999996,
-      "phase": 198.0178
+      "amplitude": 0.002,
+      "phase": 79.49
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00595043,
-      "phase": 90.40723100000002
+      "amplitude": 0.006,
+      "phase": 84.3
     },
     {
       "name": "MSF",
-      "amplitude": 0.01856344,
-      "phase": 32.87672199999997
+      "amplitude": 0.018,
+      "phase": 32.15
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0020258200000000002,
-      "phase": 139.04708900000003
+      "amplitude": 0.002,
+      "phase": 143.49
     },
     {
       "name": "EP2",
-      "amplitude": 0.01336913,
-      "phase": 142.16596600000003
+      "amplitude": 0.013,
+      "phase": 127.94
     },
     {
       "name": "M3",
-      "amplitude": 0.00100758,
-      "phase": 78.34213799999998
+      "amplitude": 0.001,
+      "phase": 234.6
     },
     {
       "name": "MU2",
-      "amplitude": 0.06256727,
-      "phase": 165.99633700000004
+      "amplitude": 0.065,
+      "phase": 149.73
     },
     {
       "name": "MTM",
-      "amplitude": 0.00256178,
-      "phase": 218.011081
+      "amplitude": 0.003,
+      "phase": 217.23
     },
     {
       "name": "NU2",
-      "amplitude": 0.04279941,
-      "phase": 12.721501999999987
+      "amplitude": 0.044,
+      "phase": 356.64
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02496963,
-      "phase": 66.670254
+      "amplitude": 0.026,
+      "phase": 49.42
     },
     {
       "name": "MN4",
-      "amplitude": 0.03254298,
-      "phase": 82.796876
+      "amplitude": 0.038,
+      "phase": 49.68
     },
     {
       "name": "MS4",
-      "amplitude": 0.059690469999999995,
-      "phase": 159.85399600000005
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.025256590000000002,
-      "phase": 184.681448
+      "amplitude": 0.069,
+      "phase": 126.29
     },
     {
       "name": "N4",
-      "amplitude": 0.00688057,
-      "phase": 58.96168899999998
+      "amplitude": 0.008,
+      "phase": 25.5
     },
     {
       "name": "M6",
-      "amplitude": 0.0305152,
-      "phase": 58.84652199999999
+      "amplitude": 0.042,
+      "phase": 6.44
     },
     {
       "name": "M8",
-      "amplitude": 0.00577966,
-      "phase": 102.06848500000001
+      "amplitude": 0.011,
+      "phase": 27.04
     },
     {
       "name": "S4",
-      "amplitude": 0.00625402,
-      "phase": 243.572224
+      "amplitude": 0.007,
+      "phase": 209.78
     },
     {
       "name": "OO1",
-      "amplitude": 0.00464174,
-      "phase": 134.76768800000002
+      "amplitude": 0.004,
+      "phase": 124.99
     },
     {
       "name": "S3",
-      "amplitude": 0.00175828,
-      "phase": 31.631939999999986
+      "amplitude": 0,
+      "phase": 6.98
     },
     {
       "name": "MA2",
-      "amplitude": 0.12393117000000001,
-      "phase": 22.770467999999994
+      "amplitude": 0.011,
+      "phase": 356.05
     },
     {
       "name": "MB2",
-      "amplitude": 0.11248706,
-      "phase": 231.109112
+      "amplitude": 0.01,
+      "phase": 115.8
     },
     {
       "name": "T3",
-      "amplitude": 0.00079141,
-      "phase": 13.548363999999992
+      "amplitude": 0.001,
+      "phase": 197.16
     },
     {
       "name": "R3",
-      "amplitude": 0.005834519999999999,
-      "phase": 231.406869
+      "amplitude": 0.006,
+      "phase": 294.65
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0076669,
-      "phase": 128.641883
+      "amplitude": 0.008,
+      "phase": 121.41
     },
     {
       "name": "SGM",
-      "amplitude": 0.00214408,
-      "phase": 140.02768100000003
+      "amplitude": 0.002,
+      "phase": 309.02
     },
     {
       "name": "3L2",
-      "amplitude": 0.00095098,
-      "phase": 156.843481
+      "amplitude": 0.001,
+      "phase": 306.61
     },
     {
       "name": "3N2",
-      "amplitude": 0.0024240999999999998,
-      "phase": 71.49471900000003
+      "amplitude": 0.007,
+      "phase": 205.82
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0183726,
-      "phase": 342.92067
+      "amplitude": 0.019,
+      "phase": 326.02
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02790969,
-      "phase": 110.845753
+      "amplitude": 0.038,
+      "phase": 58.73
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00341497,
-      "phase": 229.907152
+      "amplitude": 0.005,
+      "phase": 276.87
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00487751,
-      "phase": 242.011133
+      "amplitude": 0.006,
+      "phase": 109.18
     }
   ],
   "epoch": {

--- a/data/ticon/fahrenholzup-5940060-deu-wsv.json
+++ b/data/ticon/fahrenholzup-5940060-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.7200236835472313,
-      "phase": 142.93908944651412
+      "amplitude": 0.72,
+      "phase": 142.94
     },
     {
       "name": "N2",
-      "amplitude": 0.10634732965357299,
-      "phase": 116.09956749818821
+      "amplitude": 0.106,
+      "phase": 116.1
     },
     {
       "name": "S2",
-      "amplitude": 0.17079159829524163,
-      "phase": 225.7897902060041
+      "amplitude": 0.171,
+      "phase": 225.79
     },
     {
       "name": "K2",
-      "amplitude": 0.05379737712425057,
-      "phase": 228.72835386111748
+      "amplitude": 0.054,
+      "phase": 228.73
     },
     {
       "name": "2N2",
-      "amplitude": 0.009335102235002607,
-      "phase": 88.56239861750191
+      "amplitude": 0.009,
+      "phase": 88.56
     },
     {
       "name": "S1",
-      "amplitude": 0.013063615310472034,
-      "phase": 122.24702299191392
+      "amplitude": 0.013,
+      "phase": 122.25
     },
     {
       "name": "K1",
-      "amplitude": 0.05059187508022612,
-      "phase": 154.01508911385247
+      "amplitude": 0.051,
+      "phase": 154.02
     },
     {
       "name": "P1",
-      "amplitude": 0.017589915747251023,
-      "phase": 137.43259557356555
+      "amplitude": 0.018,
+      "phase": 137.43
     },
     {
       "name": "O1",
-      "amplitude": 0.05863006489096011,
-      "phase": 349.43936788873003
+      "amplitude": 0.059,
+      "phase": 349.44
     },
     {
       "name": "Q1",
-      "amplitude": 0.014961491570887848,
-      "phase": 283.4113695215967
+      "amplitude": 0.015,
+      "phase": 283.41
     },
     {
       "name": "M1",
-      "amplitude": 0.0018122014306496707,
-      "phase": 186.32207948387958
+      "amplitude": 0.002,
+      "phase": 186.32
     },
     {
       "name": "M4",
-      "amplitude": 0.15570446544631203,
-      "phase": 230.0471064655925
+      "amplitude": 0.156,
+      "phase": 230.05
     },
     {
       "name": "MM",
-      "amplitude": 0.021706992298048372,
-      "phase": 43.020096325268014
+      "amplitude": 0.022,
+      "phase": 43.02
     },
     {
       "name": "MF",
-      "amplitude": 0.017836793464048508,
-      "phase": 79.44631150852962
+      "amplitude": 0.018,
+      "phase": 79.45
     },
     {
       "name": "SA",
-      "amplitude": 0.2482147012937181,
-      "phase": 321.03592223359936
+      "amplitude": 0.248,
+      "phase": 321.04
     },
     {
       "name": "SSA",
-      "amplitude": 0.05227009638031375,
-      "phase": 319.5249991082511
+      "amplitude": 0.052,
+      "phase": 319.52
     },
     {
       "name": "T2",
-      "amplitude": 0.009746155200713891,
-      "phase": 346.6380576006978
+      "amplitude": 0.01,
+      "phase": 346.64
     },
     {
       "name": "J1",
-      "amplitude": 0.006692272855160882,
-      "phase": 283.5843543932355
+      "amplitude": 0.007,
+      "phase": 283.58
     },
     {
       "name": "L2",
-      "amplitude": 0.06897062620265768,
-      "phase": 157.98887609577525
+      "amplitude": 0.069,
+      "phase": 157.99
     },
     {
       "name": "R2",
-      "amplitude": 0.017530232861247497,
-      "phase": 273.58462799388235
+      "amplitude": 0.018,
+      "phase": 273.58
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0034774690910999734,
-      "phase": 214.62841769766248
+      "amplitude": 0.003,
+      "phase": 214.63
     },
     {
       "name": "MSF",
-      "amplitude": 0.08990603155225872,
-      "phase": 65.9229958537245
+      "amplitude": 0.09,
+      "phase": 65.92
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004026984255876178,
-      "phase": 18.29013075496988
+      "amplitude": 0.004,
+      "phase": 18.29
     },
     {
       "name": "EP2",
-      "amplitude": 0.02273518096848243,
-      "phase": 191.96750221133289
+      "amplitude": 0.023,
+      "phase": 191.97
     },
     {
       "name": "M3",
-      "amplitude": 0.0026276449302311267,
-      "phase": 272.5015650532382
+      "amplitude": 0.003,
+      "phase": 272.5
     },
     {
       "name": "MU2",
-      "amplitude": 0.10073797076358916,
-      "phase": 223.71065459850962
+      "amplitude": 0.101,
+      "phase": 223.71
     },
     {
       "name": "MTM",
-      "amplitude": 0.006195651755671489,
-      "phase": 112.40383110602068
+      "amplitude": 0.006,
+      "phase": 112.4
     },
     {
       "name": "NU2",
-      "amplitude": 0.04855044677551925,
-      "phase": 93.21398956848634
+      "amplitude": 0.049,
+      "phase": 93.21
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.030373376674710326,
-      "phase": 160.01532262153398
+      "amplitude": 0.03,
+      "phase": 160.02
     },
     {
       "name": "MN4",
-      "amplitude": 0.047107565034825424,
-      "phase": 203.05865851177268
+      "amplitude": 0.047,
+      "phase": 203.06
     },
     {
       "name": "MS4",
-      "amplitude": 0.07522543691120476,
-      "phase": 308.4850691281247
+      "amplitude": 0.075,
+      "phase": 308.49
     },
     {
       "name": "N4",
-      "amplitude": 0.008661570709505486,
-      "phase": 188.57700653211603
+      "amplitude": 0.009,
+      "phase": 188.58
     },
     {
       "name": "M6",
-      "amplitude": 0.026836224855454557,
-      "phase": 288.04300786863786
+      "amplitude": 0.027,
+      "phase": 288.04
     },
     {
       "name": "M8",
-      "amplitude": 0.005373164856557719,
-      "phase": 292.77352434851286
+      "amplitude": 0.005,
+      "phase": 292.77
     },
     {
       "name": "S4",
-      "amplitude": 0.005999891625026986,
-      "phase": 118.70676568905162
+      "amplitude": 0.006,
+      "phase": 118.71
     },
     {
       "name": "OO1",
-      "amplitude": 0.0026452578569152825,
-      "phase": 297.4244827309331
+      "amplitude": 0.003,
+      "phase": 297.42
     },
     {
       "name": "S3",
-      "amplitude": 0.0008114058183923677,
-      "phase": 243.91827352289476
+      "amplitude": 0.001,
+      "phase": 243.92
     },
     {
       "name": "MA2",
-      "amplitude": 0.07881855725700751,
-      "phase": 12.728141650079408
+      "amplitude": 0.079,
+      "phase": 12.73
     },
     {
       "name": "MB2",
-      "amplitude": 0.07008913507640588,
-      "phase": 272.2737900701909
+      "amplitude": 0.07,
+      "phase": 272.27
     },
     {
       "name": "T3",
-      "amplitude": 0.0009722686300375343,
-      "phase": 305.97205227639324
+      "amplitude": 0.001,
+      "phase": 305.97
     },
     {
       "name": "R3",
-      "amplitude": 0.0028549488788283213,
-      "phase": 251.27142992485517
+      "amplitude": 0.003,
+      "phase": 251.27
     },
     {
       "name": "RHO1",
-      "amplitude": 0.003883660371692789,
-      "phase": 295.2207002253659
+      "amplitude": 0.004,
+      "phase": 295.22
     },
     {
       "name": "SGM",
-      "amplitude": 0.004741843898272574,
-      "phase": 123.94269821726493
+      "amplitude": 0.005,
+      "phase": 123.94
     },
     {
       "name": "3L2",
-      "amplitude": 0.0016078035103717506,
-      "phase": 125.90597618862944
+      "amplitude": 0.002,
+      "phase": 125.91
     },
     {
       "name": "3N2",
-      "amplitude": 0.016210051920858712,
-      "phase": 252.3291455984206
+      "amplitude": 0.016,
+      "phase": 252.33
     },
     {
       "name": "2SM2",
-      "amplitude": 0.019544539365502257,
-      "phase": 87.92791143335148
+      "amplitude": 0.02,
+      "phase": 87.93
     },
     {
       "name": "2MS6",
-      "amplitude": 0.021487491745184346,
-      "phase": 358.919935598099
+      "amplitude": 0.021,
+      "phase": 358.92
     },
     {
       "name": "2MK5",
-      "amplitude": 0.007122416185671049,
-      "phase": 235.65583324504456
+      "amplitude": 0.007,
+      "phase": 235.66
     },
     {
       "name": "2MO5",
-      "amplitude": 0.007442525927476947,
-      "phase": 94.31576166211119
+      "amplitude": 0.007,
+      "phase": 94.32
     }
   ],
   "epoch": {

--- a/data/ticon/farge-4950020-deu-wsv.json
+++ b/data/ticon/farge-4950020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.6669318552127153,
-      "phase": 27.123359076791303
+      "amplitude": 1.667,
+      "phase": 27.12
     },
     {
       "name": "N2",
-      "amplitude": 0.25451149296961034,
-      "phase": 3.126675635351546
+      "amplitude": 0.255,
+      "phase": 3.13
     },
     {
       "name": "S2",
-      "amplitude": 0.4136349395870447,
-      "phase": 107.08320897589977
+      "amplitude": 0.414,
+      "phase": 107.08
     },
     {
       "name": "K2",
-      "amplitude": 0.12174533845609033,
-      "phase": 104.89604785682553
+      "amplitude": 0.122,
+      "phase": 104.9
     },
     {
       "name": "2N2",
-      "amplitude": 0.026343573180627685,
-      "phase": 342.5618646696131
+      "amplitude": 0.026,
+      "phase": 342.56
     },
     {
       "name": "S1",
-      "amplitude": 0.015552304082208769,
-      "phase": 85.98262082725068
+      "amplitude": 0.016,
+      "phase": 85.98
     },
     {
       "name": "K1",
-      "amplitude": 0.0674559317407084,
-      "phase": 68.33419670193535
+      "amplitude": 0.067,
+      "phase": 68.33
     },
     {
       "name": "P1",
-      "amplitude": 0.028991690824411855,
-      "phase": 74.66603930427709
+      "amplitude": 0.029,
+      "phase": 74.67
     },
     {
       "name": "O1",
-      "amplitude": 0.08663358525515634,
-      "phase": 274.5677732959246
+      "amplitude": 0.087,
+      "phase": 274.57
     },
     {
       "name": "Q1",
-      "amplitude": 0.023998315134815984,
-      "phase": 213.2907002439882
+      "amplitude": 0.024,
+      "phase": 213.29
     },
     {
       "name": "M1",
-      "amplitude": 0.002439385528033443,
-      "phase": 132.6231257070623
+      "amplitude": 0.002,
+      "phase": 132.62
     },
     {
       "name": "M4",
-      "amplitude": 0.07595353229401024,
-      "phase": 301.70978013834474
+      "amplitude": 0.076,
+      "phase": 301.71
     },
     {
       "name": "MM",
-      "amplitude": 0.010868362203782003,
-      "phase": 113.63497658826805
+      "amplitude": 0.011,
+      "phase": 113.63
     },
     {
       "name": "MF",
-      "amplitude": 0.012356141640351828,
-      "phase": 101.39268556491999
+      "amplitude": 0.012,
+      "phase": 101.39
     },
     {
       "name": "SA",
-      "amplitude": 0.054797055191810475,
-      "phase": 256.84690188049126
+      "amplitude": 0.055,
+      "phase": 256.85
     },
     {
       "name": "SSA",
-      "amplitude": 0.049302199489888336,
-      "phase": 228.88016554961322
+      "amplitude": 0.049,
+      "phase": 228.88
     },
     {
       "name": "T2",
-      "amplitude": 0.026903511566087456,
-      "phase": 71.08555838715517
+      "amplitude": 0.027,
+      "phase": 71.09
     },
     {
       "name": "J1",
-      "amplitude": 0.0038042634860187114,
-      "phase": 192.70086903312952
+      "amplitude": 0.004,
+      "phase": 192.7
     },
     {
       "name": "L2",
-      "amplitude": 0.1504430558849241,
-      "phase": 41.233069531010756
+      "amplitude": 0.15,
+      "phase": 41.23
     },
     {
       "name": "R2",
-      "amplitude": 0.006987401598814466,
-      "phase": 273.8213375493809
+      "amplitude": 0.007,
+      "phase": 273.82
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005044862367387548,
-      "phase": 155.3610446742341
+      "amplitude": 0.005,
+      "phase": 155.36
     },
     {
       "name": "MSF",
-      "amplitude": 0.05192672194362453,
-      "phase": 64.58561771997967
+      "amplitude": 0.052,
+      "phase": 64.59
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007994657791269668,
-      "phase": 38.049381627512446
+      "amplitude": 0.008,
+      "phase": 38.05
     },
     {
       "name": "EP2",
-      "amplitude": 0.046583739154611455,
-      "phase": 84.76537554650628
+      "amplitude": 0.047,
+      "phase": 84.77
     },
     {
       "name": "M3",
-      "amplitude": 0.004209580005877805,
-      "phase": 100.35773375028703
+      "amplitude": 0.004,
+      "phase": 100.36
     },
     {
       "name": "MU2",
-      "amplitude": 0.2270112029040641,
-      "phase": 108.2361155481504
+      "amplitude": 0.227,
+      "phase": 108.24
     },
     {
       "name": "MTM",
-      "amplitude": 0.002106637505877517,
-      "phase": 230.29231717338246
+      "amplitude": 0.002,
+      "phase": 230.29
     },
     {
       "name": "NU2",
-      "amplitude": 0.10928250211730405,
-      "phase": 338.3475799365443
+      "amplitude": 0.109,
+      "phase": 338.35
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0709792505714903,
-      "phase": 41.502251966247
+      "amplitude": 0.071,
+      "phase": 41.5
     },
     {
       "name": "MN4",
-      "amplitude": 0.025316685267228047,
-      "phase": 280.85974587340866
+      "amplitude": 0.025,
+      "phase": 280.86
     },
     {
       "name": "MS4",
-      "amplitude": 0.0508817401903507,
-      "phase": 14.339333781765788
+      "amplitude": 0.051,
+      "phase": 14.34
     },
     {
       "name": "N4",
-      "amplitude": 0.00529787779472034,
-      "phase": 259.01966923864813
+      "amplitude": 0.005,
+      "phase": 259.02
     },
     {
       "name": "M6",
-      "amplitude": 0.06111222354958871,
-      "phase": 114.7053479553357
+      "amplitude": 0.061,
+      "phase": 114.71
     },
     {
       "name": "M8",
-      "amplitude": 0.014300175927667025,
-      "phase": 21.375075926262298
+      "amplitude": 0.014,
+      "phase": 21.38
     },
     {
       "name": "S4",
-      "amplitude": 0.0065090939416720525,
-      "phase": 157.48479913140682
+      "amplitude": 0.007,
+      "phase": 157.48
     },
     {
       "name": "OO1",
-      "amplitude": 0.002576270727612741,
-      "phase": 221.70777472854653
+      "amplitude": 0.003,
+      "phase": 221.71
     },
     {
       "name": "S3",
-      "amplitude": 0.0008050814329569671,
-      "phase": 341.15545465908997
+      "amplitude": 0.001,
+      "phase": 341.16
     },
     {
       "name": "MA2",
-      "amplitude": 0.07903135623545791,
-      "phase": 356.7896506847678
+      "amplitude": 0.079,
+      "phase": 356.79
     },
     {
       "name": "MB2",
-      "amplitude": 0.019805130781054826,
-      "phase": 267.9472662848756
+      "amplitude": 0.02,
+      "phase": 267.95
     },
     {
       "name": "T3",
-      "amplitude": 0.0009304643291507504,
-      "phase": 73.19426414669283
+      "amplitude": 0.001,
+      "phase": 73.19
     },
     {
       "name": "R3",
-      "amplitude": 0.00445257237622479,
-      "phase": 102.24356644852139
+      "amplitude": 0.004,
+      "phase": 102.24
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005343690717581549,
-      "phase": 223.0672553819899
+      "amplitude": 0.005,
+      "phase": 223.07
     },
     {
       "name": "SGM",
-      "amplitude": 0.005409095160254945,
-      "phase": 46.78966360123974
+      "amplitude": 0.005,
+      "phase": 46.79
     },
     {
       "name": "3L2",
-      "amplitude": 0.003412937898564618,
-      "phase": 307.8040055461722
+      "amplitude": 0.003,
+      "phase": 307.8
     },
     {
       "name": "3N2",
-      "amplitude": 0.025233782240169294,
-      "phase": 186.20761784131602
+      "amplitude": 0.025,
+      "phase": 186.21
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04536265387912272,
-      "phase": 329.3735908854974
+      "amplitude": 0.045,
+      "phase": 329.37
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06239113392827944,
-      "phase": 186.95368356418217
+      "amplitude": 0.062,
+      "phase": 186.95
     },
     {
       "name": "2MK5",
-      "amplitude": 0.007167938496057126,
-      "phase": 128.43719102422506
+      "amplitude": 0.007,
+      "phase": 128.44
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005569001604623246,
-      "phase": 319.82777234355405
+      "amplitude": 0.006,
+      "phase": 319.83
     }
   ],
   "epoch": {

--- a/data/ticon/flensburg-9610010-deu-wsv.json
+++ b/data/ticon/flensburg-9610010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.056667794137472076,
-      "phase": 113.44764884925644
+      "amplitude": 0.057,
+      "phase": 113.45
     },
     {
       "name": "N2",
-      "amplitude": 0.01636007986946833,
-      "phase": 62.62297033503364
+      "amplitude": 0.016,
+      "phase": 62.62
     },
     {
       "name": "S2",
-      "amplitude": 0.014562475164374778,
-      "phase": 52.2883235270009
+      "amplitude": 0.015,
+      "phase": 52.29
     },
     {
       "name": "K2",
-      "amplitude": 0.0035479357366882238,
-      "phase": 32.268506190073765
+      "amplitude": 0.004,
+      "phase": 32.27
     },
     {
       "name": "2N2",
-      "amplitude": 0.002357630366406933,
-      "phase": 30.547429546700414
+      "amplitude": 0.002,
+      "phase": 30.55
     },
     {
       "name": "S1",
-      "amplitude": 0.009920928663184966,
-      "phase": 195.75967343031132
+      "amplitude": 0.01,
+      "phase": 195.76
     },
     {
       "name": "K1",
-      "amplitude": 0.022309543481527427,
-      "phase": 211.99977943219818
+      "amplitude": 0.022,
+      "phase": 212
     },
     {
       "name": "P1",
-      "amplitude": 0.008796797482510927,
-      "phase": 239.99224749497125
+      "amplitude": 0.009,
+      "phase": 239.99
     },
     {
       "name": "O1",
-      "amplitude": 0.018512944042949564,
-      "phase": 105.70028831433547
+      "amplitude": 0.019,
+      "phase": 105.7
     },
     {
       "name": "Q1",
-      "amplitude": 0.005230531937353,
-      "phase": 307.69584046297314
+      "amplitude": 0.005,
+      "phase": 307.7
     },
     {
       "name": "M1",
-      "amplitude": 0.00023503201171772343,
-      "phase": 159.68613747931022
+      "amplitude": 0,
+      "phase": 159.69
     },
     {
       "name": "M4",
-      "amplitude": 0.0030686130340750414,
-      "phase": 180.45758252470995
+      "amplitude": 0.003,
+      "phase": 180.46
     },
     {
       "name": "MM",
-      "amplitude": 0.012151746580163438,
-      "phase": 294.6120461681835
+      "amplitude": 0.012,
+      "phase": 294.61
     },
     {
       "name": "MF",
-      "amplitude": 0.011479391171092127,
-      "phase": 249.00229125034417
+      "amplitude": 0.011,
+      "phase": 249
     },
     {
       "name": "SA",
-      "amplitude": 0.03621001572617457,
-      "phase": 188.13124436219215
+      "amplitude": 0.036,
+      "phase": 188.13
     },
     {
       "name": "SSA",
-      "amplitude": 0.01252936656314027,
-      "phase": 292.78479892414055
+      "amplitude": 0.013,
+      "phase": 292.78
     },
     {
       "name": "T2",
-      "amplitude": 0.0008924025094444991,
-      "phase": 71.10502094680226
+      "amplitude": 0.001,
+      "phase": 71.11
     },
     {
       "name": "J1",
-      "amplitude": 0.0013804474484338787,
-      "phase": 129.9722225476453
+      "amplitude": 0.001,
+      "phase": 129.97
     },
     {
       "name": "L2",
-      "amplitude": 0.0054265705483069,
-      "phase": 214.52437552753005
+      "amplitude": 0.005,
+      "phase": 214.52
     },
     {
       "name": "R2",
-      "amplitude": 0.001034771208806456,
-      "phase": 105.97396870416935
+      "amplitude": 0.001,
+      "phase": 105.97
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0016869174582016323,
-      "phase": 278.4809690550638
+      "amplitude": 0.002,
+      "phase": 278.48
     },
     {
       "name": "MSF",
-      "amplitude": 0.0030446291608683656,
-      "phase": 222.35336974096592
+      "amplitude": 0.003,
+      "phase": 222.35
     },
     {
       "name": "MSQM",
-      "amplitude": 0.005132016223727995,
-      "phase": 221.2274301521709
+      "amplitude": 0.005,
+      "phase": 221.23
     },
     {
       "name": "EP2",
-      "amplitude": 0.003207881088431661,
-      "phase": 245.31158700907227
+      "amplitude": 0.003,
+      "phase": 245.31
     },
     {
       "name": "M3",
-      "amplitude": 0.0005141583905841239,
-      "phase": 356.87044286819065
+      "amplitude": 0.001,
+      "phase": 356.87
     },
     {
       "name": "MU2",
-      "amplitude": 0.013856191298893058,
-      "phase": 283.49044370791773
+      "amplitude": 0.014,
+      "phase": 283.49
     },
     {
       "name": "MTM",
-      "amplitude": 0.0038611783948794103,
-      "phase": 336.64183391724634
+      "amplitude": 0.004,
+      "phase": 336.64
     },
     {
       "name": "NU2",
-      "amplitude": 0.0059451148846310815,
-      "phase": 98.9588867169939
+      "amplitude": 0.006,
+      "phase": 98.96
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.003212066001263587,
-      "phase": 207.09700352336333
+      "amplitude": 0.003,
+      "phase": 207.1
     },
     {
       "name": "MN4",
-      "amplitude": 0.0009198538273902515,
-      "phase": 120.05301172507893
+      "amplitude": 0.001,
+      "phase": 120.05
     },
     {
       "name": "MS4",
-      "amplitude": 0.0006574781329933026,
-      "phase": 323.0139791404414
+      "amplitude": 0.001,
+      "phase": 323.01
     },
     {
       "name": "N4",
-      "amplitude": 0.00021950557498886592,
-      "phase": 98.97727266887841
+      "amplitude": 0,
+      "phase": 98.98
     },
     {
       "name": "M6",
-      "amplitude": 0.0028750958263032422,
-      "phase": 190.67992947175557
+      "amplitude": 0.003,
+      "phase": 190.68
     },
     {
       "name": "M8",
-      "amplitude": 0.00016114683379677127,
-      "phase": 230.06383406341888
+      "amplitude": 0,
+      "phase": 230.06
     },
     {
       "name": "S4",
-      "amplitude": 0.0002527803181080526,
-      "phase": 262.3051193912713
+      "amplitude": 0,
+      "phase": 262.31
     },
     {
       "name": "OO1",
-      "amplitude": 0.001681356664429345,
-      "phase": 120.6318303795822
+      "amplitude": 0.002,
+      "phase": 120.63
     },
     {
       "name": "S3",
-      "amplitude": 0.00036519183493380103,
-      "phase": 207.08254326769398
+      "amplitude": 0,
+      "phase": 207.08
     },
     {
       "name": "MA2",
-      "amplitude": 0.008129598501140107,
-      "phase": 104.85920670509682
+      "amplitude": 0.008,
+      "phase": 104.86
     },
     {
       "name": "MB2",
-      "amplitude": 0.008886073317080889,
-      "phase": 266.96831030406736
+      "amplitude": 0.009,
+      "phase": 266.97
     },
     {
       "name": "T3",
-      "amplitude": 0.00015357470049688225,
-      "phase": 352.81128085172907
+      "amplitude": 0,
+      "phase": 352.81
     },
     {
       "name": "R3",
-      "amplitude": 0.000037583868618272615,
-      "phase": 313.56340560219957
+      "amplitude": 0,
+      "phase": 313.56
     },
     {
       "name": "RHO1",
-      "amplitude": 0.001012039098239996,
-      "phase": 274.79579487971165
+      "amplitude": 0.001,
+      "phase": 274.8
     },
     {
       "name": "SGM",
-      "amplitude": 0.003237432501060256,
-      "phase": 217.31137756124127
+      "amplitude": 0.003,
+      "phase": 217.31
     },
     {
       "name": "3L2",
-      "amplitude": 0.0006272229050658635,
-      "phase": 354.948566350293
+      "amplitude": 0.001,
+      "phase": 354.95
     },
     {
       "name": "3N2",
-      "amplitude": 0.0017182539280944827,
-      "phase": 16.21372285570982
+      "amplitude": 0.002,
+      "phase": 16.21
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0022260381849590932,
-      "phase": 170.84860547060293
+      "amplitude": 0.002,
+      "phase": 170.85
     },
     {
       "name": "2MS6",
-      "amplitude": 0.002851017475018326,
-      "phase": 289.74304682341415
+      "amplitude": 0.003,
+      "phase": 289.74
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0002291362926694464,
-      "phase": 329.003076493889
+      "amplitude": 0,
+      "phase": 329
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0004113696140849623,
-      "phase": 146.7110557203489
+      "amplitude": 0,
+      "phase": 146.71
     }
   ],
   "epoch": {

--- a/data/ticon/friedrichstadtstrassenbrcke-9520060-deu-wsv.json
+++ b/data/ticon/friedrichstadtstrassenbrcke-9520060-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.8733375937485794,
-      "phase": 39.821442702439754
+      "amplitude": 0.873,
+      "phase": 39.82
     },
     {
       "name": "N2",
-      "amplitude": 0.1354954504786746,
-      "phase": 15.735428702410218
+      "amplitude": 0.135,
+      "phase": 15.74
     },
     {
       "name": "S2",
-      "amplitude": 0.22698975657978354,
-      "phase": 120.69892246707155
+      "amplitude": 0.227,
+      "phase": 120.7
     },
     {
       "name": "K2",
-      "amplitude": 0.0712971212976708,
-      "phase": 120.68140331192262
+      "amplitude": 0.071,
+      "phase": 120.68
     },
     {
       "name": "2N2",
-      "amplitude": 0.019491618106059344,
-      "phase": 9.278738557949964
+      "amplitude": 0.019,
+      "phase": 9.28
     },
     {
       "name": "S1",
-      "amplitude": 0.01604155843634476,
-      "phase": 294.28044348147324
+      "amplitude": 0.016,
+      "phase": 294.28
     },
     {
       "name": "K1",
-      "amplitude": 0.04899587862830125,
-      "phase": 79.39705710084507
+      "amplitude": 0.049,
+      "phase": 79.4
     },
     {
       "name": "P1",
-      "amplitude": 0.02288321176087316,
-      "phase": 68.36515402969962
+      "amplitude": 0.023,
+      "phase": 68.37
     },
     {
       "name": "O1",
-      "amplitude": 0.06181486741163751,
-      "phase": 294.3479844499625
+      "amplitude": 0.062,
+      "phase": 294.35
     },
     {
       "name": "Q1",
-      "amplitude": 0.01659301486935342,
-      "phase": 232.7405366117617
+      "amplitude": 0.017,
+      "phase": 232.74
     },
     {
       "name": "M1",
-      "amplitude": 0.0007782084288163021,
-      "phase": 111.42471671048895
+      "amplitude": 0.001,
+      "phase": 111.42
     },
     {
       "name": "M4",
-      "amplitude": 0.06585691712648008,
-      "phase": 30.036460223940253
+      "amplitude": 0.066,
+      "phase": 30.04
     },
     {
       "name": "MM",
-      "amplitude": 0.023410541872674936,
-      "phase": 118.60357011898105
+      "amplitude": 0.023,
+      "phase": 118.6
     },
     {
       "name": "MF",
-      "amplitude": 0.01351316233168936,
-      "phase": 146.01162508197882
+      "amplitude": 0.014,
+      "phase": 146.01
     },
     {
       "name": "SA",
-      "amplitude": 0.07650055629010089,
-      "phase": 129.9611135124194
+      "amplitude": 0.077,
+      "phase": 129.96
     },
     {
       "name": "SSA",
-      "amplitude": 0.005498185114420719,
-      "phase": 88.44150811705487
+      "amplitude": 0.005,
+      "phase": 88.44
     },
     {
       "name": "T2",
-      "amplitude": 0.0053384735508246565,
-      "phase": 144.03416473942445
+      "amplitude": 0.005,
+      "phase": 144.03
     },
     {
       "name": "J1",
-      "amplitude": 0.006520574820162081,
-      "phase": 191.04435167859447
+      "amplitude": 0.007,
+      "phase": 191.04
     },
     {
       "name": "L2",
-      "amplitude": 0.0792544875127149,
-      "phase": 49.908946070560546
+      "amplitude": 0.079,
+      "phase": 49.91
     },
     {
       "name": "R2",
-      "amplitude": 0.00566802450207673,
-      "phase": 107.22165392121644
+      "amplitude": 0.006,
+      "phase": 107.22
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00642259462773893,
-      "phase": 203.0897731469033
+      "amplitude": 0.006,
+      "phase": 203.09
     },
     {
       "name": "MSF",
-      "amplitude": 0.055015192786847786,
-      "phase": 81.10150753866333
+      "amplitude": 0.055,
+      "phase": 81.1
     },
     {
       "name": "MSQM",
-      "amplitude": 0.005324886222159231,
-      "phase": 219.97031070678915
+      "amplitude": 0.005,
+      "phase": 219.97
     },
     {
       "name": "EP2",
-      "amplitude": 0.032433439902060504,
-      "phase": 103.49086861831813
+      "amplitude": 0.032,
+      "phase": 103.49
     },
     {
       "name": "M3",
-      "amplitude": 0.0022878568521026645,
-      "phase": 150.7424946719733
+      "amplitude": 0.002,
+      "phase": 150.74
     },
     {
       "name": "MU2",
-      "amplitude": 0.11300948349356951,
-      "phase": 120.2971838105916
+      "amplitude": 0.113,
+      "phase": 120.3
     },
     {
       "name": "MTM",
-      "amplitude": 0.016429571941477566,
-      "phase": 107.76372198376453
+      "amplitude": 0.016,
+      "phase": 107.76
     },
     {
       "name": "NU2",
-      "amplitude": 0.05432848756979312,
-      "phase": 0.7906946954352065
+      "amplitude": 0.054,
+      "phase": 0.79
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03574254323151432,
-      "phase": 64.17012978660978
+      "amplitude": 0.036,
+      "phase": 64.17
     },
     {
       "name": "MN4",
-      "amplitude": 0.020991008960790928,
-      "phase": 9.329114667674617
+      "amplitude": 0.021,
+      "phase": 9.33
     },
     {
       "name": "MS4",
-      "amplitude": 0.0317483135100206,
-      "phase": 100.49236852092668
+      "amplitude": 0.032,
+      "phase": 100.49
     },
     {
       "name": "N4",
-      "amplitude": 0.004109107975108051,
-      "phase": 357.0450719329666
+      "amplitude": 0.004,
+      "phase": 357.05
     },
     {
       "name": "M6",
-      "amplitude": 0.016119015865111438,
-      "phase": 258.4460748815876
+      "amplitude": 0.016,
+      "phase": 258.45
     },
     {
       "name": "M8",
-      "amplitude": 0.010708592456322724,
-      "phase": 182.63639020640275
+      "amplitude": 0.011,
+      "phase": 182.64
     },
     {
       "name": "S4",
-      "amplitude": 0.003785066400276041,
-      "phase": 238.79462625691056
+      "amplitude": 0.004,
+      "phase": 238.79
     },
     {
       "name": "OO1",
-      "amplitude": 0.0025397483079501364,
-      "phase": 2.638654877045269
+      "amplitude": 0.003,
+      "phase": 2.64
     },
     {
       "name": "S3",
-      "amplitude": 0.004117355997096151,
-      "phase": 134.02360946996498
+      "amplitude": 0.004,
+      "phase": 134.02
     },
     {
       "name": "MA2",
-      "amplitude": 0.047584074174592,
-      "phase": 287.5571442904237
+      "amplitude": 0.048,
+      "phase": 287.56
     },
     {
       "name": "MB2",
-      "amplitude": 0.06565904644959478,
-      "phase": 135.55155343065707
+      "amplitude": 0.066,
+      "phase": 135.55
     },
     {
       "name": "T3",
-      "amplitude": 0.0012101604188882217,
-      "phase": 325.3915869178336
+      "amplitude": 0.001,
+      "phase": 325.39
     },
     {
       "name": "R3",
-      "amplitude": 0.003949534685799528,
-      "phase": 48.47532410595352
+      "amplitude": 0.004,
+      "phase": 48.48
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005306589511174351,
-      "phase": 232.5333893252811
+      "amplitude": 0.005,
+      "phase": 232.53
     },
     {
       "name": "SGM",
-      "amplitude": 0.013089620509812532,
-      "phase": 96.11573268666467
+      "amplitude": 0.013,
+      "phase": 96.12
     },
     {
       "name": "3L2",
-      "amplitude": 0.006102399473979047,
-      "phase": 319.33418996310445
+      "amplitude": 0.006,
+      "phase": 319.33
     },
     {
       "name": "3N2",
-      "amplitude": 0.002711733599390157,
-      "phase": 45.737137663027
+      "amplitude": 0.003,
+      "phase": 45.74
     },
     {
       "name": "2SM2",
-      "amplitude": 0.025573839286670383,
-      "phase": 334.5398849576377
+      "amplitude": 0.026,
+      "phase": 334.54
     },
     {
       "name": "2MS6",
-      "amplitude": 0.018631488074227598,
-      "phase": 324.44954307161515
+      "amplitude": 0.019,
+      "phase": 324.45
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005183986319265627,
-      "phase": 341.12490146874006
+      "amplitude": 0.005,
+      "phase": 341.12
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006118773317949962,
-      "phase": 195.14835268043808
+      "amplitude": 0.006,
+      "phase": 195.15
     }
   ],
   "epoch": {

--- a/data/ticon/friedrichstadttreene-9520061-deu-wsv.json
+++ b/data/ticon/friedrichstadttreene-9520061-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.039081721333015476,
-      "phase": 109.66234298331341
+      "amplitude": 0.039,
+      "phase": 109.66
     },
     {
       "name": "N2",
-      "amplitude": 0.005891934849076017,
-      "phase": 91.80382155938372
+      "amplitude": 0.006,
+      "phase": 91.8
     },
     {
       "name": "S2",
-      "amplitude": 0.010464104918726541,
-      "phase": 191.63986389802164
+      "amplitude": 0.01,
+      "phase": 191.64
     },
     {
       "name": "K2",
-      "amplitude": 0.0026219518900528643,
-      "phase": 188.74855254077264
+      "amplitude": 0.003,
+      "phase": 188.75
     },
     {
       "name": "2N2",
-      "amplitude": 0.001020785843474132,
-      "phase": 120.99639291714959
+      "amplitude": 0.001,
+      "phase": 121
     },
     {
       "name": "S1",
-      "amplitude": 0.007200201320851956,
-      "phase": 231.5585903641661
+      "amplitude": 0.007,
+      "phase": 231.56
     },
     {
       "name": "K1",
-      "amplitude": 0.003871878612634575,
-      "phase": 98.38017636031731
+      "amplitude": 0.004,
+      "phase": 98.38
     },
     {
       "name": "P1",
-      "amplitude": 0.002665102075730589,
-      "phase": 123.83224634237502
+      "amplitude": 0.003,
+      "phase": 123.83
     },
     {
       "name": "O1",
-      "amplitude": 0.005665556033544624,
-      "phase": 343.411336615536
+      "amplitude": 0.006,
+      "phase": 343.41
     },
     {
       "name": "Q1",
-      "amplitude": 0.0018154866370670218,
-      "phase": 340.1426221527121
+      "amplitude": 0.002,
+      "phase": 340.14
     },
     {
       "name": "M1",
-      "amplitude": 0.0005540065877149086,
-      "phase": 175.8080755263478
+      "amplitude": 0.001,
+      "phase": 175.81
     },
     {
       "name": "M4",
-      "amplitude": 0.010911922305491952,
-      "phase": 306.69628378835864
+      "amplitude": 0.011,
+      "phase": 306.7
     },
     {
       "name": "MM",
-      "amplitude": 0.023989937821633472,
-      "phase": 189.62938537225017
+      "amplitude": 0.024,
+      "phase": 189.63
     },
     {
       "name": "MF",
-      "amplitude": 0.008890818283484684,
-      "phase": 208.8799444613856
+      "amplitude": 0.009,
+      "phase": 208.88
     },
     {
       "name": "SA",
-      "amplitude": 0.13153623883154322,
-      "phase": 283.4656539522896
+      "amplitude": 0.132,
+      "phase": 283.47
     },
     {
       "name": "SSA",
-      "amplitude": 0.02132234404705739,
-      "phase": 245.00201998340475
+      "amplitude": 0.021,
+      "phase": 245
     },
     {
       "name": "T2",
-      "amplitude": 0.0034623485836716436,
-      "phase": 160.19770890999473
+      "amplitude": 0.003,
+      "phase": 160.2
     },
     {
       "name": "J1",
-      "amplitude": 0.0011712723644917297,
-      "phase": 36.46619296318454
+      "amplitude": 0.001,
+      "phase": 36.47
     },
     {
       "name": "L2",
-      "amplitude": 0.0035069896953556197,
-      "phase": 129.29247461749594
+      "amplitude": 0.004,
+      "phase": 129.29
     },
     {
       "name": "R2",
-      "amplitude": 0.0015845414793200876,
-      "phase": 31.355854568681252
+      "amplitude": 0.002,
+      "phase": 31.36
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0011061639649812048,
-      "phase": 297.7497620091242
+      "amplitude": 0.001,
+      "phase": 297.75
     },
     {
       "name": "MSF",
-      "amplitude": 0.03593409300416894,
-      "phase": 255.2979077175674
+      "amplitude": 0.036,
+      "phase": 255.3
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009754991221649412,
-      "phase": 101.15088473258521
+      "amplitude": 0.01,
+      "phase": 101.15
     },
     {
       "name": "EP2",
-      "amplitude": 0.001325756645390977,
-      "phase": 214.85671211553193
+      "amplitude": 0.001,
+      "phase": 214.86
     },
     {
       "name": "M3",
-      "amplitude": 0.0005058242042255953,
-      "phase": 342.6703072980194
+      "amplitude": 0.001,
+      "phase": 342.67
     },
     {
       "name": "MU2",
-      "amplitude": 0.006877136874878056,
-      "phase": 182.37473283642206
+      "amplitude": 0.007,
+      "phase": 182.37
     },
     {
       "name": "MTM",
-      "amplitude": 0.0073019921039406506,
-      "phase": 255.86041509003536
+      "amplitude": 0.007,
+      "phase": 255.86
     },
     {
       "name": "NU2",
-      "amplitude": 0.003416718635784357,
-      "phase": 52.11224368505452
+      "amplitude": 0.003,
+      "phase": 52.11
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0007118293461001583,
-      "phase": 116.25696038279972
+      "amplitude": 0.001,
+      "phase": 116.26
     },
     {
       "name": "MN4",
-      "amplitude": 0.003968170383912246,
-      "phase": 281.8039742543541
+      "amplitude": 0.004,
+      "phase": 281.8
     },
     {
       "name": "MS4",
-      "amplitude": 0.006486081557529068,
-      "phase": 26.57707709954883
+      "amplitude": 0.006,
+      "phase": 26.58
     },
     {
       "name": "N4",
-      "amplitude": 0.00081267946625351,
-      "phase": 288.7447065452111
+      "amplitude": 0.001,
+      "phase": 288.74
     },
     {
       "name": "M6",
-      "amplitude": 0.003619172232249881,
-      "phase": 161.6955606719929
+      "amplitude": 0.004,
+      "phase": 161.7
     },
     {
       "name": "M8",
-      "amplitude": 0.0006636494723807632,
-      "phase": 130.627496396865
+      "amplitude": 0.001,
+      "phase": 130.63
     },
     {
       "name": "S4",
-      "amplitude": 0.0005062960792946527,
-      "phase": 226.81571424503386
+      "amplitude": 0.001,
+      "phase": 226.82
     },
     {
       "name": "OO1",
-      "amplitude": 0.0009149741929880441,
-      "phase": 52.5171744292486
+      "amplitude": 0.001,
+      "phase": 52.52
     },
     {
       "name": "S3",
-      "amplitude": 0.0005391147201473534,
-      "phase": 207.52348788828866
+      "amplitude": 0.001,
+      "phase": 207.52
     },
     {
       "name": "MA2",
-      "amplitude": 0.008698229501142823,
-      "phase": 155.2387553874729
+      "amplitude": 0.009,
+      "phase": 155.24
     },
     {
       "name": "MB2",
-      "amplitude": 0.006703375828185649,
-      "phase": 32.407830106006884
+      "amplitude": 0.007,
+      "phase": 32.41
     },
     {
       "name": "T3",
-      "amplitude": 0.0005922974861567266,
-      "phase": 4.89596105065101
+      "amplitude": 0.001,
+      "phase": 4.9
     },
     {
       "name": "R3",
-      "amplitude": 0.0007324079808757196,
-      "phase": 282.8121336466078
+      "amplitude": 0.001,
+      "phase": 282.81
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0009703434204998146,
-      "phase": 101.73612052710018
+      "amplitude": 0.001,
+      "phase": 101.74
     },
     {
       "name": "SGM",
-      "amplitude": 0.0012324775645731344,
-      "phase": 276.30933603052455
+      "amplitude": 0.001,
+      "phase": 276.31
     },
     {
       "name": "3L2",
-      "amplitude": 0.00010436902454608796,
-      "phase": 37.522565800198834
+      "amplitude": 0,
+      "phase": 37.52
     },
     {
       "name": "3N2",
-      "amplitude": 0.0005828252873018799,
-      "phase": 352.0958822687815
+      "amplitude": 0.001,
+      "phase": 352.1
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0016145697074336177,
-      "phase": 55.13528708577036
+      "amplitude": 0.002,
+      "phase": 55.14
     },
     {
       "name": "2MS6",
-      "amplitude": 0.004443130575211513,
-      "phase": 236.23259675749276
+      "amplitude": 0.004,
+      "phase": 236.23
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0004986186606848607,
-      "phase": 223.06959232009544
+      "amplitude": 0,
+      "phase": 223.07
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0007295902281694698,
-      "phase": 66.32795835532693
+      "amplitude": 0.001,
+      "phase": 66.33
     }
   ],
   "epoch": {

--- a/data/ticon/geulhaven-geulhvn-nld-rws.json
+++ b/data/ticon/geulhaven-geulhvn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.7055443699999999,
-      "phase": 71.21356700000001
+      "amplitude": 0.724,
+      "phase": 54.95
     },
     {
       "name": "N2",
-      "amplitude": 0.10560842,
-      "phase": 44.32098400000001
+      "amplitude": 0.107,
+      "phase": 28.4
     },
     {
       "name": "S2",
-      "amplitude": 0.16952652,
-      "phase": 131.52175699999998
+      "amplitude": 0.173,
+      "phase": 114.84
     },
     {
       "name": "K2",
-      "amplitude": 0.04732443,
-      "phase": 137.78753800000004
+      "amplitude": 0.052,
+      "phase": 115.24
     },
     {
       "name": "2N2",
-      "amplitude": 0.011038639999999999,
-      "phase": 15.073969999999974
+      "amplitude": 0.011,
+      "phase": 358.46
     },
     {
       "name": "S1",
-      "amplitude": 0.00812315,
-      "phase": 13.160376999999983
+      "amplitude": 0.008,
+      "phase": 307.14
     },
     {
       "name": "K1",
-      "amplitude": 0.06869354,
-      "phase": 354.643078
+      "amplitude": 0.069,
+      "phase": 346.02
     },
     {
       "name": "P1",
-      "amplitude": 0.03057061,
-      "phase": 340.056927
+      "amplitude": 0.031,
+      "phase": 333.29
     },
     {
       "name": "O1",
-      "amplitude": 0.09575149,
-      "phase": 185.258263
+      "amplitude": 0.096,
+      "phase": 177.13
     },
     {
       "name": "Q1",
-      "amplitude": 0.03095315,
-      "phase": 127.77360599999997
+      "amplitude": 0.031,
+      "phase": 119.61
     },
     {
       "name": "M1",
-      "amplitude": 0.00242309,
-      "phase": 19.507112000000006
+      "amplitude": 0.002,
+      "phase": 19.12
     },
     {
       "name": "M4",
-      "amplitude": 0.12918645,
-      "phase": 134.195498
+      "amplitude": 0.147,
+      "phase": 99.11
     },
     {
       "name": "MM",
-      "amplitude": 0.0069029700000000005,
-      "phase": 169.99822800000004
+      "amplitude": 0.007,
+      "phase": 171.18
     },
     {
       "name": "MF",
-      "amplitude": 0.0061109400000000005,
-      "phase": 134.514565
+      "amplitude": 0.006,
+      "phase": 133.65
     },
     {
       "name": "SA",
-      "amplitude": 0.07386466,
-      "phase": 235.612934
+      "amplitude": 0.074,
+      "phase": 235.46
     },
     {
       "name": "SSA",
-      "amplitude": 0.02272193,
-      "phase": 208.305029
+      "amplitude": 0.023,
+      "phase": 207.71
     },
     {
       "name": "T2",
-      "amplitude": 0.0312631,
-      "phase": 52.46295600000002
+      "amplitude": 0.012,
+      "phase": 98.1
     },
     {
       "name": "J1",
-      "amplitude": 0.00252397,
-      "phase": 105.88700799999998
+      "amplitude": 0.003,
+      "phase": 95.85
     },
     {
       "name": "L2",
-      "amplitude": 0.06363044000000001,
-      "phase": 93.57091700000001
+      "amplitude": 0.065,
+      "phase": 77.02
     },
     {
       "name": "R2",
-      "amplitude": 0.019162310000000002,
-      "phase": 239.06177200000002
+      "amplitude": 0.002,
+      "phase": 31.87
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0046919,
-      "phase": 81.88631199999998
+      "amplitude": 0.005,
+      "phase": 77.3
     },
     {
       "name": "MSF",
-      "amplitude": 0.01517409,
-      "phase": 45.932383000000016
+      "amplitude": 0.015,
+      "phase": 45.37
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0071099100000000005,
-      "phase": 67.41389100000004
+      "amplitude": 0.007,
+      "phase": 66.17
     },
     {
       "name": "EP2",
-      "amplitude": 0.01683938,
-      "phase": 170.06964199999993
+      "amplitude": 0.017,
+      "phase": 156.12
     },
     {
       "name": "M3",
-      "amplitude": 0.00121637,
-      "phase": 287.641696
+      "amplitude": 0.001,
+      "phase": 83.52
     },
     {
       "name": "MU2",
-      "amplitude": 0.07878676999999999,
-      "phase": 189.927807
+      "amplitude": 0.082,
+      "phase": 173.68
     },
     {
       "name": "MTM",
-      "amplitude": 0.00563685,
-      "phase": 275.22242900000003
+      "amplitude": 0.005,
+      "phase": 275.82
     },
     {
       "name": "NU2",
-      "amplitude": 0.04414179,
-      "phase": 39.62356399999999
+      "amplitude": 0.046,
+      "phase": 24.42
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02998739,
-      "phase": 91.50836400000003
+      "amplitude": 0.03,
+      "phase": 74.5
     },
     {
       "name": "MN4",
-      "amplitude": 0.04675867,
-      "phase": 110.48755599999998
+      "amplitude": 0.053,
+      "phase": 76.89
     },
     {
       "name": "MS4",
-      "amplitude": 0.08279379,
-      "phase": 191.602131
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03357064,
-      "phase": 213.151508
+      "amplitude": 0.093,
+      "phase": 157.41
     },
     {
       "name": "N4",
-      "amplitude": 0.00996381,
-      "phase": 86.53393499999999
+      "amplitude": 0.011,
+      "phase": 53.49
     },
     {
       "name": "M6",
-      "amplitude": 0.02386913,
-      "phase": 101.472194
+      "amplitude": 0.033,
+      "phase": 49.77
     },
     {
       "name": "M8",
-      "amplitude": 0.00456054,
-      "phase": 157.42048499999999
+      "amplitude": 0.008,
+      "phase": 86.63
     },
     {
       "name": "S4",
-      "amplitude": 0.00827523,
-      "phase": 279.07185
+      "amplitude": 0.009,
+      "phase": 244.92
     },
     {
       "name": "OO1",
-      "amplitude": 0.00370336,
-      "phase": 146.679684
+      "amplitude": 0.003,
+      "phase": 129.36
     },
     {
       "name": "S3",
-      "amplitude": 0.00181885,
-      "phase": 38.258343000000025
+      "amplitude": 0,
+      "phase": 195.99
     },
     {
       "name": "MA2",
-      "amplitude": 0.12327134,
-      "phase": 51.31262800000002
+      "amplitude": 0.017,
+      "phase": 43.15
     },
     {
       "name": "MB2",
-      "amplitude": 0.10194392000000001,
-      "phase": 263.357206
+      "amplitude": 0.011,
+      "phase": 107.59
     },
     {
       "name": "T3",
-      "amplitude": 0.0012472,
-      "phase": 29.71880900000002
+      "amplitude": 0.002,
+      "phase": 199.49
     },
     {
       "name": "R3",
-      "amplitude": 0.0048175200000000005,
-      "phase": 240.770215
+      "amplitude": 0.005,
+      "phase": 303.73
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00670036,
-      "phase": 129.84637099999998
+      "amplitude": 0.007,
+      "phase": 122.75
     },
     {
       "name": "SGM",
-      "amplitude": 0.00246425,
-      "phase": 133.122228
+      "amplitude": 0.003,
+      "phase": 306.03
     },
     {
       "name": "3L2",
-      "amplitude": 0.00422889,
-      "phase": 354.825022
+      "amplitude": 0.004,
+      "phase": 61.91
     },
     {
       "name": "3N2",
-      "amplitude": 0.0071121199999999996,
-      "phase": 148.958952
+      "amplitude": 0.011,
+      "phase": 227.41
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02286121,
-      "phase": 6.258752000000015
+      "amplitude": 0.023,
+      "phase": 349.8
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02160505,
-      "phase": 157.50298499999997
+      "amplitude": 0.028,
+      "phase": 106.77
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0069514699999999995,
-      "phase": 267.196286
+      "amplitude": 0.009,
+      "phase": 314.61
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00792903,
-      "phase": 281.021577
+      "amplitude": 0.01,
+      "phase": 148.17
     }
   ],
   "epoch": {

--- a/data/ticon/glckstadt-5970035-deu-wsv.json
+++ b/data/ticon/glckstadt-5970035-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2359050088063226,
-      "phase": 40.88901218781041
+      "amplitude": 1.236,
+      "phase": 40.89
     },
     {
       "name": "N2",
-      "amplitude": 0.18935396576759972,
-      "phase": 14.694406002869812
+      "amplitude": 0.189,
+      "phase": 14.69
     },
     {
       "name": "S2",
-      "amplitude": 0.2866918370981306,
-      "phase": 113.34316530429828
+      "amplitude": 0.287,
+      "phase": 113.34
     },
     {
       "name": "K2",
-      "amplitude": 0.08656466331428563,
-      "phase": 111.7407156744436
+      "amplitude": 0.087,
+      "phase": 111.74
     },
     {
       "name": "2N2",
-      "amplitude": 0.020273756671632167,
-      "phase": 352.63564033773224
+      "amplitude": 0.02,
+      "phase": 352.64
     },
     {
       "name": "S1",
-      "amplitude": 0.01667812082945347,
-      "phase": 80.76812507726078
+      "amplitude": 0.017,
+      "phase": 80.77
     },
     {
       "name": "K1",
-      "amplitude": 0.07074183074820782,
-      "phase": 79.01342216324235
+      "amplitude": 0.071,
+      "phase": 79.01
     },
     {
       "name": "P1",
-      "amplitude": 0.03020543901278464,
-      "phase": 75.98332922506546
+      "amplitude": 0.03,
+      "phase": 75.98
     },
     {
       "name": "O1",
-      "amplitude": 0.08945042556882565,
-      "phase": 284.119352210779
+      "amplitude": 0.089,
+      "phase": 284.12
     },
     {
       "name": "Q1",
-      "amplitude": 0.026550543487188393,
-      "phase": 224.37311108861218
+      "amplitude": 0.027,
+      "phase": 224.37
     },
     {
       "name": "M1",
-      "amplitude": 0.002229631026550344,
-      "phase": 132.7077093601867
+      "amplitude": 0.002,
+      "phase": 132.71
     },
     {
       "name": "M4",
-      "amplitude": 0.1206730125695636,
-      "phase": 302.7426314510983
+      "amplitude": 0.121,
+      "phase": 302.74
     },
     {
       "name": "MM",
-      "amplitude": 0.01716701034833823,
-      "phase": 143.88870308234436
+      "amplitude": 0.017,
+      "phase": 143.89
     },
     {
       "name": "MF",
-      "amplitude": 0.013768655438501335,
-      "phase": 110.71126440108151
+      "amplitude": 0.014,
+      "phase": 110.71
     },
     {
       "name": "SA",
-      "amplitude": 0.07834393937396393,
-      "phase": 230.16067266348804
+      "amplitude": 0.078,
+      "phase": 230.16
     },
     {
       "name": "SSA",
-      "amplitude": 0.04824038738251492,
-      "phase": 218.4288126119919
+      "amplitude": 0.048,
+      "phase": 218.43
     },
     {
       "name": "T2",
-      "amplitude": 0.01682711421220022,
-      "phase": 96.11294463605532
+      "amplitude": 0.017,
+      "phase": 96.11
     },
     {
       "name": "J1",
-      "amplitude": 0.005306093559791018,
-      "phase": 209.760369317494
+      "amplitude": 0.005,
+      "phase": 209.76
     },
     {
       "name": "L2",
-      "amplitude": 0.10856742390236919,
-      "phase": 61.46190914498163
+      "amplitude": 0.109,
+      "phase": 61.46
     },
     {
       "name": "R2",
-      "amplitude": 0.004686795731383738,
-      "phase": 47.39602237332963
+      "amplitude": 0.005,
+      "phase": 47.4
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005775934513308206,
-      "phase": 162.54771437747831
+      "amplitude": 0.006,
+      "phase": 162.55
     },
     {
       "name": "MSF",
-      "amplitude": 0.05341604320371493,
-      "phase": 62.4149143528187
+      "amplitude": 0.053,
+      "phase": 62.41
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009517383413872864,
-      "phase": 48.4397026563945
+      "amplitude": 0.01,
+      "phase": 48.44
     },
     {
       "name": "EP2",
-      "amplitude": 0.0328524094037253,
-      "phase": 106.79589120078003
+      "amplitude": 0.033,
+      "phase": 106.8
     },
     {
       "name": "M3",
-      "amplitude": 0.0026537795145443245,
-      "phase": 66.61840021103939
+      "amplitude": 0.003,
+      "phase": 66.62
     },
     {
       "name": "MU2",
-      "amplitude": 0.15578696063230635,
-      "phase": 133.19344034645997
+      "amplitude": 0.156,
+      "phase": 133.19
     },
     {
       "name": "MTM",
-      "amplitude": 0.0043512005480814886,
-      "phase": 232.42324139354125
+      "amplitude": 0.004,
+      "phase": 232.42
     },
     {
       "name": "NU2",
-      "amplitude": 0.08181093962790245,
-      "phase": 359.571663754953
+      "amplitude": 0.082,
+      "phase": 359.57
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04775073942714617,
-      "phase": 57.0975234530726
+      "amplitude": 0.048,
+      "phase": 57.1
     },
     {
       "name": "MN4",
-      "amplitude": 0.04040997305026251,
-      "phase": 279.17560608210385
+      "amplitude": 0.04,
+      "phase": 279.18
     },
     {
       "name": "MS4",
-      "amplitude": 0.07138028589162511,
-      "phase": 13.128267540685044
+      "amplitude": 0.071,
+      "phase": 13.13
     },
     {
       "name": "N4",
-      "amplitude": 0.008386499100249535,
-      "phase": 258.09293662907027
+      "amplitude": 0.008,
+      "phase": 258.09
     },
     {
       "name": "M6",
-      "amplitude": 0.07916716081433837,
-      "phase": 187.50907993158074
+      "amplitude": 0.079,
+      "phase": 187.51
     },
     {
       "name": "M8",
-      "amplitude": 0.01645640965796039,
-      "phase": 116.52692629961496
+      "amplitude": 0.016,
+      "phase": 116.53
     },
     {
       "name": "S4",
-      "amplitude": 0.006737029563597576,
-      "phase": 144.6809592147015
+      "amplitude": 0.007,
+      "phase": 144.68
     },
     {
       "name": "OO1",
-      "amplitude": 0.0030185863338812696,
-      "phase": 219.4137635503677
+      "amplitude": 0.003,
+      "phase": 219.41
     },
     {
       "name": "S3",
-      "amplitude": 0.0007339151304870979,
-      "phase": 270.5584968314818
+      "amplitude": 0.001,
+      "phase": 270.56
     },
     {
       "name": "MA2",
-      "amplitude": 0.03196409558768648,
-      "phase": 0.7726042948831378
+      "amplitude": 0.032,
+      "phase": 0.77
     },
     {
       "name": "MB2",
-      "amplitude": 0.025626313946168225,
-      "phase": 79.81365416583697
+      "amplitude": 0.026,
+      "phase": 79.81
     },
     {
       "name": "T3",
-      "amplitude": 0.000243621697190946,
-      "phase": 83.9041477594003
+      "amplitude": 0,
+      "phase": 83.9
     },
     {
       "name": "R3",
-      "amplitude": 0.0031950749605274146,
-      "phase": 100.88694723533035
+      "amplitude": 0.003,
+      "phase": 100.89
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005617809413032687,
-      "phase": 226.70971698112865
+      "amplitude": 0.006,
+      "phase": 226.71
     },
     {
       "name": "SGM",
-      "amplitude": 0.0032693078584343426,
-      "phase": 67.99533981585228
+      "amplitude": 0.003,
+      "phase": 68
     },
     {
       "name": "3L2",
-      "amplitude": 0.003015519505401207,
-      "phase": 300.229425604486
+      "amplitude": 0.003,
+      "phase": 300.23
     },
     {
       "name": "3N2",
-      "amplitude": 0.01185299602328278,
-      "phase": 201.0724150432649
+      "amplitude": 0.012,
+      "phase": 201.07
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02896733277113079,
-      "phase": 342.26570708055164
+      "amplitude": 0.029,
+      "phase": 342.27
     },
     {
       "name": "2MS6",
-      "amplitude": 0.07474008072691249,
-      "phase": 256.2520478802853
+      "amplitude": 0.075,
+      "phase": 256.25
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004606720762562141,
-      "phase": 183.28196927377215
+      "amplitude": 0.005,
+      "phase": 183.28
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0034083385287396197,
-      "phase": 71.2308769000752
+      "amplitude": 0.003,
+      "phase": 71.23
     }
   ],
   "epoch": {

--- a/data/ticon/goidschalxoord-goidsod-nld-rws.json
+++ b/data/ticon/goidschalxoord-goidsod-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.48108007,
-      "phase": 106.89787799999999
+      "amplitude": 0.494,
+      "phase": 95.19
     },
     {
       "name": "N2",
-      "amplitude": 0.06941076,
-      "phase": 79.29557299999999
+      "amplitude": 0.071,
+      "phase": 67.84
     },
     {
       "name": "S2",
-      "amplitude": 0.11306024,
-      "phase": 166.62251400000002
+      "amplitude": 0.115,
+      "phase": 154.57
     },
     {
       "name": "K2",
-      "amplitude": 0.03583745,
-      "phase": 170.53346699999997
+      "amplitude": 0.037,
+      "phase": 156.59
     },
     {
       "name": "2N2",
-      "amplitude": 0.00976228,
-      "phase": 42.23049000000003
+      "amplitude": 0.011,
+      "phase": 33.34
     },
     {
       "name": "S1",
-      "amplitude": 0.0041705399999999995,
-      "phase": 2.7693029999999794
+      "amplitude": 0.006,
+      "phase": 317.95
     },
     {
       "name": "K1",
-      "amplitude": 0.04175649,
-      "phase": 11.003242999999998
+      "amplitude": 0.042,
+      "phase": 4.62
     },
     {
       "name": "P1",
-      "amplitude": 0.019493450000000002,
-      "phase": 7.9031590000000165
+      "amplitude": 0.02,
+      "phase": 2.59
     },
     {
       "name": "O1",
-      "amplitude": 0.06263252,
-      "phase": 203.381333
+      "amplitude": 0.063,
+      "phase": 197.65
     },
     {
       "name": "Q1",
-      "amplitude": 0.02221547,
-      "phase": 150.07982600000003
+      "amplitude": 0.022,
+      "phase": 144.01
     },
     {
       "name": "M1",
-      "amplitude": 0.00083613,
-      "phase": 183.263258
+      "amplitude": 0.002,
+      "phase": 20.64
     },
     {
       "name": "M4",
-      "amplitude": 0.10450411000000001,
-      "phase": 191.49976
+      "amplitude": 0.119,
+      "phase": 168.63
     },
     {
       "name": "MM",
-      "amplitude": 0.007282889999999999,
-      "phase": 88.85439500000001
+      "amplitude": 0.007,
+      "phase": 86.56
     },
     {
       "name": "MF",
-      "amplitude": 0.006157129999999999,
-      "phase": 161.85146899999995
+      "amplitude": 0.006,
+      "phase": 163.52
     },
     {
       "name": "SA",
-      "amplitude": 0.07549903,
-      "phase": 247.08226100000002
+      "amplitude": 0.077,
+      "phase": 246.43
     },
     {
       "name": "SSA",
-      "amplitude": 0.03589992,
-      "phase": 170.318536
+      "amplitude": 0.036,
+      "phase": 168.36
     },
     {
       "name": "T2",
-      "amplitude": 0.01798066,
-      "phase": 99.55307399999998
+      "amplitude": 0.008,
+      "phase": 139.39
     },
     {
       "name": "J1",
-      "amplitude": 0.0015591,
-      "phase": 108.489938
+      "amplitude": 0.002,
+      "phase": 99.21
     },
     {
       "name": "L2",
-      "amplitude": 0.041550649999999995,
-      "phase": 131.62892999999997
+      "amplitude": 0.043,
+      "phase": 120.5
     },
     {
       "name": "R2",
-      "amplitude": 0.00798464,
-      "phase": 250.664104
+      "amplitude": 0.003,
+      "phase": 130.74
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00404161,
-      "phase": 88.16833099999997
+      "amplitude": 0.004,
+      "phase": 85.17
     },
     {
       "name": "MSF",
-      "amplitude": 0.03538624,
-      "phase": 61.071143000000006
+      "amplitude": 0.036,
+      "phase": 60.79
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00503459,
-      "phase": 331.447747
+      "amplitude": 0.005,
+      "phase": 330.52
     },
     {
       "name": "EP2",
-      "amplitude": 0.009963300000000001,
-      "phase": 209.002139
+      "amplitude": 0.01,
+      "phase": 198.05
     },
     {
       "name": "M3",
-      "amplitude": 0.0009145399999999999,
-      "phase": 245.831457
+      "amplitude": 0.001,
+      "phase": 43.7
     },
     {
       "name": "MU2",
-      "amplitude": 0.05658209,
-      "phase": 225.338522
+      "amplitude": 0.057,
+      "phase": 214.15
     },
     {
       "name": "MTM",
-      "amplitude": 0.00703718,
-      "phase": 250.231315
+      "amplitude": 0.007,
+      "phase": 241.05
     },
     {
       "name": "NU2",
-      "amplitude": 0.03134361,
-      "phase": 77.71164499999998
+      "amplitude": 0.033,
+      "phase": 63.82
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02034906,
-      "phase": 126.14728600000001
+      "amplitude": 0.021,
+      "phase": 116.03
     },
     {
       "name": "MN4",
-      "amplitude": 0.03515973,
-      "phase": 167.53017699999998
+      "amplitude": 0.04,
+      "phase": 145.01
     },
     {
       "name": "MS4",
-      "amplitude": 0.06414095,
-      "phase": 249.956265
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.00793409,
-      "phase": 272.517958
+      "amplitude": 0.072,
+      "phase": 227.83
     },
     {
       "name": "N4",
-      "amplitude": 0.009439030000000001,
-      "phase": 138.25464899999997
+      "amplitude": 0.012,
+      "phase": 116.09
     },
     {
       "name": "M6",
-      "amplitude": 0.01816988,
-      "phase": 201.23228
+      "amplitude": 0.023,
+      "phase": 166.23
     },
     {
       "name": "M8",
-      "amplitude": 0.0050510699999999995,
-      "phase": 252.863281
+      "amplitude": 0.01,
+      "phase": 208.76
     },
     {
       "name": "S4",
-      "amplitude": 0.00574061,
-      "phase": 349.572803
+      "amplitude": 0.006,
+      "phase": 322.65
     },
     {
       "name": "OO1",
-      "amplitude": 0.00124679,
-      "phase": 166.50462700000003
+      "amplitude": 0.001,
+      "phase": 152.13
     },
     {
       "name": "S3",
-      "amplitude": 0.00079458,
-      "phase": 59.42111399999999
+      "amplitude": 0.001,
+      "phase": 161.78
     },
     {
       "name": "MA2",
-      "amplitude": 0.06564889,
-      "phase": 99.63961999999998
+      "amplitude": 0.012,
+      "phase": 116.37
     },
     {
       "name": "MB2",
-      "amplitude": 0.05246513,
-      "phase": 290.48996999999997
+      "amplitude": 0.013,
+      "phase": 172.09
     },
     {
       "name": "T3",
-      "amplitude": 0.0009229999999999999,
-      "phase": 70.432229
+      "amplitude": 0.001,
+      "phase": 239.41
     },
     {
       "name": "R3",
-      "amplitude": 0.00279741,
-      "phase": 296.939081
+      "amplitude": 0.003,
+      "phase": 3.74
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00433002,
-      "phase": 145.17623100000003
+      "amplitude": 0.005,
+      "phase": 141.72
     },
     {
       "name": "SGM",
-      "amplitude": 0.00105265,
-      "phase": 175.62284899999997
+      "amplitude": 0.001,
+      "phase": 316.47
     },
     {
       "name": "3L2",
-      "amplitude": 0.00068424,
-      "phase": 307.44005400000003
+      "amplitude": 0.003,
+      "phase": 98.76
     },
     {
       "name": "3N2",
-      "amplitude": 0.00134413,
-      "phase": 122.57243199999999
+      "amplitude": 0.004,
+      "phase": 323.25
     },
     {
       "name": "2SM2",
-      "amplitude": 0.01582417,
-      "phase": 37.200784999999996
+      "amplitude": 0.016,
+      "phase": 27.13
     },
     {
       "name": "2MS6",
-      "amplitude": 0.01636472,
-      "phase": 258.574814
+      "amplitude": 0.02,
+      "phase": 222.94
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00476314,
-      "phase": 326.350135
+      "amplitude": 0.006,
+      "phase": 21.86
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00568334,
-      "phase": 333.617276
+      "amplitude": 0.007,
+      "phase": 217.97
     }
   ],
   "epoch": {

--- a/data/ticon/gouda_brug-goudbg-nld-rws.json
+++ b/data/ticon/gouda_brug-goudbg-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.6405386900000001,
-      "phase": 125.67439000000002
+      "amplitude": 0.661,
+      "phase": 109.18
     },
     {
       "name": "N2",
-      "amplitude": 0.08962131,
-      "phase": 99.99910799999998
+      "amplitude": 0.091,
+      "phase": 82.97
     },
     {
       "name": "S2",
-      "amplitude": 0.14899172,
-      "phase": 190.763149
+      "amplitude": 0.152,
+      "phase": 173.59
     },
     {
       "name": "K2",
-      "amplitude": 0.050561049999999996,
-      "phase": 196.044904
+      "amplitude": 0.05,
+      "phase": 177.58
     },
     {
       "name": "2N2",
-      "amplitude": 0.0216751,
-      "phase": 63.470256000000006
+      "amplitude": 0.023,
+      "phase": 54.28
     },
     {
       "name": "S1",
-      "amplitude": 0.00986994,
-      "phase": 20.919918999999993
+      "amplitude": 0.012,
+      "phase": 341.79
     },
     {
       "name": "K1",
-      "amplitude": 0.046409479999999996,
-      "phase": 26.167236000000003
+      "amplitude": 0.046,
+      "phase": 16.88
     },
     {
       "name": "P1",
-      "amplitude": 0.02797214,
-      "phase": 21.26542999999998
+      "amplitude": 0.028,
+      "phase": 13.31
     },
     {
       "name": "O1",
-      "amplitude": 0.0746204,
-      "phase": 214.019164
+      "amplitude": 0.075,
+      "phase": 206.03
     },
     {
       "name": "Q1",
-      "amplitude": 0.02861726,
-      "phase": 158.931373
+      "amplitude": 0.029,
+      "phase": 150.97
     },
     {
       "name": "M1",
-      "amplitude": 0.00293409,
-      "phase": 111.80514099999999
+      "amplitude": 0.002,
+      "phase": 6.82
     },
     {
       "name": "M4",
-      "amplitude": 0.16920525,
-      "phase": 233.77209499999998
+      "amplitude": 0.199,
+      "phase": 201.13
     },
     {
       "name": "MM",
-      "amplitude": 0.00687959,
-      "phase": 111.91519700000003
+      "amplitude": 0.006,
+      "phase": 114.78
     },
     {
       "name": "MF",
-      "amplitude": 0.00317583,
-      "phase": 52.796663000000024
+      "amplitude": 0.003,
+      "phase": 51.34
     },
     {
       "name": "SA",
-      "amplitude": 0.1037451,
-      "phase": 257.307958
+      "amplitude": 0.103,
+      "phase": 257.42
     },
     {
       "name": "SSA",
-      "amplitude": 0.03495677,
-      "phase": 181.142418
+      "amplitude": 0.035,
+      "phase": 182.42
     },
     {
       "name": "T2",
-      "amplitude": 0.02567049,
-      "phase": 112.11066700000003
+      "amplitude": 0.007,
+      "phase": 176.57
     },
     {
       "name": "J1",
-      "amplitude": 0.00221504,
-      "phase": 158.776563
+      "amplitude": 0.002,
+      "phase": 150.17
     },
     {
       "name": "L2",
-      "amplitude": 0.05614764,
-      "phase": 153.412152
+      "amplitude": 0.057,
+      "phase": 136.6
     },
     {
       "name": "R2",
-      "amplitude": 0.015396,
-      "phase": 258.052743
+      "amplitude": 0.008,
+      "phase": 169.99
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0052398,
-      "phase": 91.668451
+      "amplitude": 0.005,
+      "phase": 90.46
     },
     {
       "name": "MSF",
-      "amplitude": 0.03415364,
-      "phase": 62.64537999999999
+      "amplitude": 0.035,
+      "phase": 63.25
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00419263,
-      "phase": 249.551987
+      "amplitude": 0.004,
+      "phase": 250.38
     },
     {
       "name": "EP2",
-      "amplitude": 0.01312579,
-      "phase": 230.20167
+      "amplitude": 0.012,
+      "phase": 213.93
     },
     {
       "name": "M3",
-      "amplitude": 0.0015384700000000001,
-      "phase": 246.644996
+      "amplitude": 0.001,
+      "phase": 44.45
     },
     {
       "name": "MU2",
-      "amplitude": 0.08474475999999999,
-      "phase": 237.89643999999998
+      "amplitude": 0.085,
+      "phase": 222.61
     },
     {
       "name": "MTM",
-      "amplitude": 0.00901064,
-      "phase": 267.38392899999997
+      "amplitude": 0.009,
+      "phase": 260.08
     },
     {
       "name": "NU2",
-      "amplitude": 0.04502829,
-      "phase": 93.09602799999999
+      "amplitude": 0.046,
+      "phase": 73.48
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02789189,
-      "phase": 148.482682
+      "amplitude": 0.03,
+      "phase": 130.23
     },
     {
       "name": "MN4",
-      "amplitude": 0.05509662,
-      "phase": 211.919136
+      "amplitude": 0.065,
+      "phase": 179.25
     },
     {
       "name": "MS4",
-      "amplitude": 0.10442185999999999,
-      "phase": 294.01934900000003
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.012708950000000002,
-      "phase": 244.09554
+      "amplitude": 0.122,
+      "phase": 262.09
     },
     {
       "name": "N4",
-      "amplitude": 0.018596269999999998,
-      "phase": 178.00510199999997
+      "amplitude": 0.025,
+      "phase": 148.04
     },
     {
       "name": "M6",
-      "amplitude": 0.05554134,
-      "phase": 286.440509
+      "amplitude": 0.081,
+      "phase": 235.69
     },
     {
       "name": "M8",
-      "amplitude": 0.00755247,
-      "phase": 87.02454699999998
+      "amplitude": 0.019,
+      "phase": 16.95
     },
     {
       "name": "S4",
-      "amplitude": 0.01087423,
-      "phase": 49.71118200000001
+      "amplitude": 0.01,
+      "phase": 10.83
     },
     {
       "name": "OO1",
-      "amplitude": 0.0012281899999999999,
-      "phase": 181.67739
+      "amplitude": 0.001,
+      "phase": 152.9
     },
     {
       "name": "S3",
-      "amplitude": 0.002163,
-      "phase": 88.16538600000001
+      "amplitude": 0.001,
+      "phase": 223.53
     },
     {
       "name": "MA2",
-      "amplitude": 0.11034397,
-      "phase": 112.07486599999999
+      "amplitude": 0.01,
+      "phase": 126.99
     },
     {
       "name": "MB2",
-      "amplitude": 0.10499950999999999,
-      "phase": 302.70687399999997
+      "amplitude": 0.028,
+      "phase": 208.31
     },
     {
       "name": "T3",
-      "amplitude": 0.00042571,
-      "phase": 101.06782599999997
+      "amplitude": 0.001,
+      "phase": 271.94
     },
     {
       "name": "R3",
-      "amplitude": 0.00300623,
-      "phase": 316.528234
+      "amplitude": 0.003,
+      "phase": 6.89
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00572233,
-      "phase": 134.59824600000002
+      "amplitude": 0.005,
+      "phase": 134.78
     },
     {
       "name": "SGM",
-      "amplitude": 0.00135275,
-      "phase": 132.06831999999997
+      "amplitude": 0.002,
+      "phase": 281.07
     },
     {
       "name": "3L2",
-      "amplitude": 0.00912677,
-      "phase": 26.273676000000023
+      "amplitude": 0.009,
+      "phase": 103.59
     },
     {
       "name": "3N2",
-      "amplitude": 0.00445656,
-      "phase": 146.307138
+      "amplitude": 0.001,
+      "phase": 153.64
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02376927,
-      "phase": 53.437138000000004
+      "amplitude": 0.024,
+      "phase": 42.05
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04817235,
-      "phase": 345.853455
+      "amplitude": 0.068,
+      "phase": 294.98
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00707373,
-      "phase": 58.61728599999998
+      "amplitude": 0.009,
+      "phase": 97.32
     },
     {
       "name": "2MO5",
-      "amplitude": 0.010624880000000001,
-      "phase": 52.593631000000016
+      "amplitude": 0.013,
+      "phase": 288.63
     }
   ],
   "epoch": {

--- a/data/ticon/grauerortreede-5970026-deu-wsv.json
+++ b/data/ticon/grauerortreede-5970026-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3523743965862636,
-      "phase": 54.131628822191544
+      "amplitude": 1.352,
+      "phase": 54.13
     },
     {
       "name": "N2",
-      "amplitude": 0.20489740834006195,
-      "phase": 27.30405410626912
+      "amplitude": 0.205,
+      "phase": 27.3
     },
     {
       "name": "S2",
-      "amplitude": 0.31149353489259685,
-      "phase": 128.13541830616725
+      "amplitude": 0.311,
+      "phase": 128.14
     },
     {
       "name": "K2",
-      "amplitude": 0.09469131923003792,
-      "phase": 125.73221972525744
+      "amplitude": 0.095,
+      "phase": 125.73
     },
     {
       "name": "2N2",
-      "amplitude": 0.016194670972735782,
-      "phase": 350.0923297320234
+      "amplitude": 0.016,
+      "phase": 350.09
     },
     {
       "name": "S1",
-      "amplitude": 0.019386115100324428,
-      "phase": 84.81504972046099
+      "amplitude": 0.019,
+      "phase": 84.82
     },
     {
       "name": "K1",
-      "amplitude": 0.07162465462249948,
-      "phase": 85.80643505305204
+      "amplitude": 0.072,
+      "phase": 85.81
     },
     {
       "name": "P1",
-      "amplitude": 0.029671882147584556,
-      "phase": 86.39450535746255
+      "amplitude": 0.03,
+      "phase": 86.39
     },
     {
       "name": "O1",
-      "amplitude": 0.09065988295100741,
-      "phase": 290.0809775069117
+      "amplitude": 0.091,
+      "phase": 290.08
     },
     {
       "name": "Q1",
-      "amplitude": 0.028822318734604058,
-      "phase": 232.07477284569114
+      "amplitude": 0.029,
+      "phase": 232.07
     },
     {
       "name": "M1",
-      "amplitude": 0.00071013942337993,
-      "phase": 173.6542369460086
+      "amplitude": 0.001,
+      "phase": 173.65
     },
     {
       "name": "M4",
-      "amplitude": 0.10947081914276398,
-      "phase": 329.55127653858455
+      "amplitude": 0.109,
+      "phase": 329.55
     },
     {
       "name": "MM",
-      "amplitude": 0.055792626244642325,
-      "phase": 92.97231215033929
+      "amplitude": 0.056,
+      "phase": 92.97
     },
     {
       "name": "MF",
-      "amplitude": 0.025896158229854842,
-      "phase": 121.74248326965153
+      "amplitude": 0.026,
+      "phase": 121.74
     },
     {
       "name": "SA",
-      "amplitude": 0.08620273578731895,
-      "phase": 253.99245782622918
+      "amplitude": 0.086,
+      "phase": 253.99
     },
     {
       "name": "SSA",
-      "amplitude": 0.05584003262385013,
-      "phase": 227.15662899208613
+      "amplitude": 0.056,
+      "phase": 227.16
     },
     {
       "name": "T2",
-      "amplitude": 0.022404498136400976,
-      "phase": 102.98619660784641
+      "amplitude": 0.022,
+      "phase": 102.99
     },
     {
       "name": "J1",
-      "amplitude": 0.006044547306119646,
-      "phase": 199.28741471492393
+      "amplitude": 0.006,
+      "phase": 199.29
     },
     {
       "name": "L2",
-      "amplitude": 0.1392100250727004,
-      "phase": 65.15144320414868
+      "amplitude": 0.139,
+      "phase": 65.15
     },
     {
       "name": "R2",
-      "amplitude": 0.005659800813905045,
-      "phase": 33.41294380394555
+      "amplitude": 0.006,
+      "phase": 33.41
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005865755694397247,
-      "phase": 145.71404262963495
+      "amplitude": 0.006,
+      "phase": 145.71
     },
     {
       "name": "MSF",
-      "amplitude": 0.05071586606308001,
-      "phase": 66.58864338243245
+      "amplitude": 0.051,
+      "phase": 66.59
     },
     {
       "name": "MSQM",
-      "amplitude": 0.010411071420866044,
-      "phase": 251.4726783290006
+      "amplitude": 0.01,
+      "phase": 251.47
     },
     {
       "name": "EP2",
-      "amplitude": 0.037212623682178377,
-      "phase": 123.56102256136302
+      "amplitude": 0.037,
+      "phase": 123.56
     },
     {
       "name": "M3",
-      "amplitude": 0.0033525431765951386,
-      "phase": 69.34108058193891
+      "amplitude": 0.003,
+      "phase": 69.34
     },
     {
       "name": "MU2",
-      "amplitude": 0.1834006227317119,
-      "phase": 146.62896601732234
+      "amplitude": 0.183,
+      "phase": 146.63
     },
     {
       "name": "MTM",
-      "amplitude": 0.012693782271037159,
-      "phase": 225.61185409094716
+      "amplitude": 0.013,
+      "phase": 225.61
     },
     {
       "name": "NU2",
-      "amplitude": 0.09342233735948331,
-      "phase": 13.153783922859986
+      "amplitude": 0.093,
+      "phase": 13.15
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05153800773794513,
-      "phase": 71.6715594802929
+      "amplitude": 0.052,
+      "phase": 71.67
     },
     {
       "name": "MN4",
-      "amplitude": 0.03673769959139927,
-      "phase": 305.5168904136635
+      "amplitude": 0.037,
+      "phase": 305.52
     },
     {
       "name": "MS4",
-      "amplitude": 0.06331559767177147,
-      "phase": 39.29084690867262
+      "amplitude": 0.063,
+      "phase": 39.29
     },
     {
       "name": "N4",
-      "amplitude": 0.006403491292903457,
-      "phase": 278.49614234798463
+      "amplitude": 0.006,
+      "phase": 278.5
     },
     {
       "name": "M6",
-      "amplitude": 0.0860631233708322,
-      "phase": 209.45856012659416
+      "amplitude": 0.086,
+      "phase": 209.46
     },
     {
       "name": "M8",
-      "amplitude": 0.025314883807303193,
-      "phase": 162.8609196218972
+      "amplitude": 0.025,
+      "phase": 162.86
     },
     {
       "name": "S4",
-      "amplitude": 0.006455927734438939,
-      "phase": 170.0184057421618
+      "amplitude": 0.006,
+      "phase": 170.02
     },
     {
       "name": "OO1",
-      "amplitude": 0.00512129744489548,
-      "phase": 200.44382184897052
+      "amplitude": 0.005,
+      "phase": 200.44
     },
     {
       "name": "S3",
-      "amplitude": 0.0010172366095653053,
-      "phase": 28.962081326391512
+      "amplitude": 0.001,
+      "phase": 28.96
     },
     {
       "name": "MA2",
-      "amplitude": 0.0442478814355124,
-      "phase": 27.543475244775777
+      "amplitude": 0.044,
+      "phase": 27.54
     },
     {
       "name": "MB2",
-      "amplitude": 0.019937108249881073,
-      "phase": 65.43819408627587
+      "amplitude": 0.02,
+      "phase": 65.44
     },
     {
       "name": "T3",
-      "amplitude": 0.00019158918924648595,
-      "phase": 324.5020239526731
+      "amplitude": 0,
+      "phase": 324.5
     },
     {
       "name": "R3",
-      "amplitude": 0.004289784404914765,
-      "phase": 124.2410230825709
+      "amplitude": 0.004,
+      "phase": 124.24
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006422913884326533,
-      "phase": 253.09123988880424
+      "amplitude": 0.006,
+      "phase": 253.09
     },
     {
       "name": "SGM",
-      "amplitude": 0.003991594446239299,
-      "phase": 118.10764904986866
+      "amplitude": 0.004,
+      "phase": 118.11
     },
     {
       "name": "3L2",
-      "amplitude": 0.03983115401671431,
-      "phase": 313.73347432336556
+      "amplitude": 0.04,
+      "phase": 313.73
     },
     {
       "name": "3N2",
-      "amplitude": 0.014347784478716794,
-      "phase": 236.14804883067177
+      "amplitude": 0.014,
+      "phase": 236.15
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03280979466158244,
-      "phase": 356.49621741420674
+      "amplitude": 0.033,
+      "phase": 356.5
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08308742603820606,
-      "phase": 278.49427623401687
+      "amplitude": 0.083,
+      "phase": 278.49
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005241720107348501,
-      "phase": 220.25071136059816
+      "amplitude": 0.005,
+      "phase": 220.25
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004451907653037136,
-      "phase": 90.97429720726558
+      "amplitude": 0.004,
+      "phase": 90.97
     }
   ],
   "epoch": {

--- a/data/ticon/greifswaldoie-9690078-deu-wsv.json
+++ b/data/ticon/greifswaldoie-9690078-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.011095272227492502,
-      "phase": 294.50228338246524
+      "amplitude": 0.011,
+      "phase": 294.5
     },
     {
       "name": "N2",
-      "amplitude": 0.0032401619646430144,
-      "phase": 251.71589150544048
+      "amplitude": 0.003,
+      "phase": 251.72
     },
     {
       "name": "S2",
-      "amplitude": 0.0026814961693431287,
-      "phase": 258.4937435428818
+      "amplitude": 0.003,
+      "phase": 258.49
     },
     {
       "name": "K2",
-      "amplitude": 0.0009939395862674106,
-      "phase": 228.10959633651362
+      "amplitude": 0.001,
+      "phase": 228.11
     },
     {
       "name": "2N2",
-      "amplitude": 0.0004984447933003172,
-      "phase": 250.10028563203062
+      "amplitude": 0,
+      "phase": 250.1
     },
     {
       "name": "S1",
-      "amplitude": 0.005996634973532158,
-      "phase": 15.91790250727854
+      "amplitude": 0.006,
+      "phase": 15.92
     },
     {
       "name": "K1",
-      "amplitude": 0.0069332450263786235,
-      "phase": 151.51078110776
+      "amplitude": 0.007,
+      "phase": 151.51
     },
     {
       "name": "P1",
-      "amplitude": 0.0012770110285043582,
-      "phase": 156.92396004533555
+      "amplitude": 0.001,
+      "phase": 156.92
     },
     {
       "name": "O1",
-      "amplitude": 0.01151480947872961,
-      "phase": 142.86193988695902
+      "amplitude": 0.012,
+      "phase": 142.86
     },
     {
       "name": "Q1",
-      "amplitude": 0.0018316810400376372,
-      "phase": 106.44374357278838
+      "amplitude": 0.002,
+      "phase": 106.44
     },
     {
       "name": "M1",
-      "amplitude": 0.0005394540884791124,
-      "phase": 49.45719541747974
+      "amplitude": 0.001,
+      "phase": 49.46
     },
     {
       "name": "M4",
-      "amplitude": 0.0005851587997999977,
-      "phase": 279.0463924384254
+      "amplitude": 0.001,
+      "phase": 279.05
     },
     {
       "name": "MM",
-      "amplitude": 0.011448469924105687,
-      "phase": 272.27316407909456
+      "amplitude": 0.011,
+      "phase": 272.27
     },
     {
       "name": "MF",
-      "amplitude": 0.007921433797127982,
-      "phase": 272.1289049937865
+      "amplitude": 0.008,
+      "phase": 272.13
     },
     {
       "name": "SA",
-      "amplitude": 0.0458244470031586,
-      "phase": 196.1408466129364
+      "amplitude": 0.046,
+      "phase": 196.14
     },
     {
       "name": "SSA",
-      "amplitude": 0.0376468864008184,
-      "phase": 237.35609034502983
+      "amplitude": 0.038,
+      "phase": 237.36
     },
     {
       "name": "T2",
-      "amplitude": 0.0008056067833075323,
-      "phase": 243.20179110443127
+      "amplitude": 0.001,
+      "phase": 243.2
     },
     {
       "name": "J1",
-      "amplitude": 0.0007608450834729786,
-      "phase": 211.3441721551425
+      "amplitude": 0.001,
+      "phase": 211.34
     },
     {
       "name": "L2",
-      "amplitude": 0.0010795832468534635,
-      "phase": 48.33998421151307
+      "amplitude": 0.001,
+      "phase": 48.34
     },
     {
       "name": "R2",
-      "amplitude": 0.0003480634052392502,
-      "phase": 59.817707350064836
+      "amplitude": 0,
+      "phase": 59.82
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00016084343917215115,
-      "phase": 140.4183340289942
+      "amplitude": 0,
+      "phase": 140.42
     },
     {
       "name": "MSF",
-      "amplitude": 0.001022212348422306,
-      "phase": 268.5867409238059
+      "amplitude": 0.001,
+      "phase": 268.59
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003682560530281907,
-      "phase": 188.5125582017105
+      "amplitude": 0.004,
+      "phase": 188.51
     },
     {
       "name": "EP2",
-      "amplitude": 0.0005179353332323989,
-      "phase": 80.14284425165135
+      "amplitude": 0.001,
+      "phase": 80.14
     },
     {
       "name": "M3",
-      "amplitude": 0.000257468128647311,
-      "phase": 282.83584352470626
+      "amplitude": 0,
+      "phase": 282.84
     },
     {
       "name": "MU2",
-      "amplitude": 0.002151801484689631,
-      "phase": 119.68631555739876
+      "amplitude": 0.002,
+      "phase": 119.69
     },
     {
       "name": "MTM",
-      "amplitude": 0.0033522428488384987,
-      "phase": 337.31041858364665
+      "amplitude": 0.003,
+      "phase": 337.31
     },
     {
       "name": "NU2",
-      "amplitude": 0.0011098692915657003,
-      "phase": 294.606322536609
+      "amplitude": 0.001,
+      "phase": 294.61
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0005855127069065879,
-      "phase": 34.83885882347437
+      "amplitude": 0.001,
+      "phase": 34.84
     },
     {
       "name": "MN4",
-      "amplitude": 0.0003120943893338819,
-      "phase": 212.1037579401723
+      "amplitude": 0,
+      "phase": 212.1
     },
     {
       "name": "MS4",
-      "amplitude": 0.00026893634307759194,
-      "phase": 87.68181716259176
+      "amplitude": 0,
+      "phase": 87.68
     },
     {
       "name": "N4",
-      "amplitude": 0.00005894424979547673,
-      "phase": 157.95485850383534
+      "amplitude": 0,
+      "phase": 157.95
     },
     {
       "name": "M6",
-      "amplitude": 0.00008302804859014233,
-      "phase": 39.516072530025156
+      "amplitude": 0,
+      "phase": 39.52
     },
     {
       "name": "M8",
-      "amplitude": 0.00005352569093982375,
-      "phase": 237.71369808730338
+      "amplitude": 0,
+      "phase": 237.71
     },
     {
       "name": "S4",
-      "amplitude": 0.00010105002630968675,
-      "phase": 66.68291429058104
+      "amplitude": 0,
+      "phase": 66.68
     },
     {
       "name": "OO1",
-      "amplitude": 0.00015010165361345696,
-      "phase": 157.90749255882645
+      "amplitude": 0,
+      "phase": 157.91
     },
     {
       "name": "S3",
-      "amplitude": 0.0005358439971336702,
-      "phase": 308.57813594882407
+      "amplitude": 0.001,
+      "phase": 308.58
     },
     {
       "name": "MA2",
-      "amplitude": 0.00132203782556448,
-      "phase": 314.9368198851205
+      "amplitude": 0.001,
+      "phase": 314.94
     },
     {
       "name": "MB2",
-      "amplitude": 0.0012832223501061098,
-      "phase": 89.48517738330321
+      "amplitude": 0.001,
+      "phase": 89.49
     },
     {
       "name": "T3",
-      "amplitude": 0.0003453023137361354,
-      "phase": 182.1445873749024
+      "amplitude": 0,
+      "phase": 182.14
     },
     {
       "name": "R3",
-      "amplitude": 0.00028245431747071423,
-      "phase": 319.443357233073
+      "amplitude": 0,
+      "phase": 319.44
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00053221540718197,
-      "phase": 78.28929825129023
+      "amplitude": 0.001,
+      "phase": 78.29
     },
     {
       "name": "SGM",
-      "amplitude": 0.0010713356201232172,
-      "phase": 237.75602060050278
+      "amplitude": 0.001,
+      "phase": 237.76
     },
     {
       "name": "3L2",
-      "amplitude": 0.00018537942429963148,
-      "phase": 200.62458898272575
+      "amplitude": 0,
+      "phase": 200.62
     },
     {
       "name": "3N2",
-      "amplitude": 0.0003161299356531309,
-      "phase": 192.82803894058534
+      "amplitude": 0,
+      "phase": 192.83
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0005498216234293975,
-      "phase": 18.257451164909696
+      "amplitude": 0.001,
+      "phase": 18.26
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00007979917818279802,
-      "phase": 120.87836256274682
+      "amplitude": 0,
+      "phase": 120.88
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000023585572079751425,
-      "phase": 201.21684573666045
+      "amplitude": 0,
+      "phase": 201.22
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00003637600126808392,
-      "phase": 149.65057357334194
+      "amplitude": 0,
+      "phase": 149.65
     }
   ],
   "epoch": {

--- a/data/ticon/greifswaldwieck-9650073-deu-wsv.json
+++ b/data/ticon/greifswaldwieck-9650073-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.015723277159474535,
-      "phase": 311.15958132371827
+      "amplitude": 0.016,
+      "phase": 311.16
     },
     {
       "name": "N2",
-      "amplitude": 0.004580782675506539,
-      "phase": 266.3603888769459
+      "amplitude": 0.005,
+      "phase": 266.36
     },
     {
       "name": "S2",
-      "amplitude": 0.0030872119782642876,
-      "phase": 266.5117428239062
+      "amplitude": 0.003,
+      "phase": 266.51
     },
     {
       "name": "K2",
-      "amplitude": 0.001743416143339712,
-      "phase": 249.75011783121556
+      "amplitude": 0.002,
+      "phase": 249.75
     },
     {
       "name": "2N2",
-      "amplitude": 0.0008148642874922014,
-      "phase": 286.13760422415055
+      "amplitude": 0.001,
+      "phase": 286.14
     },
     {
       "name": "S1",
-      "amplitude": 0.010014111382006781,
-      "phase": 41.441724540716336
+      "amplitude": 0.01,
+      "phase": 41.44
     },
     {
       "name": "K1",
-      "amplitude": 0.0075845518033924465,
-      "phase": 145.88180977078144
+      "amplitude": 0.008,
+      "phase": 145.88
     },
     {
       "name": "P1",
-      "amplitude": 0.0017561059834625887,
-      "phase": 92.75970291174735
+      "amplitude": 0.002,
+      "phase": 92.76
     },
     {
       "name": "O1",
-      "amplitude": 0.013510898967834493,
-      "phase": 147.27424157638552
+      "amplitude": 0.014,
+      "phase": 147.27
     },
     {
       "name": "Q1",
-      "amplitude": 0.002046935430863554,
-      "phase": 108.15027210386654
+      "amplitude": 0.002,
+      "phase": 108.15
     },
     {
       "name": "M1",
-      "amplitude": 0.0006111844520425636,
-      "phase": 43.11018204998163
+      "amplitude": 0.001,
+      "phase": 43.11
     },
     {
       "name": "M4",
-      "amplitude": 0.0018139321035894717,
-      "phase": 4.582146822648099
+      "amplitude": 0.002,
+      "phase": 4.58
     },
     {
       "name": "MM",
-      "amplitude": 0.012012795772930143,
-      "phase": 285.80415515183654
+      "amplitude": 0.012,
+      "phase": 285.8
     },
     {
       "name": "MF",
-      "amplitude": 0.00925884171568808,
-      "phase": 275.9282269587614
+      "amplitude": 0.009,
+      "phase": 275.93
     },
     {
       "name": "SA",
-      "amplitude": 0.0356293035654468,
-      "phase": 189.5026713468112
+      "amplitude": 0.036,
+      "phase": 189.5
     },
     {
       "name": "SSA",
-      "amplitude": 0.031219612491395873,
-      "phase": 249.76126122128352
+      "amplitude": 0.031,
+      "phase": 249.76
     },
     {
       "name": "T2",
-      "amplitude": 0.001028369954431247,
-      "phase": 252.17681321227673
+      "amplitude": 0.001,
+      "phase": 252.18
     },
     {
       "name": "J1",
-      "amplitude": 0.0007392706708013929,
-      "phase": 211.18645606080239
+      "amplitude": 0.001,
+      "phase": 211.19
     },
     {
       "name": "L2",
-      "amplitude": 0.001699322187579575,
-      "phase": 66.97679201943771
+      "amplitude": 0.002,
+      "phase": 66.98
     },
     {
       "name": "R2",
-      "amplitude": 0.0006892424844055267,
-      "phase": 52.95111536576934
+      "amplitude": 0.001,
+      "phase": 52.95
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00031330183531861727,
-      "phase": 213.63064336581056
+      "amplitude": 0,
+      "phase": 213.63
     },
     {
       "name": "MSF",
-      "amplitude": 0.0010611787155436244,
-      "phase": 239.5449898360004
+      "amplitude": 0.001,
+      "phase": 239.54
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004269420173683635,
-      "phase": 195.89454662934529
+      "amplitude": 0.004,
+      "phase": 195.89
     },
     {
       "name": "EP2",
-      "amplitude": 0.0007717300909412838,
-      "phase": 81.36856010588463
+      "amplitude": 0.001,
+      "phase": 81.37
     },
     {
       "name": "M3",
-      "amplitude": 0.0007276559719027857,
-      "phase": 303.6518483331933
+      "amplitude": 0.001,
+      "phase": 303.65
     },
     {
       "name": "MU2",
-      "amplitude": 0.002845020539104621,
-      "phase": 133.57356789645746
+      "amplitude": 0.003,
+      "phase": 133.57
     },
     {
       "name": "MTM",
-      "amplitude": 0.004046057972294805,
-      "phase": 351.65778608968225
+      "amplitude": 0.004,
+      "phase": 351.66
     },
     {
       "name": "NU2",
-      "amplitude": 0.0014198170241517582,
-      "phase": 314.12992957080104
+      "amplitude": 0.001,
+      "phase": 314.13
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0007444241359382089,
-      "phase": 53.051294551418664
+      "amplitude": 0.001,
+      "phase": 53.05
     },
     {
       "name": "MN4",
-      "amplitude": 0.0006856077747368031,
-      "phase": 298.4135877139726
+      "amplitude": 0.001,
+      "phase": 298.41
     },
     {
       "name": "MS4",
-      "amplitude": 0.0007862435518470948,
-      "phase": 172.62098281469684
+      "amplitude": 0.001,
+      "phase": 172.62
     },
     {
       "name": "N4",
-      "amplitude": 0.00015904204650924868,
-      "phase": 240.02996866209764
+      "amplitude": 0,
+      "phase": 240.03
     },
     {
       "name": "M6",
-      "amplitude": 0.00012774825058681525,
-      "phase": 209.68557792332481
+      "amplitude": 0,
+      "phase": 209.69
     },
     {
       "name": "M8",
-      "amplitude": 0.00006589665384929699,
-      "phase": 330.06792279822326
+      "amplitude": 0,
+      "phase": 330.07
     },
     {
       "name": "S4",
-      "amplitude": 0.00013999787843939427,
-      "phase": 155.3115151565205
+      "amplitude": 0,
+      "phase": 155.31
     },
     {
       "name": "OO1",
-      "amplitude": 0.00037996437171398473,
-      "phase": 96.09871194087879
+      "amplitude": 0,
+      "phase": 96.1
     },
     {
       "name": "S3",
-      "amplitude": 0.0011116914521464199,
-      "phase": 1.2608294919978107
+      "amplitude": 0.001,
+      "phase": 1.26
     },
     {
       "name": "MA2",
-      "amplitude": 0.001454823189098017,
-      "phase": 326.001018291239
+      "amplitude": 0.001,
+      "phase": 326
     },
     {
       "name": "MB2",
-      "amplitude": 0.0018229262157007605,
-      "phase": 88.86181226273214
+      "amplitude": 0.002,
+      "phase": 88.86
     },
     {
       "name": "T3",
-      "amplitude": 0.0006630815622367409,
-      "phase": 247.82435421227268
+      "amplitude": 0.001,
+      "phase": 247.82
     },
     {
       "name": "R3",
-      "amplitude": 0.0007066272645453335,
-      "phase": 4.097986720194456
+      "amplitude": 0.001,
+      "phase": 4.1
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00010403664845478301,
-      "phase": 241.1103979664769
+      "amplitude": 0,
+      "phase": 241.11
     },
     {
       "name": "SGM",
-      "amplitude": 0.0010926168912715887,
-      "phase": 237.04939429162386
+      "amplitude": 0.001,
+      "phase": 237.05
     },
     {
       "name": "3L2",
-      "amplitude": 0.0002536527150248541,
-      "phase": 217.32792529721021
+      "amplitude": 0,
+      "phase": 217.33
     },
     {
       "name": "3N2",
-      "amplitude": 0.0005911837353530454,
-      "phase": 213.29247377048978
+      "amplitude": 0.001,
+      "phase": 213.29
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0007525600407957,
-      "phase": 49.46870154548583
+      "amplitude": 0.001,
+      "phase": 49.47
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0001568954488147064,
-      "phase": 275.52966963622396
+      "amplitude": 0,
+      "phase": 275.53
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00004357211864970067,
-      "phase": 73.8520034094467
+      "amplitude": 0,
+      "phase": 73.85
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00010274320168998446,
-      "phase": 278.54770776786984
+      "amplitude": 0,
+      "phase": 278.55
     }
   ],
   "epoch": {

--- a/data/ticon/grnhude-5970037-deu-wsv.json
+++ b/data/ticon/grnhude-5970037-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.4284311522376752,
-      "phase": 127.20503007845156
+      "amplitude": 0.428,
+      "phase": 127.21
     },
     {
       "name": "N2",
-      "amplitude": 0.06281611954723765,
-      "phase": 98.29863342666022
+      "amplitude": 0.063,
+      "phase": 98.3
     },
     {
       "name": "S2",
-      "amplitude": 0.10100279072557458,
-      "phase": 202.92626775127985
+      "amplitude": 0.101,
+      "phase": 202.93
     },
     {
       "name": "K2",
-      "amplitude": 0.029612586124026466,
-      "phase": 207.06929049978746
+      "amplitude": 0.03,
+      "phase": 207.07
     },
     {
       "name": "2N2",
-      "amplitude": 0.004043975739758994,
-      "phase": 64.20316298190829
+      "amplitude": 0.004,
+      "phase": 64.2
     },
     {
       "name": "S1",
-      "amplitude": 0.009956168512711621,
-      "phase": 120.79522038959249
+      "amplitude": 0.01,
+      "phase": 120.8
     },
     {
       "name": "K1",
-      "amplitude": 0.040651117001860027,
-      "phase": 146.10707426215458
+      "amplitude": 0.041,
+      "phase": 146.11
     },
     {
       "name": "P1",
-      "amplitude": 0.01281454760804482,
-      "phase": 128.8076693797874
+      "amplitude": 0.013,
+      "phase": 128.81
     },
     {
       "name": "O1",
-      "amplitude": 0.045630790345196924,
-      "phase": 345.4850768878935
+      "amplitude": 0.046,
+      "phase": 345.49
     },
     {
       "name": "Q1",
-      "amplitude": 0.011724314269726373,
-      "phase": 281.5785247832466
+      "amplitude": 0.012,
+      "phase": 281.58
     },
     {
       "name": "M1",
-      "amplitude": 0.0010623914585676103,
-      "phase": 168.66035146902618
+      "amplitude": 0.001,
+      "phase": 168.66
     },
     {
       "name": "M4",
-      "amplitude": 0.10071624487924345,
-      "phase": 204.38854758600564
+      "amplitude": 0.101,
+      "phase": 204.39
     },
     {
       "name": "MM",
-      "amplitude": 0.005598592784410317,
-      "phase": 64.8136625424907
+      "amplitude": 0.006,
+      "phase": 64.81
     },
     {
       "name": "MF",
-      "amplitude": 0.01502932318165052,
-      "phase": 98.11591279550964
+      "amplitude": 0.015,
+      "phase": 98.12
     },
     {
       "name": "SA",
-      "amplitude": 0.21120876103170372,
-      "phase": 300.1477271284846
+      "amplitude": 0.211,
+      "phase": 300.15
     },
     {
       "name": "SSA",
-      "amplitude": 0.06250811354205196,
-      "phase": 247.85119221094908
+      "amplitude": 0.063,
+      "phase": 247.85
     },
     {
       "name": "T2",
-      "amplitude": 0.005902604490238837,
-      "phase": 337.2915118566528
+      "amplitude": 0.006,
+      "phase": 337.29
     },
     {
       "name": "J1",
-      "amplitude": 0.005298234737669171,
-      "phase": 261.58073382742015
+      "amplitude": 0.005,
+      "phase": 261.58
     },
     {
       "name": "L2",
-      "amplitude": 0.04021262737183303,
-      "phase": 142.5385810097074
+      "amplitude": 0.04,
+      "phase": 142.54
     },
     {
       "name": "R2",
-      "amplitude": 0.010983309475664105,
-      "phase": 245.43424567887922
+      "amplitude": 0.011,
+      "phase": 245.43
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0022282948685441208,
-      "phase": 216.06601311660228
+      "amplitude": 0.002,
+      "phase": 216.07
     },
     {
       "name": "MSF",
-      "amplitude": 0.05881037201881746,
-      "phase": 64.73472618437654
+      "amplitude": 0.059,
+      "phase": 64.73
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0035738906904453525,
-      "phase": 18.148639570599926
+      "amplitude": 0.004,
+      "phase": 18.15
     },
     {
       "name": "EP2",
-      "amplitude": 0.011839515800485848,
-      "phase": 177.24469920151387
+      "amplitude": 0.012,
+      "phase": 177.24
     },
     {
       "name": "M3",
-      "amplitude": 0.0018483935857211882,
-      "phase": 233.31858627219214
+      "amplitude": 0.002,
+      "phase": 233.32
     },
     {
       "name": "MU2",
-      "amplitude": 0.050938967976397936,
-      "phase": 216.624961979312
+      "amplitude": 0.051,
+      "phase": 216.62
     },
     {
       "name": "MTM",
-      "amplitude": 0.002373603834139556,
-      "phase": 190.54417956290882
+      "amplitude": 0.002,
+      "phase": 190.54
     },
     {
       "name": "NU2",
-      "amplitude": 0.027006308136498697,
-      "phase": 86.25975967960312
+      "amplitude": 0.027,
+      "phase": 86.26
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.01805609659180927,
-      "phase": 153.2717334988638
+      "amplitude": 0.018,
+      "phase": 153.27
     },
     {
       "name": "MN4",
-      "amplitude": 0.03132102065221197,
-      "phase": 177.15482547971965
+      "amplitude": 0.031,
+      "phase": 177.15
     },
     {
       "name": "MS4",
-      "amplitude": 0.04857385383022353,
-      "phase": 276.4401115463554
+      "amplitude": 0.049,
+      "phase": 276.44
     },
     {
       "name": "N4",
-      "amplitude": 0.005310799958135873,
-      "phase": 160.25250297955972
+      "amplitude": 0.005,
+      "phase": 160.25
     },
     {
       "name": "M6",
-      "amplitude": 0.018127786713393736,
-      "phase": 277.18411921097174
+      "amplitude": 0.018,
+      "phase": 277.18
     },
     {
       "name": "M8",
-      "amplitude": 0.0018369105068434246,
-      "phase": 107.9348425404254
+      "amplitude": 0.002,
+      "phase": 107.93
     },
     {
       "name": "S4",
-      "amplitude": 0.0019642014807909796,
-      "phase": 66.58873981555371
+      "amplitude": 0.002,
+      "phase": 66.59
     },
     {
       "name": "OO1",
-      "amplitude": 0.0013669804907404555,
-      "phase": 270.06262622055283
+      "amplitude": 0.001,
+      "phase": 270.06
     },
     {
       "name": "S3",
-      "amplitude": 0.0003870301519435391,
-      "phase": 279.3000638948538
+      "amplitude": 0,
+      "phase": 279.3
     },
     {
       "name": "MA2",
-      "amplitude": 0.051558099199716094,
-      "phase": 357.4066360530548
+      "amplitude": 0.052,
+      "phase": 357.41
     },
     {
       "name": "MB2",
-      "amplitude": 0.05242879008436545,
-      "phase": 252.379410114764
+      "amplitude": 0.052,
+      "phase": 252.38
     },
     {
       "name": "T3",
-      "amplitude": 0.0007068800606474431,
-      "phase": 227.61032453822355
+      "amplitude": 0.001,
+      "phase": 227.61
     },
     {
       "name": "R3",
-      "amplitude": 0.0017885536399295874,
-      "phase": 256.96861079094816
+      "amplitude": 0.002,
+      "phase": 256.97
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0031509839279908612,
-      "phase": 296.32048672689785
+      "amplitude": 0.003,
+      "phase": 296.32
     },
     {
       "name": "SGM",
-      "amplitude": 0.003792580574684929,
-      "phase": 123.54623478173295
+      "amplitude": 0.004,
+      "phase": 123.55
     },
     {
       "name": "3L2",
-      "amplitude": 0.0009303671152596486,
-      "phase": 23.986849001110613
+      "amplitude": 0.001,
+      "phase": 23.99
     },
     {
       "name": "3N2",
-      "amplitude": 0.011587027926397394,
-      "phase": 258.18505674779726
+      "amplitude": 0.012,
+      "phase": 258.19
     },
     {
       "name": "2SM2",
-      "amplitude": 0.009934925730643957,
-      "phase": 71.4450712712113
+      "amplitude": 0.01,
+      "phase": 71.45
     },
     {
       "name": "2MS6",
-      "amplitude": 0.01413657955889351,
-      "phase": 346.2548319874981
+      "amplitude": 0.014,
+      "phase": 346.25
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0037837061020917556,
-      "phase": 235.31596558913418
+      "amplitude": 0.004,
+      "phase": 235.32
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005153254420313517,
-      "phase": 83.64316971558208
+      "amplitude": 0.005,
+      "phase": 83.64
     }
   ],
   "epoch": {

--- a/data/ticon/grosseweserbrcke-4910050-deu-wsv.json
+++ b/data/ticon/grosseweserbrcke-4910050-deu-wsv.json
@@ -1,6 +1,6 @@
 {
   "name": "Grosseweserbrcke",
-  "region": "City state Bremen",
+  "region": "Bremen",
   "country": "Germany",
   "continent": "Europe",
   "latitude": 53.074594,
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.750687775469703,
-      "phase": 40.55191895951299
+      "amplitude": 1.751,
+      "phase": 40.55
     },
     {
       "name": "N2",
-      "amplitude": 0.26598454594885823,
-      "phase": 16.578489440922908
+      "amplitude": 0.266,
+      "phase": 16.58
     },
     {
       "name": "S2",
-      "amplitude": 0.43967784634301227,
-      "phase": 121.75353165042497
+      "amplitude": 0.44,
+      "phase": 121.75
     },
     {
       "name": "K2",
-      "amplitude": 0.12934648126673928,
-      "phase": 121.31188830254047
+      "amplitude": 0.129,
+      "phase": 121.31
     },
     {
       "name": "2N2",
-      "amplitude": 0.027735759736967652,
-      "phase": 356.5755338074931
+      "amplitude": 0.028,
+      "phase": 356.58
     },
     {
       "name": "S1",
-      "amplitude": 0.015665042733271475,
-      "phase": 89.10400284812084
+      "amplitude": 0.016,
+      "phase": 89.1
     },
     {
       "name": "K1",
-      "amplitude": 0.0676280566555501,
-      "phase": 76.10797158815586
+      "amplitude": 0.068,
+      "phase": 76.11
     },
     {
       "name": "P1",
-      "amplitude": 0.028794715660787826,
-      "phase": 82.24033147721678
+      "amplitude": 0.029,
+      "phase": 82.24
     },
     {
       "name": "O1",
-      "amplitude": 0.08590140066176064,
-      "phase": 281.6999945131846
+      "amplitude": 0.086,
+      "phase": 281.7
     },
     {
       "name": "Q1",
-      "amplitude": 0.02307151986520869,
-      "phase": 219.83475315687355
+      "amplitude": 0.023,
+      "phase": 219.83
     },
     {
       "name": "M1",
-      "amplitude": 0.002535905738055904,
-      "phase": 137.8749483581006
+      "amplitude": 0.003,
+      "phase": 137.87
     },
     {
       "name": "M4",
-      "amplitude": 0.18816357683043627,
-      "phase": 348.559815505554
+      "amplitude": 0.188,
+      "phase": 348.56
     },
     {
       "name": "MM",
-      "amplitude": 0.010675399288779001,
-      "phase": 94.44074560008465
+      "amplitude": 0.011,
+      "phase": 94.44
     },
     {
       "name": "MF",
-      "amplitude": 0.012830917654256348,
-      "phase": 89.30584139909843
+      "amplitude": 0.013,
+      "phase": 89.31
     },
     {
       "name": "SA",
-      "amplitude": 0.12119950815092637,
-      "phase": 301.7712741092557
+      "amplitude": 0.121,
+      "phase": 301.77
     },
     {
       "name": "SSA",
-      "amplitude": 0.07140734581713394,
-      "phase": 247.28986570812714
+      "amplitude": 0.071,
+      "phase": 247.29
     },
     {
       "name": "T2",
-      "amplitude": 0.019485312391360532,
-      "phase": 87.47995604282852
+      "amplitude": 0.019,
+      "phase": 87.48
     },
     {
       "name": "J1",
-      "amplitude": 0.004016811538090977,
-      "phase": 199.6917065601699
+      "amplitude": 0.004,
+      "phase": 199.69
     },
     {
       "name": "L2",
-      "amplitude": 0.15910681554765033,
-      "phase": 53.83335803778522
+      "amplitude": 0.159,
+      "phase": 53.83
     },
     {
       "name": "R2",
-      "amplitude": 0.012993122218627664,
-      "phase": 206.7870127614058
+      "amplitude": 0.013,
+      "phase": 206.79
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004889352648179917,
-      "phase": 159.50977167681992
+      "amplitude": 0.005,
+      "phase": 159.51
     },
     {
       "name": "MSF",
-      "amplitude": 0.05666676673248564,
-      "phase": 66.37608227429996
+      "amplitude": 0.057,
+      "phase": 66.38
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007551267864833064,
-      "phase": 32.51922307776772
+      "amplitude": 0.008,
+      "phase": 32.52
     },
     {
       "name": "EP2",
-      "amplitude": 0.04853417306937273,
-      "phase": 95.34418086845221
+      "amplitude": 0.049,
+      "phase": 95.34
     },
     {
       "name": "M3",
-      "amplitude": 0.005021927252371477,
-      "phase": 118.19831042210723
+      "amplitude": 0.005,
+      "phase": 118.2
     },
     {
       "name": "MU2",
-      "amplitude": 0.24202519881325343,
-      "phase": 119.7383240294755
+      "amplitude": 0.242,
+      "phase": 119.74
     },
     {
       "name": "MTM",
-      "amplitude": 0.0018757927076577274,
-      "phase": 210.9639913892488
+      "amplitude": 0.002,
+      "phase": 210.96
     },
     {
       "name": "NU2",
-      "amplitude": 0.11473326465640883,
-      "phase": 350.88768003470517
+      "amplitude": 0.115,
+      "phase": 350.89
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07530307977930598,
-      "phase": 54.975223442290996
+      "amplitude": 0.075,
+      "phase": 54.98
     },
     {
       "name": "MN4",
-      "amplitude": 0.061557044058501424,
-      "phase": 325.02442287450316
+      "amplitude": 0.062,
+      "phase": 325.02
     },
     {
       "name": "MS4",
-      "amplitude": 0.11870289152133463,
-      "phase": 66.54477789604982
+      "amplitude": 0.119,
+      "phase": 66.54
     },
     {
       "name": "N4",
-      "amplitude": 0.012513802597807934,
-      "phase": 303.00125351431825
+      "amplitude": 0.013,
+      "phase": 303
     },
     {
       "name": "M6",
-      "amplitude": 0.09122556877950502,
-      "phase": 188.19414674268086
+      "amplitude": 0.091,
+      "phase": 188.19
     },
     {
       "name": "M8",
-      "amplitude": 0.03583374345703547,
-      "phase": 156.5069644552932
+      "amplitude": 0.036,
+      "phase": 156.51
     },
     {
       "name": "S4",
-      "amplitude": 0.014844922737857967,
-      "phase": 210.4224832166133
+      "amplitude": 0.015,
+      "phase": 210.42
     },
     {
       "name": "OO1",
-      "amplitude": 0.0024000998314626897,
-      "phase": 227.65522376963867
+      "amplitude": 0.002,
+      "phase": 227.66
     },
     {
       "name": "S3",
-      "amplitude": 0.0015988260201867351,
-      "phase": 15.94891112244892
+      "amplitude": 0.002,
+      "phase": 15.95
     },
     {
       "name": "MA2",
-      "amplitude": 0.07659016846565549,
-      "phase": 351.93670958531396
+      "amplitude": 0.077,
+      "phase": 351.94
     },
     {
       "name": "MB2",
-      "amplitude": 0.04383752139197589,
-      "phase": 215.43121802482412
+      "amplitude": 0.044,
+      "phase": 215.43
     },
     {
       "name": "T3",
-      "amplitude": 0.002133448946903723,
-      "phase": 87.74842592493621
+      "amplitude": 0.002,
+      "phase": 87.75
     },
     {
       "name": "R3",
-      "amplitude": 0.006131751966244472,
-      "phase": 126.08361976601282
+      "amplitude": 0.006,
+      "phase": 126.08
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005181753894769728,
-      "phase": 230.86813625722954
+      "amplitude": 0.005,
+      "phase": 230.87
     },
     {
       "name": "SGM",
-      "amplitude": 0.006308162786192896,
-      "phase": 53.25368778812475
+      "amplitude": 0.006,
+      "phase": 53.25
     },
     {
       "name": "3L2",
-      "amplitude": 0.0035029018271830544,
-      "phase": 348.2397401640829
+      "amplitude": 0.004,
+      "phase": 348.24
     },
     {
       "name": "3N2",
-      "amplitude": 0.030066894816051442,
-      "phase": 180.20115163917143
+      "amplitude": 0.03,
+      "phase": 180.2
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04783765988616712,
-      "phase": 343.3099854924806
+      "amplitude": 0.048,
+      "phase": 343.31
     },
     {
       "name": "2MS6",
-      "amplitude": 0.09174584537743063,
-      "phase": 266.05100722016675
+      "amplitude": 0.092,
+      "phase": 266.05
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00961640103029041,
-      "phase": 185.44917862539907
+      "amplitude": 0.01,
+      "phase": 185.45
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00663294813806565,
-      "phase": 4.586159416195642
+      "amplitude": 0.007,
+      "phase": 4.59
     }
   ],
   "epoch": {

--- a/data/ticon/hechthausen-5980030-deu-wsv.json
+++ b/data/ticon/hechthausen-5980030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.6827304031458848,
-      "phase": 69.40925397348514
+      "amplitude": 0.683,
+      "phase": 69.41
     },
     {
       "name": "N2",
-      "amplitude": 0.1006900280848215,
-      "phase": 43.12950397437555
+      "amplitude": 0.101,
+      "phase": 43.13
     },
     {
       "name": "S2",
-      "amplitude": 0.15546974830391766,
-      "phase": 141.86085683511578
+      "amplitude": 0.155,
+      "phase": 141.86
     },
     {
       "name": "K2",
-      "amplitude": 0.04844765718520502,
-      "phase": 143.0659286205913
+      "amplitude": 0.048,
+      "phase": 143.07
     },
     {
       "name": "2N2",
-      "amplitude": 0.009946515036979083,
-      "phase": 20.55587650989645
+      "amplitude": 0.01,
+      "phase": 20.56
     },
     {
       "name": "S1",
-      "amplitude": 0.012334112578572356,
-      "phase": 108.01972714446572
+      "amplitude": 0.012,
+      "phase": 108.02
     },
     {
       "name": "K1",
-      "amplitude": 0.045202870004053305,
-      "phase": 110.38686797893638
+      "amplitude": 0.045,
+      "phase": 110.39
     },
     {
       "name": "P1",
-      "amplitude": 0.01630669990270604,
-      "phase": 107.90928580961548
+      "amplitude": 0.016,
+      "phase": 107.91
     },
     {
       "name": "O1",
-      "amplitude": 0.05516575846522801,
-      "phase": 314.1951532956468
+      "amplitude": 0.055,
+      "phase": 314.2
     },
     {
       "name": "Q1",
-      "amplitude": 0.015933103080331634,
-      "phase": 250.99099565728136
+      "amplitude": 0.016,
+      "phase": 250.99
     },
     {
       "name": "M1",
-      "amplitude": 0.0013716365696220653,
-      "phase": 154.374082286075
+      "amplitude": 0.001,
+      "phase": 154.37
     },
     {
       "name": "M4",
-      "amplitude": 0.12298530989756623,
-      "phase": 54.641196285143906
+      "amplitude": 0.123,
+      "phase": 54.64
     },
     {
       "name": "MM",
-      "amplitude": 0.012114161713923014,
-      "phase": 125.8837572952192
+      "amplitude": 0.012,
+      "phase": 125.88
     },
     {
       "name": "MF",
-      "amplitude": 0.017061307714485552,
-      "phase": 96.06742457124898
+      "amplitude": 0.017,
+      "phase": 96.07
     },
     {
       "name": "SA",
-      "amplitude": 0.08134422062970008,
-      "phase": 260.79273728988414
+      "amplitude": 0.081,
+      "phase": 260.79
     },
     {
       "name": "SSA",
-      "amplitude": 0.05280293190404666,
-      "phase": 226.45292726789123
+      "amplitude": 0.053,
+      "phase": 226.45
     },
     {
       "name": "T2",
-      "amplitude": 0.0038444917299498608,
-      "phase": 174.45544877588577
+      "amplitude": 0.004,
+      "phase": 174.46
     },
     {
       "name": "J1",
-      "amplitude": 0.00436634747368259,
-      "phase": 238.27301778400712
+      "amplitude": 0.004,
+      "phase": 238.27
     },
     {
       "name": "L2",
-      "amplitude": 0.061801530520535476,
-      "phase": 88.63659459763738
+      "amplitude": 0.062,
+      "phase": 88.64
     },
     {
       "name": "R2",
-      "amplitude": 0.009147002918326522,
-      "phase": 152.53908841567102
+      "amplitude": 0.009,
+      "phase": 152.54
     },
     {
       "name": "2Q1",
-      "amplitude": 0.003012367719412962,
-      "phase": 195.0520732921731
+      "amplitude": 0.003,
+      "phase": 195.05
     },
     {
       "name": "MSF",
-      "amplitude": 0.07449594714554222,
-      "phase": 70.31875749563437
+      "amplitude": 0.074,
+      "phase": 70.32
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004690947679742298,
-      "phase": 44.26017575012406
+      "amplitude": 0.005,
+      "phase": 44.26
     },
     {
       "name": "EP2",
-      "amplitude": 0.018907563512768025,
-      "phase": 138.66563620444708
+      "amplitude": 0.019,
+      "phase": 138.67
     },
     {
       "name": "M3",
-      "amplitude": 0.002136463760014169,
-      "phase": 118.06250941251898
+      "amplitude": 0.002,
+      "phase": 118.06
     },
     {
       "name": "MU2",
-      "amplitude": 0.09098752610606392,
-      "phase": 165.84803891511422
+      "amplitude": 0.091,
+      "phase": 165.85
     },
     {
       "name": "MTM",
-      "amplitude": 0.003213684346842457,
-      "phase": 167.1648970556662
+      "amplitude": 0.003,
+      "phase": 167.16
     },
     {
       "name": "NU2",
-      "amplitude": 0.04519546633478669,
-      "phase": 29.194839706003677
+      "amplitude": 0.045,
+      "phase": 29.19
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.028558117611518385,
-      "phase": 90.30978578083653
+      "amplitude": 0.029,
+      "phase": 90.31
     },
     {
       "name": "MN4",
-      "amplitude": 0.040719559865229224,
-      "phase": 26.505008377236095
+      "amplitude": 0.041,
+      "phase": 26.51
     },
     {
       "name": "MS4",
-      "amplitude": 0.0646839528543755,
-      "phase": 125.18777593829839
+      "amplitude": 0.065,
+      "phase": 125.19
     },
     {
       "name": "N4",
-      "amplitude": 0.007831895649210349,
-      "phase": 9.00754332661677
+      "amplitude": 0.008,
+      "phase": 9.01
     },
     {
       "name": "M6",
-      "amplitude": 0.027140716925636785,
-      "phase": 278.6393927657734
+      "amplitude": 0.027,
+      "phase": 278.64
     },
     {
       "name": "M8",
-      "amplitude": 0.021688961990680718,
-      "phase": 264.8497822845195
+      "amplitude": 0.022,
+      "phase": 264.85
     },
     {
       "name": "S4",
-      "amplitude": 0.0042554666345561345,
-      "phase": 264.3918325094713
+      "amplitude": 0.004,
+      "phase": 264.39
     },
     {
       "name": "OO1",
-      "amplitude": 0.0013494051208139467,
-      "phase": 259.39457942146237
+      "amplitude": 0.001,
+      "phase": 259.39
     },
     {
       "name": "S3",
-      "amplitude": 0.0006560964759104559,
-      "phase": 348.9650970330135
+      "amplitude": 0.001,
+      "phase": 348.97
     },
     {
       "name": "MA2",
-      "amplitude": 0.02732896333534229,
-      "phase": 321.33704519894553
+      "amplitude": 0.027,
+      "phase": 321.34
     },
     {
       "name": "MB2",
-      "amplitude": 0.03813244744792579,
-      "phase": 170.56893472710772
+      "amplitude": 0.038,
+      "phase": 170.57
     },
     {
       "name": "T3",
-      "amplitude": 0.0014167283570334093,
-      "phase": 123.2945654787361
+      "amplitude": 0.001,
+      "phase": 123.29
     },
     {
       "name": "R3",
-      "amplitude": 0.003984582671990749,
-      "phase": 145.83723950182218
+      "amplitude": 0.004,
+      "phase": 145.84
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0035208913766321326,
-      "phase": 263.41693330676975
+      "amplitude": 0.004,
+      "phase": 263.42
     },
     {
       "name": "SGM",
-      "amplitude": 0.00446835307805379,
-      "phase": 103.28532257210378
+      "amplitude": 0.004,
+      "phase": 103.29
     },
     {
       "name": "3L2",
-      "amplitude": 0.003043982241046425,
-      "phase": 0.5096877275179281
+      "amplitude": 0.003,
+      "phase": 0.51
     },
     {
       "name": "3N2",
-      "amplitude": 0.012252572656083443,
-      "phase": 190.47823397863178
+      "amplitude": 0.012,
+      "phase": 190.48
     },
     {
       "name": "2SM2",
-      "amplitude": 0.01737676235899555,
-      "phase": 9.983844527877295
+      "amplitude": 0.017,
+      "phase": 9.98
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02560435859002207,
-      "phase": 352.4668223031178
+      "amplitude": 0.026,
+      "phase": 352.47
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0016529285454443387,
-      "phase": 358.96804469996596
+      "amplitude": 0.002,
+      "phase": 358.97
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0034997807186787034,
-      "phase": 234.6518954652782
+      "amplitude": 0.003,
+      "phase": 234.65
     }
   ],
   "epoch": {

--- a/data/ticon/heiligenhafen-9610070-deu-wsv.json
+++ b/data/ticon/heiligenhafen-9610070-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.044723142818701926,
-      "phase": 123.50569715779358
+      "amplitude": 0.045,
+      "phase": 123.51
     },
     {
       "name": "N2",
-      "amplitude": 0.012485356108652914,
-      "phase": 67.08078814265423
+      "amplitude": 0.012,
+      "phase": 67.08
     },
     {
       "name": "S2",
-      "amplitude": 0.010301103255250297,
-      "phase": 66.81899626380806
+      "amplitude": 0.01,
+      "phase": 66.82
     },
     {
       "name": "K2",
-      "amplitude": 0.002521634933841581,
-      "phase": 47.51921362731554
+      "amplitude": 0.003,
+      "phase": 47.52
     },
     {
       "name": "2N2",
-      "amplitude": 0.0017520353985610276,
-      "phase": 37.95484254995267
+      "amplitude": 0.002,
+      "phase": 37.95
     },
     {
       "name": "S1",
-      "amplitude": 0.006939184676764207,
-      "phase": 187.11577378366968
+      "amplitude": 0.007,
+      "phase": 187.12
     },
     {
       "name": "K1",
-      "amplitude": 0.019376130375551054,
-      "phase": 215.64735785438828
+      "amplitude": 0.019,
+      "phase": 215.65
     },
     {
       "name": "P1",
-      "amplitude": 0.007524260295540461,
-      "phase": 251.54425728223424
+      "amplitude": 0.008,
+      "phase": 251.54
     },
     {
       "name": "O1",
-      "amplitude": 0.015946097304264904,
-      "phase": 110.49303543389124
+      "amplitude": 0.016,
+      "phase": 110.49
     },
     {
       "name": "Q1",
-      "amplitude": 0.005240227516943959,
-      "phase": 315.1522574192343
+      "amplitude": 0.005,
+      "phase": 315.15
     },
     {
       "name": "M1",
-      "amplitude": 0.00009766002610841397,
-      "phase": 96.63233369271325
+      "amplitude": 0,
+      "phase": 96.63
     },
     {
       "name": "M4",
-      "amplitude": 0.002182087437406229,
-      "phase": 234.321800559917
+      "amplitude": 0.002,
+      "phase": 234.32
     },
     {
       "name": "MM",
-      "amplitude": 0.009800674426182883,
-      "phase": 281.2759447915726
+      "amplitude": 0.01,
+      "phase": 281.28
     },
     {
       "name": "MF",
-      "amplitude": 0.009119613901101348,
-      "phase": 247.5176854621215
+      "amplitude": 0.009,
+      "phase": 247.52
     },
     {
       "name": "SA",
-      "amplitude": 0.03837287802784026,
-      "phase": 169.43558072947212
+      "amplitude": 0.038,
+      "phase": 169.44
     },
     {
       "name": "SSA",
-      "amplitude": 0.020698706501074728,
-      "phase": 257.6665110998058
+      "amplitude": 0.021,
+      "phase": 257.67
     },
     {
       "name": "T2",
-      "amplitude": 0.0014403424697046255,
-      "phase": 56.58978010431656
+      "amplitude": 0.001,
+      "phase": 56.59
     },
     {
       "name": "J1",
-      "amplitude": 0.0010339149071103481,
-      "phase": 165.29632169751653
+      "amplitude": 0.001,
+      "phase": 165.3
     },
     {
       "name": "L2",
-      "amplitude": 0.0047411601042737644,
-      "phase": 219.42302115471077
+      "amplitude": 0.005,
+      "phase": 219.42
     },
     {
       "name": "R2",
-      "amplitude": 0.0014416469708859402,
-      "phase": 174.3283782608312
+      "amplitude": 0.001,
+      "phase": 174.33
     },
     {
       "name": "2Q1",
-      "amplitude": 0.001248198517388592,
-      "phase": 273.04445955335075
+      "amplitude": 0.001,
+      "phase": 273.04
     },
     {
       "name": "MSF",
-      "amplitude": 0.002708369382569166,
-      "phase": 245.42154535658597
+      "amplitude": 0.003,
+      "phase": 245.42
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003604257169391299,
-      "phase": 214.30532267256328
+      "amplitude": 0.004,
+      "phase": 214.31
     },
     {
       "name": "EP2",
-      "amplitude": 0.0027125658833843597,
-      "phase": 243.0641222143431
+      "amplitude": 0.003,
+      "phase": 243.06
     },
     {
       "name": "M3",
-      "amplitude": 0.0006090542371418032,
-      "phase": 325.2165892726147
+      "amplitude": 0.001,
+      "phase": 325.22
     },
     {
       "name": "MU2",
-      "amplitude": 0.010872422565181606,
-      "phase": 285.6788365556251
+      "amplitude": 0.011,
+      "phase": 285.68
     },
     {
       "name": "MTM",
-      "amplitude": 0.003299535747974295,
-      "phase": 347.51894175497506
+      "amplitude": 0.003,
+      "phase": 347.52
     },
     {
       "name": "NU2",
-      "amplitude": 0.004409519566621199,
-      "phase": 107.65995124080393
+      "amplitude": 0.004,
+      "phase": 107.66
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.002508712226488298,
-      "phase": 212.7569007522148
+      "amplitude": 0.003,
+      "phase": 212.76
     },
     {
       "name": "MN4",
-      "amplitude": 0.0006781411117010969,
-      "phase": 174.63107935555945
+      "amplitude": 0.001,
+      "phase": 174.63
     },
     {
       "name": "MS4",
-      "amplitude": 0.00047265798462929674,
-      "phase": 24.3959403661309
+      "amplitude": 0,
+      "phase": 24.4
     },
     {
       "name": "N4",
-      "amplitude": 0.00013870447702577158,
-      "phase": 121.98536127317993
+      "amplitude": 0,
+      "phase": 121.99
     },
     {
       "name": "M6",
-      "amplitude": 0.0005072353428944258,
-      "phase": 314.554947453959
+      "amplitude": 0.001,
+      "phase": 314.55
     },
     {
       "name": "M8",
-      "amplitude": 0.00007941994953878867,
-      "phase": 270.0959996438785
+      "amplitude": 0,
+      "phase": 270.1
     },
     {
       "name": "S4",
-      "amplitude": 0.00016562714319086244,
-      "phase": 307.2369068047062
+      "amplitude": 0,
+      "phase": 307.24
     },
     {
       "name": "OO1",
-      "amplitude": 0.0017312310336247288,
-      "phase": 135.1255744095912
+      "amplitude": 0.002,
+      "phase": 135.13
     },
     {
       "name": "S3",
-      "amplitude": 0.00020975772893813924,
-      "phase": 271.3680517531479
+      "amplitude": 0,
+      "phase": 271.37
     },
     {
       "name": "MA2",
-      "amplitude": 0.005879830593410319,
-      "phase": 107.06384200401448
+      "amplitude": 0.006,
+      "phase": 107.06
     },
     {
       "name": "MB2",
-      "amplitude": 0.006315394607633896,
-      "phase": 269.04776504837275
+      "amplitude": 0.006,
+      "phase": 269.05
     },
     {
       "name": "T3",
-      "amplitude": 0.000483515255873091,
-      "phase": 193.8527456072862
+      "amplitude": 0,
+      "phase": 193.85
     },
     {
       "name": "R3",
-      "amplitude": 0.0003510186582430294,
-      "phase": 267.3378914753104
+      "amplitude": 0,
+      "phase": 267.34
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0006445385429968497,
-      "phase": 279.88040416362537
+      "amplitude": 0.001,
+      "phase": 279.88
     },
     {
       "name": "SGM",
-      "amplitude": 0.0029936828901335733,
-      "phase": 220.99526204389628
+      "amplitude": 0.003,
+      "phase": 221
     },
     {
       "name": "3L2",
-      "amplitude": 0.00046700574494856653,
-      "phase": 15.107249909851589
+      "amplitude": 0,
+      "phase": 15.11
     },
     {
       "name": "3N2",
-      "amplitude": 0.0013337492715663757,
-      "phase": 19.851495205894764
+      "amplitude": 0.001,
+      "phase": 19.85
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0015044256093876946,
-      "phase": 184.12318486066226
+      "amplitude": 0.002,
+      "phase": 184.12
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0006060032645409581,
-      "phase": 42.186362355956135
+      "amplitude": 0.001,
+      "phase": 42.19
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00023724530292310467,
-      "phase": 125.52156589796772
+      "amplitude": 0,
+      "phase": 125.52
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0002377523469209424,
-      "phase": 267.8547361967199
+      "amplitude": 0,
+      "phase": 267.85
     }
   ],
   "epoch": {

--- a/data/ticon/helgolandbinnenhafen-9510070-deu-wsv.json
+++ b/data/ticon/helgolandbinnenhafen-9510070-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.0977264028276628,
-      "phase": 310.6250764312833
+      "amplitude": 1.098,
+      "phase": 310.63
     },
     {
       "name": "N2",
-      "amplitude": 0.17779837057058126,
-      "phase": 285.03816441341974
+      "amplitude": 0.178,
+      "phase": 285.04
     },
     {
       "name": "S2",
-      "amplitude": 0.2917191775709124,
-      "phase": 17.689497445186362
+      "amplitude": 0.292,
+      "phase": 17.69
     },
     {
       "name": "K2",
-      "amplitude": 0.08750556432560268,
-      "phase": 16.255407192049006
+      "amplitude": 0.088,
+      "phase": 16.26
     },
     {
       "name": "2N2",
-      "amplitude": 0.02036326464221136,
-      "phase": 264.5798381769131
+      "amplitude": 0.02,
+      "phase": 264.58
     },
     {
       "name": "S1",
-      "amplitude": 0.0075717773651335155,
-      "phase": 7.055471599180294
+      "amplitude": 0.008,
+      "phase": 7.06
     },
     {
       "name": "K1",
-      "amplitude": 0.0673985657430261,
-      "phase": 22.30492413419603
+      "amplitude": 0.067,
+      "phase": 22.3
     },
     {
       "name": "P1",
-      "amplitude": 0.026806873017388103,
-      "phase": 28.73592074330145
+      "amplitude": 0.027,
+      "phase": 28.74
     },
     {
       "name": "O1",
-      "amplitude": 0.08946692954898125,
-      "phase": 233.11618130694825
+      "amplitude": 0.089,
+      "phase": 233.12
     },
     {
       "name": "Q1",
-      "amplitude": 0.028842310769146916,
-      "phase": 174.8670914121151
+      "amplitude": 0.029,
+      "phase": 174.87
     },
     {
       "name": "M1",
-      "amplitude": 0.0016244852329616942,
-      "phase": 87.14515249003512
+      "amplitude": 0.002,
+      "phase": 87.15
     },
     {
       "name": "M4",
-      "amplitude": 0.06891211321583844,
-      "phase": 142.97069657817593
+      "amplitude": 0.069,
+      "phase": 142.97
     },
     {
       "name": "MM",
-      "amplitude": 0.025296933592010303,
-      "phase": 178.78578863824214
+      "amplitude": 0.025,
+      "phase": 178.79
     },
     {
       "name": "MF",
-      "amplitude": 0.010732553790466557,
-      "phase": 179.19313960132467
+      "amplitude": 0.011,
+      "phase": 179.19
     },
     {
       "name": "SA",
-      "amplitude": 0.11438174156236224,
-      "phase": 223.94992069266976
+      "amplitude": 0.114,
+      "phase": 223.95
     },
     {
       "name": "SSA",
-      "amplitude": 0.03731363282679593,
-      "phase": 198.12356229396173
+      "amplitude": 0.037,
+      "phase": 198.12
     },
     {
       "name": "T2",
-      "amplitude": 0.014768523120040246,
-      "phase": 3.941138627771352
+      "amplitude": 0.015,
+      "phase": 3.94
     },
     {
       "name": "J1",
-      "amplitude": 0.0014480171769738165,
-      "phase": 130.05265331083388
+      "amplitude": 0.001,
+      "phase": 130.05
     },
     {
       "name": "L2",
-      "amplitude": 0.08255979814109381,
-      "phase": 328.7249775650595
+      "amplitude": 0.083,
+      "phase": 328.72
     },
     {
       "name": "R2",
-      "amplitude": 0.004494983904084504,
-      "phase": 340.7786071746365
+      "amplitude": 0.004,
+      "phase": 340.78
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005743895836675645,
-      "phase": 120.17889174507269
+      "amplitude": 0.006,
+      "phase": 120.18
     },
     {
       "name": "MSF",
-      "amplitude": 0.0048661892425874405,
-      "phase": 8.471571131397752
+      "amplitude": 0.005,
+      "phase": 8.47
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007130820622334801,
-      "phase": 63.37166234931209
+      "amplitude": 0.007,
+      "phase": 63.37
     },
     {
       "name": "EP2",
-      "amplitude": 0.023470801477401264,
-      "phase": 17.856657050125023
+      "amplitude": 0.023,
+      "phase": 17.86
     },
     {
       "name": "M3",
-      "amplitude": 0.0030041558294262253,
-      "phase": 302.2210516959356
+      "amplitude": 0.003,
+      "phase": 302.22
     },
     {
       "name": "MU2",
-      "amplitude": 0.10006931934742813,
-      "phase": 41.39555498716652
+      "amplitude": 0.1,
+      "phase": 41.4
     },
     {
       "name": "MTM",
-      "amplitude": 0.004936744387399087,
-      "phase": 235.79740877924363
+      "amplitude": 0.005,
+      "phase": 235.8
     },
     {
       "name": "NU2",
-      "amplitude": 0.06151185184520814,
-      "phase": 271.7204224796766
+      "amplitude": 0.062,
+      "phase": 271.72
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.039522583203216326,
-      "phase": 321.8621105083031
+      "amplitude": 0.04,
+      "phase": 321.86
     },
     {
       "name": "MN4",
-      "amplitude": 0.024499330475664077,
-      "phase": 120.03553667203204
+      "amplitude": 0.024,
+      "phase": 120.04
     },
     {
       "name": "MS4",
-      "amplitude": 0.04144986359824829,
-      "phase": 201.61140954878707
+      "amplitude": 0.041,
+      "phase": 201.61
     },
     {
       "name": "N4",
-      "amplitude": 0.005210999686862531,
-      "phase": 98.95827032820068
+      "amplitude": 0.005,
+      "phase": 98.96
     },
     {
       "name": "M6",
-      "amplitude": 0.0211193321989724,
-      "phase": 286.3112246343627
+      "amplitude": 0.021,
+      "phase": 286.31
     },
     {
       "name": "M8",
-      "amplitude": 0.00404293645459135,
-      "phase": 113.19485802356252
+      "amplitude": 0.004,
+      "phase": 113.19
     },
     {
       "name": "S4",
-      "amplitude": 0.004061826976379212,
-      "phase": 297.9036981750546
+      "amplitude": 0.004,
+      "phase": 297.9
     },
     {
       "name": "OO1",
-      "amplitude": 0.0022017038608048707,
-      "phase": 193.93488438365512
+      "amplitude": 0.002,
+      "phase": 193.93
     },
     {
       "name": "S3",
-      "amplitude": 0.0002527643898167075,
-      "phase": 103.11282996535203
+      "amplitude": 0,
+      "phase": 103.11
     },
     {
       "name": "MA2",
-      "amplitude": 0.0309058542275016,
-      "phase": 251.151660539563
+      "amplitude": 0.031,
+      "phase": 251.15
     },
     {
       "name": "MB2",
-      "amplitude": 0.02584291855667835,
-      "phase": 22.82950530140772
+      "amplitude": 0.026,
+      "phase": 22.83
     },
     {
       "name": "T3",
-      "amplitude": 0.0003661801426929174,
-      "phase": 317.91506344170875
+      "amplitude": 0,
+      "phase": 317.92
     },
     {
       "name": "R3",
-      "amplitude": 0.0017062790863539628,
-      "phase": 348.83652572831204
+      "amplitude": 0.002,
+      "phase": 348.84
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005689536937849326,
-      "phase": 180.95205423533125
+      "amplitude": 0.006,
+      "phase": 180.95
     },
     {
       "name": "SGM",
-      "amplitude": 0.0024402064178078884,
-      "phase": 57.673593718080156
+      "amplitude": 0.002,
+      "phase": 57.67
     },
     {
       "name": "3L2",
-      "amplitude": 0.0035002120693077843,
-      "phase": 223.49206216220432
+      "amplitude": 0.004,
+      "phase": 223.49
     },
     {
       "name": "3N2",
-      "amplitude": 0.012703151964740282,
-      "phase": 109.08437261362678
+      "amplitude": 0.013,
+      "phase": 109.08
     },
     {
       "name": "2SM2",
-      "amplitude": 0.026213045410824955,
-      "phase": 239.09161316810554
+      "amplitude": 0.026,
+      "phase": 239.09
     },
     {
       "name": "2MS6",
-      "amplitude": 0.021215805890329054,
-      "phase": 342.1124234371929
+      "amplitude": 0.021,
+      "phase": 342.11
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0015212499756447873,
-      "phase": 93.32775576982647
+      "amplitude": 0.002,
+      "phase": 93.33
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0034637456652468267,
-      "phase": 288.2105135041637
+      "amplitude": 0.003,
+      "phase": 288.21
     }
   ],
   "epoch": {

--- a/data/ticon/helgolandsdhafen-9510075-deu-wsv.json
+++ b/data/ticon/helgolandsdhafen-9510075-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.0473509995880717,
-      "phase": 310.6867908042362
+      "amplitude": 1.047,
+      "phase": 310.69
     },
     {
       "name": "N2",
-      "amplitude": 0.17175854363642457,
-      "phase": 286.41672120563754
+      "amplitude": 0.172,
+      "phase": 286.42
     },
     {
       "name": "S2",
-      "amplitude": 0.27964803664106935,
-      "phase": 17.261202144901063
+      "amplitude": 0.28,
+      "phase": 17.26
     },
     {
       "name": "K2",
-      "amplitude": 0.0835239555254772,
-      "phase": 15.994748112367859
+      "amplitude": 0.084,
+      "phase": 15.99
     },
     {
       "name": "2N2",
-      "amplitude": 0.019949170048830657,
-      "phase": 268.31093846912734
+      "amplitude": 0.02,
+      "phase": 268.31
     },
     {
       "name": "S1",
-      "amplitude": 0.007065914545527955,
-      "phase": 35.61651547724182
+      "amplitude": 0.007,
+      "phase": 35.62
     },
     {
       "name": "K1",
-      "amplitude": 0.06334646154797682,
-      "phase": 24.13226787762642
+      "amplitude": 0.063,
+      "phase": 24.13
     },
     {
       "name": "P1",
-      "amplitude": 0.026189697488922345,
-      "phase": 35.857213518821595
+      "amplitude": 0.026,
+      "phase": 35.86
     },
     {
       "name": "O1",
-      "amplitude": 0.08391406566856437,
-      "phase": 235.59014098898683
+      "amplitude": 0.084,
+      "phase": 235.59
     },
     {
       "name": "Q1",
-      "amplitude": 0.02916235529576283,
-      "phase": 178.63832362413905
+      "amplitude": 0.029,
+      "phase": 178.64
     },
     {
       "name": "M1",
-      "amplitude": 0.002062810225937851,
-      "phase": 351.53495474889246
+      "amplitude": 0.002,
+      "phase": 351.53
     },
     {
       "name": "M4",
-      "amplitude": 0.0631373931805986,
-      "phase": 139.21093669637833
+      "amplitude": 0.063,
+      "phase": 139.21
     },
     {
       "name": "MM",
-      "amplitude": 0.008890057891050851,
-      "phase": 25.87990643919437
+      "amplitude": 0.009,
+      "phase": 25.88
     },
     {
       "name": "MF",
-      "amplitude": 0.01822154000142252,
-      "phase": 224.92382303945737
+      "amplitude": 0.018,
+      "phase": 224.92
     },
     {
       "name": "SA",
-      "amplitude": 0.38901138905437577,
-      "phase": 199.57061651444266
+      "amplitude": 0.389,
+      "phase": 199.57
     },
     {
       "name": "SSA",
-      "amplitude": 0.04013998408005013,
-      "phase": 155.13132292762657
+      "amplitude": 0.04,
+      "phase": 155.13
     },
     {
       "name": "T2",
-      "amplitude": 0.01563913924279273,
-      "phase": 31.93459274721539
+      "amplitude": 0.016,
+      "phase": 31.93
     },
     {
       "name": "J1",
-      "amplitude": 0.003672620436979332,
-      "phase": 68.84626904034957
+      "amplitude": 0.004,
+      "phase": 68.85
     },
     {
       "name": "L2",
-      "amplitude": 0.07248707799990961,
-      "phase": 328.9785426192055
+      "amplitude": 0.072,
+      "phase": 328.98
     },
     {
       "name": "R2",
-      "amplitude": 0.011081003298604328,
-      "phase": 80.52765446085505
+      "amplitude": 0.011,
+      "phase": 80.53
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0056275448513745845,
-      "phase": 108.45770881555012
+      "amplitude": 0.006,
+      "phase": 108.46
     },
     {
       "name": "MSF",
-      "amplitude": 0.012473007182018825,
-      "phase": 164.77194899570804
+      "amplitude": 0.012,
+      "phase": 164.77
     },
     {
       "name": "MSQM",
-      "amplitude": 0.02040046010294455,
-      "phase": 50.062276800359825
+      "amplitude": 0.02,
+      "phase": 50.06
     },
     {
       "name": "EP2",
-      "amplitude": 0.021668702924586187,
-      "phase": 22.031875196783346
+      "amplitude": 0.022,
+      "phase": 22.03
     },
     {
       "name": "M3",
-      "amplitude": 0.0032469557856745768,
-      "phase": 310.3568836804938
+      "amplitude": 0.003,
+      "phase": 310.36
     },
     {
       "name": "MU2",
-      "amplitude": 0.09519375449524299,
-      "phase": 42.14657205857236
+      "amplitude": 0.095,
+      "phase": 42.15
     },
     {
       "name": "MTM",
-      "amplitude": 0.007721820574258666,
-      "phase": 225.28716594607687
+      "amplitude": 0.008,
+      "phase": 225.29
     },
     {
       "name": "NU2",
-      "amplitude": 0.05837418825230213,
-      "phase": 270.3359174068779
+      "amplitude": 0.058,
+      "phase": 270.34
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03894320207229882,
-      "phase": 317.2383162437417
+      "amplitude": 0.039,
+      "phase": 317.24
     },
     {
       "name": "MN4",
-      "amplitude": 0.02259857372784585,
-      "phase": 118.36246573855288
+      "amplitude": 0.023,
+      "phase": 118.36
     },
     {
       "name": "MS4",
-      "amplitude": 0.03902923279870678,
-      "phase": 197.46046451922672
+      "amplitude": 0.039,
+      "phase": 197.46
     },
     {
       "name": "N4",
-      "amplitude": 0.005101990415572386,
-      "phase": 85.69787922017497
+      "amplitude": 0.005,
+      "phase": 85.7
     },
     {
       "name": "M6",
-      "amplitude": 0.01991684138599323,
-      "phase": 284.3392068399012
+      "amplitude": 0.02,
+      "phase": 284.34
     },
     {
       "name": "M8",
-      "amplitude": 0.0038951598679802216,
-      "phase": 119.19681550801374
+      "amplitude": 0.004,
+      "phase": 119.2
     },
     {
       "name": "S4",
-      "amplitude": 0.0040094326550066915,
-      "phase": 296.6043940894614
+      "amplitude": 0.004,
+      "phase": 296.6
     },
     {
       "name": "OO1",
-      "amplitude": 0.0023160968086027452,
-      "phase": 172.99298651852166
+      "amplitude": 0.002,
+      "phase": 172.99
     },
     {
       "name": "S3",
-      "amplitude": 0.0013966587858912157,
-      "phase": 255.1162473201017
+      "amplitude": 0.001,
+      "phase": 255.12
     },
     {
       "name": "MA2",
-      "amplitude": 0.022684322060220495,
-      "phase": 178.7836618310563
+      "amplitude": 0.023,
+      "phase": 178.78
     },
     {
       "name": "MB2",
-      "amplitude": 0.028957056556535663,
-      "phase": 102.06074552059727
+      "amplitude": 0.029,
+      "phase": 102.06
     },
     {
       "name": "T3",
-      "amplitude": 0.000529498792398492,
-      "phase": 280.7140234781434
+      "amplitude": 0.001,
+      "phase": 280.71
     },
     {
       "name": "R3",
-      "amplitude": 0.001577433324219085,
-      "phase": 13.704983129874961
+      "amplitude": 0.002,
+      "phase": 13.7
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005010219832148649,
-      "phase": 174.52886013041916
+      "amplitude": 0.005,
+      "phase": 174.53
     },
     {
       "name": "SGM",
-      "amplitude": 0.0033567764620193417,
-      "phase": 9.770659383112672
+      "amplitude": 0.003,
+      "phase": 9.77
     },
     {
       "name": "3L2",
-      "amplitude": 0.009114428550204563,
-      "phase": 175.15307294271713
+      "amplitude": 0.009,
+      "phase": 175.15
     },
     {
       "name": "3N2",
-      "amplitude": 0.011826849345247687,
-      "phase": 114.38738190051765
+      "amplitude": 0.012,
+      "phase": 114.39
     },
     {
       "name": "2SM2",
-      "amplitude": 0.025575083406016295,
-      "phase": 237.82070018611333
+      "amplitude": 0.026,
+      "phase": 237.82
     },
     {
       "name": "2MS6",
-      "amplitude": 0.020331000975530894,
-      "phase": 342.0566822606959
+      "amplitude": 0.02,
+      "phase": 342.06
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0007516970952226038,
-      "phase": 67.88301589208913
+      "amplitude": 0.001,
+      "phase": 67.88
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0029378553274811868,
-      "phase": 285.09802665858746
+      "amplitude": 0.003,
+      "phase": 285.1
     }
   ],
   "epoch": {

--- a/data/ticon/herbrumhafendamm-3770030-deu-wsv.json
+++ b/data/ticon/herbrumhafendamm-3770030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.1656017762847464,
-      "phase": 2.923489775515634
+      "amplitude": 1.166,
+      "phase": 2.92
     },
     {
       "name": "N2",
-      "amplitude": 0.17581948940963202,
-      "phase": 336.82047181143577
+      "amplitude": 0.176,
+      "phase": 336.82
     },
     {
       "name": "S2",
-      "amplitude": 0.2913148843002616,
-      "phase": 81.44914598281287
+      "amplitude": 0.291,
+      "phase": 81.45
     },
     {
       "name": "K2",
-      "amplitude": 0.09021666450401453,
-      "phase": 91.57930872111984
+      "amplitude": 0.09,
+      "phase": 91.58
     },
     {
       "name": "2N2",
-      "amplitude": 0.014434031038162667,
-      "phase": 322.28242165959796
+      "amplitude": 0.014,
+      "phase": 322.28
     },
     {
       "name": "S1",
-      "amplitude": 0.01211358367028055,
-      "phase": 73.3133888998612
+      "amplitude": 0.012,
+      "phase": 73.31
     },
     {
       "name": "K1",
-      "amplitude": 0.06543514230580857,
-      "phase": 68.22856865560402
+      "amplitude": 0.065,
+      "phase": 68.23
     },
     {
       "name": "P1",
-      "amplitude": 0.028178619902899323,
-      "phase": 63.19906280925147
+      "amplitude": 0.028,
+      "phase": 63.2
     },
     {
       "name": "O1",
-      "amplitude": 0.07677409606968615,
-      "phase": 271.85397983125597
+      "amplitude": 0.077,
+      "phase": 271.85
     },
     {
       "name": "Q1",
-      "amplitude": 0.01973246088384617,
-      "phase": 210.68123106711238
+      "amplitude": 0.02,
+      "phase": 210.68
     },
     {
       "name": "M1",
-      "amplitude": 0.0019295510651829069,
-      "phase": 113.22713810105483
+      "amplitude": 0.002,
+      "phase": 113.23
     },
     {
       "name": "M4",
-      "amplitude": 0.21378560221145237,
-      "phase": 271.9638704960629
+      "amplitude": 0.214,
+      "phase": 271.96
     },
     {
       "name": "MM",
-      "amplitude": 0.01242979470368198,
-      "phase": 25.183012687048574
+      "amplitude": 0.012,
+      "phase": 25.18
     },
     {
       "name": "MF",
-      "amplitude": 0.02897541867004606,
-      "phase": 81.54073246171589
+      "amplitude": 0.029,
+      "phase": 81.54
     },
     {
       "name": "SA",
-      "amplitude": 0.31298444370722106,
-      "phase": 301.91430810766684
+      "amplitude": 0.313,
+      "phase": 301.91
     },
     {
       "name": "SSA",
-      "amplitude": 0.16720976953818537,
-      "phase": 253.32944994571756
+      "amplitude": 0.167,
+      "phase": 253.33
     },
     {
       "name": "T2",
-      "amplitude": 0.009211234863628171,
-      "phase": 257.0082144542572
+      "amplitude": 0.009,
+      "phase": 257.01
     },
     {
       "name": "J1",
-      "amplitude": 0.007179129825337016,
-      "phase": 183.98330907826914
+      "amplitude": 0.007,
+      "phase": 183.98
     },
     {
       "name": "L2",
-      "amplitude": 0.11133356185015489,
-      "phase": 10.492393962505048
+      "amplitude": 0.111,
+      "phase": 10.49
     },
     {
       "name": "R2",
-      "amplitude": 0.024093958359666243,
-      "phase": 143.88718578262694
+      "amplitude": 0.024,
+      "phase": 143.89
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0035444059526761446,
-      "phase": 152.78552066797602
+      "amplitude": 0.004,
+      "phase": 152.79
     },
     {
       "name": "MSF",
-      "amplitude": 0.06086280470460416,
-      "phase": 36.90361158821406
+      "amplitude": 0.061,
+      "phase": 36.9
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003964987886363683,
-      "phase": 38.004446156715005
+      "amplitude": 0.004,
+      "phase": 38
     },
     {
       "name": "EP2",
-      "amplitude": 0.031726481267769426,
-      "phase": 63.53481729433156
+      "amplitude": 0.032,
+      "phase": 63.53
     },
     {
       "name": "M3",
-      "amplitude": 0.005307757401717471,
-      "phase": 63.60333875286119
+      "amplitude": 0.005,
+      "phase": 63.6
     },
     {
       "name": "MU2",
-      "amplitude": 0.15387664721156008,
-      "phase": 85.70309678893597
+      "amplitude": 0.154,
+      "phase": 85.7
     },
     {
       "name": "MTM",
-      "amplitude": 0.013202807615340205,
-      "phase": 356.54595901357675
+      "amplitude": 0.013,
+      "phase": 356.55
     },
     {
       "name": "NU2",
-      "amplitude": 0.07796058818682218,
-      "phase": 315.09904743893554
+      "amplitude": 0.078,
+      "phase": 315.1
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.051118265297079836,
-      "phase": 13.365577452962953
+      "amplitude": 0.051,
+      "phase": 13.37
     },
     {
       "name": "MN4",
-      "amplitude": 0.06317527248073318,
-      "phase": 246.62168402496263
+      "amplitude": 0.063,
+      "phase": 246.62
     },
     {
       "name": "MS4",
-      "amplitude": 0.12554251575972478,
-      "phase": 353.449519268739
+      "amplitude": 0.126,
+      "phase": 353.45
     },
     {
       "name": "N4",
-      "amplitude": 0.010406069527639178,
-      "phase": 228.84241513165847
+      "amplitude": 0.01,
+      "phase": 228.84
     },
     {
       "name": "M6",
-      "amplitude": 0.10864392286888543,
-      "phase": 167.03253199422602
+      "amplitude": 0.109,
+      "phase": 167.03
     },
     {
       "name": "M8",
-      "amplitude": 0.038445534761654875,
-      "phase": 85.48580432274247
+      "amplitude": 0.038,
+      "phase": 85.49
     },
     {
       "name": "S4",
-      "amplitude": 0.012585829176257803,
-      "phase": 152.18295219205754
+      "amplitude": 0.013,
+      "phase": 152.18
     },
     {
       "name": "OO1",
-      "amplitude": 0.003606758305180397,
-      "phase": 211.47274892604557
+      "amplitude": 0.004,
+      "phase": 211.47
     },
     {
       "name": "S3",
-      "amplitude": 0.003041260420084046,
-      "phase": 10.578342886521114
+      "amplitude": 0.003,
+      "phase": 10.58
     },
     {
       "name": "MA2",
-      "amplitude": 0.11455033030296882,
-      "phase": 260.1413756275108
+      "amplitude": 0.115,
+      "phase": 260.14
     },
     {
       "name": "MB2",
-      "amplitude": 0.09834471802570308,
-      "phase": 132.59726693092637
+      "amplitude": 0.098,
+      "phase": 132.6
     },
     {
       "name": "T3",
-      "amplitude": 0.002426476000722683,
-      "phase": 45.43639201469796
+      "amplitude": 0.002,
+      "phase": 45.44
     },
     {
       "name": "R3",
-      "amplitude": 0.006493721455222079,
-      "phase": 71.1943997196505
+      "amplitude": 0.006,
+      "phase": 71.19
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006851801549029524,
-      "phase": 231.61458804456277
+      "amplitude": 0.007,
+      "phase": 231.61
     },
     {
       "name": "SGM",
-      "amplitude": 0.005293638139106368,
-      "phase": 45.905566562982585
+      "amplitude": 0.005,
+      "phase": 45.91
     },
     {
       "name": "3L2",
-      "amplitude": 0.004873514930348265,
-      "phase": 275.4036375481797
+      "amplitude": 0.005,
+      "phase": 275.4
     },
     {
       "name": "3N2",
-      "amplitude": 0.05343021179049812,
-      "phase": 92.57939213271862
+      "amplitude": 0.053,
+      "phase": 92.58
     },
     {
       "name": "2SM2",
-      "amplitude": 0.029216178220823213,
-      "phase": 295.8501332156041
+      "amplitude": 0.029,
+      "phase": 295.85
     },
     {
       "name": "2MS6",
-      "amplitude": 0.09976814293170344,
-      "phase": 241.077742931474
+      "amplitude": 0.1,
+      "phase": 241.08
     },
     {
       "name": "2MK5",
-      "amplitude": 0.012960639282447372,
-      "phase": 176.38023014911778
+      "amplitude": 0.013,
+      "phase": 176.38
     },
     {
       "name": "2MO5",
-      "amplitude": 0.010118174343311415,
-      "phase": 43.54450477553297
+      "amplitude": 0.01,
+      "phase": 43.54
     }
   ],
   "epoch": {

--- a/data/ticon/hetlingen-5970010-deu-wsv.json
+++ b/data/ticon/hetlingen-5970010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.356630685600435,
-      "phase": 63.95286346426832
+      "amplitude": 1.357,
+      "phase": 63.95
     },
     {
       "name": "N2",
-      "amplitude": 0.20476192978682758,
-      "phase": 37.48702715878426
+      "amplitude": 0.205,
+      "phase": 37.49
     },
     {
       "name": "S2",
-      "amplitude": 0.3099853519080364,
-      "phase": 139.33054833638198
+      "amplitude": 0.31,
+      "phase": 139.33
     },
     {
       "name": "K2",
-      "amplitude": 0.09346505669449547,
-      "phase": 137.74134894910424
+      "amplitude": 0.093,
+      "phase": 137.74
     },
     {
       "name": "2N2",
-      "amplitude": 0.02121748144169461,
-      "phase": 15.769617000628159
+      "amplitude": 0.021,
+      "phase": 15.77
     },
     {
       "name": "S1",
-      "amplitude": 0.0189821090681212,
-      "phase": 91.92220509531717
+      "amplitude": 0.019,
+      "phase": 91.92
     },
     {
       "name": "K1",
-      "amplitude": 0.0712241869114672,
-      "phase": 89.85809409807086
+      "amplitude": 0.071,
+      "phase": 89.86
     },
     {
       "name": "P1",
-      "amplitude": 0.03062375712375462,
-      "phase": 87.17404374414429
+      "amplitude": 0.031,
+      "phase": 87.17
     },
     {
       "name": "O1",
-      "amplitude": 0.08950136353533901,
-      "phase": 295.2531453577694
+      "amplitude": 0.09,
+      "phase": 295.25
     },
     {
       "name": "Q1",
-      "amplitude": 0.026013385479579997,
-      "phase": 235.53459502670017
+      "amplitude": 0.026,
+      "phase": 235.53
     },
     {
       "name": "M1",
-      "amplitude": 0.002263658055127399,
-      "phase": 144.9740810558696
+      "amplitude": 0.002,
+      "phase": 144.97
     },
     {
       "name": "M4",
-      "amplitude": 0.10066561285493364,
-      "phase": 357.37289186779327
+      "amplitude": 0.101,
+      "phase": 357.37
     },
     {
       "name": "MM",
-      "amplitude": 0.016878619678913447,
-      "phase": 143.84341104914552
+      "amplitude": 0.017,
+      "phase": 143.84
     },
     {
       "name": "MF",
-      "amplitude": 0.01432198333644825,
-      "phase": 108.31852502082575
+      "amplitude": 0.014,
+      "phase": 108.32
     },
     {
       "name": "SA",
-      "amplitude": 0.06613575424255053,
-      "phase": 236.96775987548878
+      "amplitude": 0.066,
+      "phase": 236.97
     },
     {
       "name": "SSA",
-      "amplitude": 0.04786977143756726,
-      "phase": 224.21642396436206
+      "amplitude": 0.048,
+      "phase": 224.22
     },
     {
       "name": "T2",
-      "amplitude": 0.01933001594561119,
-      "phase": 117.66882937429966
+      "amplitude": 0.019,
+      "phase": 117.67
     },
     {
       "name": "J1",
-      "amplitude": 0.005433855912141015,
-      "phase": 220.00896908572506
+      "amplitude": 0.005,
+      "phase": 220.01
     },
     {
       "name": "L2",
-      "amplitude": 0.12206759685825655,
-      "phase": 84.19538472439979
+      "amplitude": 0.122,
+      "phase": 84.2
     },
     {
       "name": "R2",
-      "amplitude": 0.004386175110516932,
-      "phase": 46.931071288365786
+      "amplitude": 0.004,
+      "phase": 46.93
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005883502354790153,
-      "phase": 172.5143884557706
+      "amplitude": 0.006,
+      "phase": 172.51
     },
     {
       "name": "MSF",
-      "amplitude": 0.05597387436679939,
-      "phase": 63.27418930197939
+      "amplitude": 0.056,
+      "phase": 63.27
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009531584340936658,
-      "phase": 48.55028063083182
+      "amplitude": 0.01,
+      "phase": 48.55
     },
     {
       "name": "EP2",
-      "amplitude": 0.037281247898448604,
-      "phase": 129.37856461298549
+      "amplitude": 0.037,
+      "phase": 129.38
     },
     {
       "name": "M3",
-      "amplitude": 0.0024068192380721416,
-      "phase": 115.47760389069356
+      "amplitude": 0.002,
+      "phase": 115.48
     },
     {
       "name": "MU2",
-      "amplitude": 0.18182105959042047,
-      "phase": 155.44649609910732
+      "amplitude": 0.182,
+      "phase": 155.45
     },
     {
       "name": "MTM",
-      "amplitude": 0.00402742764688194,
-      "phase": 231.07326636835822
+      "amplitude": 0.004,
+      "phase": 231.07
     },
     {
       "name": "NU2",
-      "amplitude": 0.09251608717500891,
-      "phase": 20.778669557476007
+      "amplitude": 0.093,
+      "phase": 20.78
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05426225778280539,
-      "phase": 81.62780969637151
+      "amplitude": 0.054,
+      "phase": 81.63
     },
     {
       "name": "MN4",
-      "amplitude": 0.03371586477356192,
-      "phase": 333.3749728770682
+      "amplitude": 0.034,
+      "phase": 333.37
     },
     {
       "name": "MS4",
-      "amplitude": 0.057220470131892014,
-      "phase": 68.2514241851818
+      "amplitude": 0.057,
+      "phase": 68.25
     },
     {
       "name": "N4",
-      "amplitude": 0.006947517707702344,
-      "phase": 312.2829366933055
+      "amplitude": 0.007,
+      "phase": 312.28
     },
     {
       "name": "M6",
-      "amplitude": 0.07713689154937925,
-      "phase": 238.33217533085315
+      "amplitude": 0.077,
+      "phase": 238.33
     },
     {
       "name": "M8",
-      "amplitude": 0.027779142757782604,
-      "phase": 191.0983206511429
+      "amplitude": 0.028,
+      "phase": 191.1
     },
     {
       "name": "S4",
-      "amplitude": 0.0054365662127106845,
-      "phase": 201.97238931471983
+      "amplitude": 0.005,
+      "phase": 201.97
     },
     {
       "name": "OO1",
-      "amplitude": 0.002928226343851643,
-      "phase": 228.5327878690783
+      "amplitude": 0.003,
+      "phase": 228.53
     },
     {
       "name": "S3",
-      "amplitude": 0.0007687266651086143,
-      "phase": 339.00844228400854
+      "amplitude": 0.001,
+      "phase": 339.01
     },
     {
       "name": "MA2",
-      "amplitude": 0.04104862844375042,
-      "phase": 30.16253886733932
+      "amplitude": 0.041,
+      "phase": 30.16
     },
     {
       "name": "MB2",
-      "amplitude": 0.019618982597962686,
-      "phase": 84.77167055316579
+      "amplitude": 0.02,
+      "phase": 84.77
     },
     {
       "name": "T3",
-      "amplitude": 0.0006572713565746495,
-      "phase": 127.68674059331852
+      "amplitude": 0.001,
+      "phase": 127.69
     },
     {
       "name": "R3",
-      "amplitude": 0.004130557794430756,
-      "phase": 133.36786892039208
+      "amplitude": 0.004,
+      "phase": 133.37
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005558624222804637,
-      "phase": 238.41777554600753
+      "amplitude": 0.006,
+      "phase": 238.42
     },
     {
       "name": "SGM",
-      "amplitude": 0.003763655684352636,
-      "phase": 72.67043920319031
+      "amplitude": 0.004,
+      "phase": 72.67
     },
     {
       "name": "3L2",
-      "amplitude": 0.0033432219260298842,
-      "phase": 329.65722320023224
+      "amplitude": 0.003,
+      "phase": 329.66
     },
     {
       "name": "3N2",
-      "amplitude": 0.014365211018854433,
-      "phase": 218.50166181353782
+      "amplitude": 0.014,
+      "phase": 218.5
     },
     {
       "name": "2SM2",
-      "amplitude": 0.032768008242213986,
-      "phase": 9.940172303115332
+      "amplitude": 0.033,
+      "phase": 9.94
     },
     {
       "name": "2MS6",
-      "amplitude": 0.07247460958467335,
-      "phase": 308.23441114630714
+      "amplitude": 0.072,
+      "phase": 308.23
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005502142409987398,
-      "phase": 242.9996980980988
+      "amplitude": 0.006,
+      "phase": 243
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004729802865411535,
-      "phase": 109.83317812690393
+      "amplitude": 0.005,
+      "phase": 109.83
     }
   ],
   "epoch": {

--- a/data/ticon/hollersiel-4960050-deu-wsv.json
+++ b/data/ticon/hollersiel-4960050-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.150351062349068,
-      "phase": 55.57818029651622
+      "amplitude": 1.15,
+      "phase": 55.58
     },
     {
       "name": "N2",
-      "amplitude": 0.17047371242761436,
-      "phase": 32.13314166420946
+      "amplitude": 0.17,
+      "phase": 32.13
     },
     {
       "name": "S2",
-      "amplitude": 0.2628959705026062,
-      "phase": 137.11495203894322
+      "amplitude": 0.263,
+      "phase": 137.11
     },
     {
       "name": "K2",
-      "amplitude": 0.07829095376341175,
-      "phase": 135.34738141630305
+      "amplitude": 0.078,
+      "phase": 135.35
     },
     {
       "name": "2N2",
-      "amplitude": 0.01647866108304323,
-      "phase": 12.932860563839427
+      "amplitude": 0.016,
+      "phase": 12.93
     },
     {
       "name": "S1",
-      "amplitude": 0.01439568021116789,
-      "phase": 84.18478863537257
+      "amplitude": 0.014,
+      "phase": 84.18
     },
     {
       "name": "K1",
-      "amplitude": 0.05927262694782811,
-      "phase": 92.98819178121448
+      "amplitude": 0.059,
+      "phase": 92.99
     },
     {
       "name": "P1",
-      "amplitude": 0.021686113293509657,
-      "phase": 92.08232922054123
+      "amplitude": 0.022,
+      "phase": 92.08
     },
     {
       "name": "O1",
-      "amplitude": 0.07267296419055909,
-      "phase": 298.2885449400814
+      "amplitude": 0.073,
+      "phase": 298.29
     },
     {
       "name": "Q1",
-      "amplitude": 0.019074562615097733,
-      "phase": 234.8176481704473
+      "amplitude": 0.019,
+      "phase": 234.82
     },
     {
       "name": "M1",
-      "amplitude": 0.001905727786936829,
-      "phase": 154.15285380280852
+      "amplitude": 0.002,
+      "phase": 154.15
     },
     {
       "name": "M4",
-      "amplitude": 0.07394660061327926,
-      "phase": 42.541525565374116
+      "amplitude": 0.074,
+      "phase": 42.54
     },
     {
       "name": "MM",
-      "amplitude": 0.01997180669778262,
-      "phase": 59.20442337135705
+      "amplitude": 0.02,
+      "phase": 59.2
     },
     {
       "name": "MF",
-      "amplitude": 0.021717456939544827,
-      "phase": 80.63390615354325
+      "amplitude": 0.022,
+      "phase": 80.63
     },
     {
       "name": "SA",
-      "amplitude": 0.09924288278150357,
-      "phase": 295.8057917502211
+      "amplitude": 0.099,
+      "phase": 295.81
     },
     {
       "name": "SSA",
-      "amplitude": 0.051532298246310435,
-      "phase": 237.73702713644917
+      "amplitude": 0.052,
+      "phase": 237.74
     },
     {
       "name": "T2",
-      "amplitude": 0.013410617016936967,
-      "phase": 106.27441035694511
+      "amplitude": 0.013,
+      "phase": 106.27
     },
     {
       "name": "J1",
-      "amplitude": 0.004731872564153699,
-      "phase": 218.64864992942353
+      "amplitude": 0.005,
+      "phase": 218.65
     },
     {
       "name": "L2",
-      "amplitude": 0.11076759903606828,
-      "phase": 69.63672525826337
+      "amplitude": 0.111,
+      "phase": 69.64
     },
     {
       "name": "R2",
-      "amplitude": 0.005326366980704614,
-      "phase": 203.93566023025153
+      "amplitude": 0.005,
+      "phase": 203.94
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0032387624894809853,
-      "phase": 179.25320496437757
+      "amplitude": 0.003,
+      "phase": 179.25
     },
     {
       "name": "MSF",
-      "amplitude": 0.09918988195290546,
-      "phase": 67.02803717988547
+      "amplitude": 0.099,
+      "phase": 67.03
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007722644692161827,
-      "phase": 353.38471174681376
+      "amplitude": 0.008,
+      "phase": 353.38
     },
     {
       "name": "EP2",
-      "amplitude": 0.03538789412240262,
-      "phase": 115.48674241735972
+      "amplitude": 0.035,
+      "phase": 115.49
     },
     {
       "name": "M3",
-      "amplitude": 0.0027337318688517823,
-      "phase": 137.2425879395741
+      "amplitude": 0.003,
+      "phase": 137.24
     },
     {
       "name": "MU2",
-      "amplitude": 0.17465194928400057,
-      "phase": 139.92710669955386
+      "amplitude": 0.175,
+      "phase": 139.93
     },
     {
       "name": "MTM",
-      "amplitude": 0.0031701289512687087,
-      "phase": 137.65826209064994
+      "amplitude": 0.003,
+      "phase": 137.66
     },
     {
       "name": "NU2",
-      "amplitude": 0.082271393956184,
-      "phase": 5.394655551930327
+      "amplitude": 0.082,
+      "phase": 5.39
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.050590655576607524,
-      "phase": 70.82872608029123
+      "amplitude": 0.051,
+      "phase": 70.83
     },
     {
       "name": "MN4",
-      "amplitude": 0.024601110018392974,
-      "phase": 17.06636939292821
+      "amplitude": 0.025,
+      "phase": 17.07
     },
     {
       "name": "MS4",
-      "amplitude": 0.03698260559314334,
-      "phase": 116.2691903230459
+      "amplitude": 0.037,
+      "phase": 116.27
     },
     {
       "name": "N4",
-      "amplitude": 0.0045348827258030215,
-      "phase": 356.89216678538895
+      "amplitude": 0.005,
+      "phase": 356.89
     },
     {
       "name": "M6",
-      "amplitude": 0.031966488093066965,
-      "phase": 166.17781316722085
+      "amplitude": 0.032,
+      "phase": 166.18
     },
     {
       "name": "M8",
-      "amplitude": 0.010124950177689024,
-      "phase": 113.39708166041817
+      "amplitude": 0.01,
+      "phase": 113.4
     },
     {
       "name": "S4",
-      "amplitude": 0.002857742342947634,
-      "phase": 259.62451728061296
+      "amplitude": 0.003,
+      "phase": 259.62
     },
     {
       "name": "OO1",
-      "amplitude": 0.0023686369573801378,
-      "phase": 253.76696025193502
+      "amplitude": 0.002,
+      "phase": 253.77
     },
     {
       "name": "S3",
-      "amplitude": 0.0014977278601999648,
-      "phase": 55.15107509095503
+      "amplitude": 0.001,
+      "phase": 55.15
     },
     {
       "name": "MA2",
-      "amplitude": 0.03695759050021842,
-      "phase": 1.56534519523899
+      "amplitude": 0.037,
+      "phase": 1.57
     },
     {
       "name": "MB2",
-      "amplitude": 0.030588056696973086,
-      "phase": 202.86783028816905
+      "amplitude": 0.031,
+      "phase": 202.87
     },
     {
       "name": "T3",
-      "amplitude": 0.0012772040944844692,
-      "phase": 123.60415166614189
+      "amplitude": 0.001,
+      "phase": 123.6
     },
     {
       "name": "R3",
-      "amplitude": 0.0043893635927401515,
-      "phase": 123.23573287481713
+      "amplitude": 0.004,
+      "phase": 123.24
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004785252324426679,
-      "phase": 245.58551440049527
+      "amplitude": 0.005,
+      "phase": 245.59
     },
     {
       "name": "SGM",
-      "amplitude": 0.006462237810043454,
-      "phase": 67.56724489458435
+      "amplitude": 0.006,
+      "phase": 67.57
     },
     {
       "name": "3L2",
-      "amplitude": 0.0028715430886174357,
-      "phase": 340.7351154057305
+      "amplitude": 0.003,
+      "phase": 340.74
     },
     {
       "name": "3N2",
-      "amplitude": 0.0204480460403285,
-      "phase": 206.29039538489016
+      "amplitude": 0.02,
+      "phase": 206.29
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03111687409519361,
-      "phase": 0.5858748646141407
+      "amplitude": 0.031,
+      "phase": 0.59
     },
     {
       "name": "2MS6",
-      "amplitude": 0.031047180015769168,
-      "phase": 239.06879139248724
+      "amplitude": 0.031,
+      "phase": 239.07
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0020910645738587575,
-      "phase": 151.2962371513819
+      "amplitude": 0.002,
+      "phase": 151.3
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0014981669805613392,
-      "phase": 328.7829408304271
+      "amplitude": 0.001,
+      "phase": 328.78
     }
   ],
   "epoch": {

--- a/data/ticon/hooksielplate-9430020-deu-wsv.json
+++ b/data/ticon/hooksielplate-9430020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.5276123715805026,
-      "phase": 324.48140814166356
+      "amplitude": 1.528,
+      "phase": 324.48
     },
     {
       "name": "N2",
-      "amplitude": 0.24196406079216415,
-      "phase": 299.49302309138193
+      "amplitude": 0.242,
+      "phase": 299.49
     },
     {
       "name": "S2",
-      "amplitude": 0.4018867895297704,
-      "phase": 36.15611282146011
+      "amplitude": 0.402,
+      "phase": 36.16
     },
     {
       "name": "K2",
-      "amplitude": 0.11964472311929407,
-      "phase": 33.70065219909162
+      "amplitude": 0.12,
+      "phase": 33.7
     },
     {
       "name": "2N2",
-      "amplitude": 0.026591296426646174,
-      "phase": 279.54065855208137
+      "amplitude": 0.027,
+      "phase": 279.54
     },
     {
       "name": "S1",
-      "amplitude": 0.0115401020910655,
-      "phase": 32.32786428688712
+      "amplitude": 0.012,
+      "phase": 32.33
     },
     {
       "name": "K1",
-      "amplitude": 0.07165584372674343,
-      "phase": 29.04140271851901
+      "amplitude": 0.072,
+      "phase": 29.04
     },
     {
       "name": "P1",
-      "amplitude": 0.030201040494574918,
-      "phase": 34.804870238342744
+      "amplitude": 0.03,
+      "phase": 34.8
     },
     {
       "name": "O1",
-      "amplitude": 0.09284402656396866,
-      "phase": 238.31793229470446
+      "amplitude": 0.093,
+      "phase": 238.32
     },
     {
       "name": "Q1",
-      "amplitude": 0.029003245493048963,
-      "phase": 179.554704248009
+      "amplitude": 0.029,
+      "phase": 179.55
     },
     {
       "name": "M1",
-      "amplitude": 0.001738585604394159,
-      "phase": 91.43231325960181
+      "amplitude": 0.002,
+      "phase": 91.43
     },
     {
       "name": "M4",
-      "amplitude": 0.0825504666069279,
-      "phase": 130.74220948741356
+      "amplitude": 0.083,
+      "phase": 130.74
     },
     {
       "name": "MM",
-      "amplitude": 0.022149363886302283,
-      "phase": 174.9546911427019
+      "amplitude": 0.022,
+      "phase": 174.95
     },
     {
       "name": "MF",
-      "amplitude": 0.009818751604473984,
-      "phase": 175.6546546073514
+      "amplitude": 0.01,
+      "phase": 175.65
     },
     {
       "name": "SA",
-      "amplitude": 0.09824762896528044,
-      "phase": 222.13936504863184
+      "amplitude": 0.098,
+      "phase": 222.14
     },
     {
       "name": "SSA",
-      "amplitude": 0.03577906588875439,
-      "phase": 205.84627383181504
+      "amplitude": 0.036,
+      "phase": 205.85
     },
     {
       "name": "T2",
-      "amplitude": 0.02156512224678948,
-      "phase": 11.148998160373992
+      "amplitude": 0.022,
+      "phase": 11.15
     },
     {
       "name": "J1",
-      "amplitude": 0.0019269065346065757,
-      "phase": 151.29391353460073
+      "amplitude": 0.002,
+      "phase": 151.29
     },
     {
       "name": "L2",
-      "amplitude": 0.12317356598834385,
-      "phase": 340.92497848706427
+      "amplitude": 0.123,
+      "phase": 340.92
     },
     {
       "name": "R2",
-      "amplitude": 0.0017132764051502735,
-      "phase": 27.324836723944145
+      "amplitude": 0.002,
+      "phase": 27.32
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005951942442029678,
-      "phase": 123.76477989489763
+      "amplitude": 0.006,
+      "phase": 123.76
     },
     {
       "name": "MSF",
-      "amplitude": 0.004128356675456543,
-      "phase": 14.512036032337164
+      "amplitude": 0.004,
+      "phase": 14.51
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008518472566227446,
-      "phase": 66.12286135996646
+      "amplitude": 0.009,
+      "phase": 66.12
     },
     {
       "name": "EP2",
-      "amplitude": 0.03535098008216987,
-      "phase": 26.30525898169276
+      "amplitude": 0.035,
+      "phase": 26.31
     },
     {
       "name": "M3",
-      "amplitude": 0.004152057223259824,
-      "phase": 1.854266365425815
+      "amplitude": 0.004,
+      "phase": 1.85
     },
     {
       "name": "MU2",
-      "amplitude": 0.15810551485344815,
-      "phase": 48.77358702092863
+      "amplitude": 0.158,
+      "phase": 48.77
     },
     {
       "name": "MTM",
-      "amplitude": 0.004728298511273529,
-      "phase": 245.88273497190644
+      "amplitude": 0.005,
+      "phase": 245.88
     },
     {
       "name": "NU2",
-      "amplitude": 0.08832967776569602,
-      "phase": 281.61973434248705
+      "amplitude": 0.088,
+      "phase": 281.62
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05833361766119269,
-      "phase": 335.6080522634064
+      "amplitude": 0.058,
+      "phase": 335.61
     },
     {
       "name": "MN4",
-      "amplitude": 0.02538163941088384,
-      "phase": 109.65449106720399
+      "amplitude": 0.025,
+      "phase": 109.65
     },
     {
       "name": "MS4",
-      "amplitude": 0.05926227651363781,
-      "phase": 206.9822995849584
+      "amplitude": 0.059,
+      "phase": 206.98
     },
     {
       "name": "N4",
-      "amplitude": 0.005440723686223821,
-      "phase": 91.27640218317435
+      "amplitude": 0.005,
+      "phase": 91.28
     },
     {
       "name": "M6",
-      "amplitude": 0.04414960013881217,
-      "phase": 310.66760723760785
+      "amplitude": 0.044,
+      "phase": 310.67
     },
     {
       "name": "M8",
-      "amplitude": 0.006294602571068145,
-      "phase": 130.74788559307808
+      "amplitude": 0.006,
+      "phase": 130.75
     },
     {
       "name": "S4",
-      "amplitude": 0.007638310211295046,
-      "phase": 339.2402118950991
+      "amplitude": 0.008,
+      "phase": 339.24
     },
     {
       "name": "OO1",
-      "amplitude": 0.0025687826491797615,
-      "phase": 195.4253836105437
+      "amplitude": 0.003,
+      "phase": 195.43
     },
     {
       "name": "S3",
-      "amplitude": 0.000293629138788751,
-      "phase": 192.71184164288704
+      "amplitude": 0,
+      "phase": 192.71
     },
     {
       "name": "MA2",
-      "amplitude": 0.05342293717939318,
-      "phase": 274.5618653337275
+      "amplitude": 0.053,
+      "phase": 274.56
     },
     {
       "name": "MB2",
-      "amplitude": 0.022766120091981146,
-      "phase": 54.03132732369971
+      "amplitude": 0.023,
+      "phase": 54.03
     },
     {
       "name": "T3",
-      "amplitude": 0.0001741864052074318,
-      "phase": 77.70929881809627
+      "amplitude": 0,
+      "phase": 77.71
     },
     {
       "name": "R3",
-      "amplitude": 0.003197088450474808,
-      "phase": 36.827628782901854
+      "amplitude": 0.003,
+      "phase": 36.83
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005756798538838482,
-      "phase": 184.38364378573897
+      "amplitude": 0.006,
+      "phase": 184.38
     },
     {
       "name": "SGM",
-      "amplitude": 0.0023547586361104588,
-      "phase": 46.82563433370689
+      "amplitude": 0.002,
+      "phase": 46.83
     },
     {
       "name": "3L2",
-      "amplitude": 0.004190261902614471,
-      "phase": 233.4703091573517
+      "amplitude": 0.004,
+      "phase": 233.47
     },
     {
       "name": "3N2",
-      "amplitude": 0.0192363540743292,
-      "phase": 125.05901059723254
+      "amplitude": 0.019,
+      "phase": 125.06
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03982024718618821,
-      "phase": 256.93658005517807
+      "amplitude": 0.04,
+      "phase": 256.94
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04626109830860163,
-      "phase": 17.537850882926307
+      "amplitude": 0.046,
+      "phase": 17.54
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004327696418756143,
-      "phase": 344.3801000972097
+      "amplitude": 0.004,
+      "phase": 344.38
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0026145188574278927,
-      "phase": 181.72642962997097
+      "amplitude": 0.003,
+      "phase": 181.73
     }
   ],
   "epoch": {

--- a/data/ticon/horneburg-5960020-deu-wsv.json
+++ b/data/ticon/horneburg-5960020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.4646694133661228,
-      "phase": 133.287670222239
+      "amplitude": 0.465,
+      "phase": 133.29
     },
     {
       "name": "N2",
-      "amplitude": 0.0664222761154185,
-      "phase": 104.38733669588885
+      "amplitude": 0.066,
+      "phase": 104.39
     },
     {
       "name": "S2",
-      "amplitude": 0.09842055769357161,
-      "phase": 213.1804281336445
+      "amplitude": 0.098,
+      "phase": 213.18
     },
     {
       "name": "K2",
-      "amplitude": 0.03065417761411036,
-      "phase": 218.77544724960578
+      "amplitude": 0.031,
+      "phase": 218.78
     },
     {
       "name": "2N2",
-      "amplitude": 0.00488347974742702,
-      "phase": 104.65087574759707
+      "amplitude": 0.005,
+      "phase": 104.65
     },
     {
       "name": "S1",
-      "amplitude": 0.009181903422310539,
-      "phase": 142.78310023327424
+      "amplitude": 0.009,
+      "phase": 142.78
     },
     {
       "name": "K1",
-      "amplitude": 0.03434480897658329,
-      "phase": 150.63967299474984
+      "amplitude": 0.034,
+      "phase": 150.64
     },
     {
       "name": "P1",
-      "amplitude": 0.012425417786071438,
-      "phase": 151.75773920295694
+      "amplitude": 0.012,
+      "phase": 151.76
     },
     {
       "name": "O1",
-      "amplitude": 0.04134341524076447,
-      "phase": 351.89175688846797
+      "amplitude": 0.041,
+      "phase": 351.89
     },
     {
       "name": "Q1",
-      "amplitude": 0.009723286528352163,
-      "phase": 282.0553745065792
+      "amplitude": 0.01,
+      "phase": 282.06
     },
     {
       "name": "M1",
-      "amplitude": 0.001226210168357491,
-      "phase": 225.2210799520717
+      "amplitude": 0.001,
+      "phase": 225.22
     },
     {
       "name": "M4",
-      "amplitude": 0.07445580939012168,
-      "phase": 188.27695621525214
+      "amplitude": 0.074,
+      "phase": 188.28
     },
     {
       "name": "MM",
-      "amplitude": 0.003777127715478309,
-      "phase": 358.4666517274065
+      "amplitude": 0.004,
+      "phase": 358.47
     },
     {
       "name": "MF",
-      "amplitude": 0.02089023317695947,
-      "phase": 107.29765503367531
+      "amplitude": 0.021,
+      "phase": 107.3
     },
     {
       "name": "SA",
-      "amplitude": 0.11228655496506844,
-      "phase": 295.10094126864243
+      "amplitude": 0.112,
+      "phase": 295.1
     },
     {
       "name": "SSA",
-      "amplitude": 0.04171608704930355,
-      "phase": 221.88889471049507
+      "amplitude": 0.042,
+      "phase": 221.89
     },
     {
       "name": "T2",
-      "amplitude": 0.002195715297076988,
-      "phase": 123.35526374663021
+      "amplitude": 0.002,
+      "phase": 123.36
     },
     {
       "name": "J1",
-      "amplitude": 0.0021792218882470513,
-      "phase": 280.66968040883665
+      "amplitude": 0.002,
+      "phase": 280.67
     },
     {
       "name": "L2",
-      "amplitude": 0.04788449627792122,
-      "phase": 150.58546761228445
+      "amplitude": 0.048,
+      "phase": 150.59
     },
     {
       "name": "R2",
-      "amplitude": 0.006396976978515915,
-      "phase": 250.69658820807405
+      "amplitude": 0.006,
+      "phase": 250.7
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0020955019972881805,
-      "phase": 177.48918682910914
+      "amplitude": 0.002,
+      "phase": 177.49
     },
     {
       "name": "MSF",
-      "amplitude": 0.05642879793356828,
-      "phase": 68.90772160284189
+      "amplitude": 0.056,
+      "phase": 68.91
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0050982195979068995,
-      "phase": 305.21394396247535
+      "amplitude": 0.005,
+      "phase": 305.21
     },
     {
       "name": "EP2",
-      "amplitude": 0.014855618904679704,
-      "phase": 194.91959335458506
+      "amplitude": 0.015,
+      "phase": 194.92
     },
     {
       "name": "M3",
-      "amplitude": 0.0014177676177884386,
-      "phase": 245.50862763230114
+      "amplitude": 0.001,
+      "phase": 245.51
     },
     {
       "name": "MU2",
-      "amplitude": 0.06942515443460986,
-      "phase": 226.06553246965507
+      "amplitude": 0.069,
+      "phase": 226.07
     },
     {
       "name": "MTM",
-      "amplitude": 0.005919197490833348,
-      "phase": 196.56809899137423
+      "amplitude": 0.006,
+      "phase": 196.57
     },
     {
       "name": "NU2",
-      "amplitude": 0.03229469826239116,
-      "phase": 87.4066403427816
+      "amplitude": 0.032,
+      "phase": 87.41
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.020887949468853476,
-      "phase": 154.77954498860367
+      "amplitude": 0.021,
+      "phase": 154.78
     },
     {
       "name": "MN4",
-      "amplitude": 0.02260117638025201,
-      "phase": 160.0757659756232
+      "amplitude": 0.023,
+      "phase": 160.08
     },
     {
       "name": "MS4",
-      "amplitude": 0.033463901856100646,
-      "phase": 261.09278138570744
+      "amplitude": 0.033,
+      "phase": 261.09
     },
     {
       "name": "N4",
-      "amplitude": 0.004234189376868042,
-      "phase": 158.29365252550372
+      "amplitude": 0.004,
+      "phase": 158.29
     },
     {
       "name": "M6",
-      "amplitude": 0.006087543606755464,
-      "phase": 228.8913158449193
+      "amplitude": 0.006,
+      "phase": 228.89
     },
     {
       "name": "M8",
-      "amplitude": 0.0032990786018248833,
-      "phase": 131.1486665327057
+      "amplitude": 0.003,
+      "phase": 131.15
     },
     {
       "name": "S4",
-      "amplitude": 0.001764891261976083,
-      "phase": 107.55606067434502
+      "amplitude": 0.002,
+      "phase": 107.56
     },
     {
       "name": "OO1",
-      "amplitude": 0.0006230245029018762,
-      "phase": 13.52019385625647
+      "amplitude": 0.001,
+      "phase": 13.52
     },
     {
       "name": "S3",
-      "amplitude": 0.0005276568484142764,
-      "phase": 102.70967640436515
+      "amplitude": 0.001,
+      "phase": 102.71
     },
     {
       "name": "MA2",
-      "amplitude": 0.03790618965725483,
-      "phase": 38.206493433333094
+      "amplitude": 0.038,
+      "phase": 38.21
     },
     {
       "name": "MB2",
-      "amplitude": 0.031052374928507903,
-      "phase": 253.4257997175461
+      "amplitude": 0.031,
+      "phase": 253.43
     },
     {
       "name": "T3",
-      "amplitude": 0.00025306748319870397,
-      "phase": 126.28305974184383
+      "amplitude": 0,
+      "phase": 126.28
     },
     {
       "name": "R3",
-      "amplitude": 0.0033244414643398,
-      "phase": 205.566327524667
+      "amplitude": 0.003,
+      "phase": 205.57
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0033656866335366664,
-      "phase": 307.6948827356747
+      "amplitude": 0.003,
+      "phase": 307.69
     },
     {
       "name": "SGM",
-      "amplitude": 0.005324979925012012,
-      "phase": 136.35899999887238
+      "amplitude": 0.005,
+      "phase": 136.36
     },
     {
       "name": "3L2",
-      "amplitude": 0.0029640192608906325,
-      "phase": 66.0511152254204
+      "amplitude": 0.003,
+      "phase": 66.05
     },
     {
       "name": "3N2",
-      "amplitude": 0.009745619260454953,
-      "phase": 228.650436855803
+      "amplitude": 0.01,
+      "phase": 228.65
     },
     {
       "name": "2SM2",
-      "amplitude": 0.011144951781499912,
-      "phase": 80.44662286094149
+      "amplitude": 0.011,
+      "phase": 80.45
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00400595807011755,
-      "phase": 291.84459730173415
+      "amplitude": 0.004,
+      "phase": 291.84
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0036168383340642956,
-      "phase": 179.48372250087914
+      "amplitude": 0.004,
+      "phase": 179.48
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00427825483264716,
-      "phase": 35.25487626566007
+      "amplitude": 0.004,
+      "phase": 35.25
     }
   ],
   "epoch": {

--- a/data/ticon/hrnum-9570050-deu-wsv.json
+++ b/data/ticon/hrnum-9570050-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.9442340011796908,
-      "phase": 1.9384863495972695
+      "amplitude": 0.944,
+      "phase": 1.94
     },
     {
       "name": "N2",
-      "amplitude": 0.1517926586535539,
-      "phase": 335.81289074603654
+      "amplitude": 0.152,
+      "phase": 335.81
     },
     {
       "name": "S2",
-      "amplitude": 0.23392563131743957,
-      "phase": 71.29882005045312
+      "amplitude": 0.234,
+      "phase": 71.3
     },
     {
       "name": "K2",
-      "amplitude": 0.07005357450513386,
-      "phase": 69.9002091542124
+      "amplitude": 0.07,
+      "phase": 69.9
     },
     {
       "name": "2N2",
-      "amplitude": 0.017446320203254585,
-      "phase": 313.7615217839185
+      "amplitude": 0.017,
+      "phase": 313.76
     },
     {
       "name": "S1",
-      "amplitude": 0.008990551323919509,
-      "phase": 20.43943608353908
+      "amplitude": 0.009,
+      "phase": 20.44
     },
     {
       "name": "K1",
-      "amplitude": 0.06338596601028727,
-      "phase": 49.421259227267626
+      "amplitude": 0.063,
+      "phase": 49.42
     },
     {
       "name": "P1",
-      "amplitude": 0.026739784947309286,
-      "phase": 52.08244096155647
+      "amplitude": 0.027,
+      "phase": 52.08
     },
     {
       "name": "O1",
-      "amplitude": 0.08777947782631337,
-      "phase": 257.92246082631164
+      "amplitude": 0.088,
+      "phase": 257.92
     },
     {
       "name": "Q1",
-      "amplitude": 0.028025478663060373,
-      "phase": 198.99657957639394
+      "amplitude": 0.028,
+      "phase": 199
     },
     {
       "name": "M1",
-      "amplitude": 0.0017217565034336553,
-      "phase": 116.42755565963859
+      "amplitude": 0.002,
+      "phase": 116.43
     },
     {
       "name": "M4",
-      "amplitude": 0.061482070439620264,
-      "phase": 190.3112340032408
+      "amplitude": 0.061,
+      "phase": 190.31
     },
     {
       "name": "MM",
-      "amplitude": 0.025361287149047552,
-      "phase": 174.8712898703211
+      "amplitude": 0.025,
+      "phase": 174.87
     },
     {
       "name": "MF",
-      "amplitude": 0.009963640276303776,
-      "phase": 162.29620801117267
+      "amplitude": 0.01,
+      "phase": 162.3
     },
     {
       "name": "SA",
-      "amplitude": 0.12541471902378923,
-      "phase": 231.05317609368728
+      "amplitude": 0.125,
+      "phase": 231.05
     },
     {
       "name": "SSA",
-      "amplitude": 0.04419716123412306,
-      "phase": 205.87588766993113
+      "amplitude": 0.044,
+      "phase": 205.88
     },
     {
       "name": "T2",
-      "amplitude": 0.012595612305127665,
-      "phase": 53.654648215633415
+      "amplitude": 0.013,
+      "phase": 53.65
     },
     {
       "name": "J1",
-      "amplitude": 0.0027683298701883354,
-      "phase": 180.38941123414926
+      "amplitude": 0.003,
+      "phase": 180.39
     },
     {
       "name": "L2",
-      "amplitude": 0.0751021913502517,
-      "phase": 22.065671710784045
+      "amplitude": 0.075,
+      "phase": 22.07
     },
     {
       "name": "R2",
-      "amplitude": 0.0019346594014290521,
-      "phase": 5.4344553245067
+      "amplitude": 0.002,
+      "phase": 5.43
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0054545723369701996,
-      "phase": 137.75439120997544
+      "amplitude": 0.005,
+      "phase": 137.75
     },
     {
       "name": "MSF",
-      "amplitude": 0.019379780724164252,
-      "phase": 49.55590060196306
+      "amplitude": 0.019,
+      "phase": 49.56
     },
     {
       "name": "MSQM",
-      "amplitude": 0.006915710608479331,
-      "phase": 53.262820609118364
+      "amplitude": 0.007,
+      "phase": 53.26
     },
     {
       "name": "EP2",
-      "amplitude": 0.02347438872505471,
-      "phase": 70.04911147659283
+      "amplitude": 0.023,
+      "phase": 70.05
     },
     {
       "name": "M3",
-      "amplitude": 0.0008929454227344576,
-      "phase": 355.39621711774157
+      "amplitude": 0.001,
+      "phase": 355.4
     },
     {
       "name": "MU2",
-      "amplitude": 0.10205996253457615,
-      "phase": 93.85902280987716
+      "amplitude": 0.102,
+      "phase": 93.86
     },
     {
       "name": "MTM",
-      "amplitude": 0.006145628938756543,
-      "phase": 233.26813841942445
+      "amplitude": 0.006,
+      "phase": 233.27
     },
     {
       "name": "NU2",
-      "amplitude": 0.05668154135695565,
-      "phase": 322.1718128862925
+      "amplitude": 0.057,
+      "phase": 322.17
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03497353809946893,
-      "phase": 15.346839123722816
+      "amplitude": 0.035,
+      "phase": 15.35
     },
     {
       "name": "MN4",
-      "amplitude": 0.02152707065548166,
-      "phase": 163.3858622940994
+      "amplitude": 0.022,
+      "phase": 163.39
     },
     {
       "name": "MS4",
-      "amplitude": 0.03347788482204147,
-      "phase": 260.8835279827665
+      "amplitude": 0.033,
+      "phase": 260.88
     },
     {
       "name": "N4",
-      "amplitude": 0.004626643080486622,
-      "phase": 146.14103445527644
+      "amplitude": 0.005,
+      "phase": 146.14
     },
     {
       "name": "M6",
-      "amplitude": 0.023211388678486777,
-      "phase": 72.13409103575111
+      "amplitude": 0.023,
+      "phase": 72.13
     },
     {
       "name": "M8",
-      "amplitude": 0.004238005090923602,
-      "phase": 235.4445267295291
+      "amplitude": 0.004,
+      "phase": 235.44
     },
     {
       "name": "S4",
-      "amplitude": 0.0017677693082077451,
-      "phase": 21.456657413316123
+      "amplitude": 0.002,
+      "phase": 21.46
     },
     {
       "name": "OO1",
-      "amplitude": 0.0024277927938513182,
-      "phase": 230.56416992786404
+      "amplitude": 0.002,
+      "phase": 230.56
     },
     {
       "name": "S3",
-      "amplitude": 0.00019003817659473285,
-      "phase": 205.78926206819415
+      "amplitude": 0,
+      "phase": 205.79
     },
     {
       "name": "MA2",
-      "amplitude": 0.025753136964741914,
-      "phase": 313.3105516315223
+      "amplitude": 0.026,
+      "phase": 313.31
     },
     {
       "name": "MB2",
-      "amplitude": 0.013025010477054242,
-      "phase": 59.91768816418062
+      "amplitude": 0.013,
+      "phase": 59.92
     },
     {
       "name": "T3",
-      "amplitude": 0.0002935699959021444,
-      "phase": 265.03191635224516
+      "amplitude": 0,
+      "phase": 265.03
     },
     {
       "name": "R3",
-      "amplitude": 0.0007977966239237993,
-      "phase": 2.878106956095735
+      "amplitude": 0.001,
+      "phase": 2.88
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00613459038187454,
-      "phase": 203.658095106627
+      "amplitude": 0.006,
+      "phase": 203.66
     },
     {
       "name": "SGM",
-      "amplitude": 0.0023116700379662786,
-      "phase": 61.977357239416335
+      "amplitude": 0.002,
+      "phase": 61.98
     },
     {
       "name": "3L2",
-      "amplitude": 0.002795790946684563,
-      "phase": 271.4071649602283
+      "amplitude": 0.003,
+      "phase": 271.41
     },
     {
       "name": "3N2",
-      "amplitude": 0.009981739405255817,
-      "phase": 163.6240462082394
+      "amplitude": 0.01,
+      "phase": 163.62
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0224941759105942,
-      "phase": 296.32706435244853
+      "amplitude": 0.022,
+      "phase": 296.33
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02019146590396011,
-      "phase": 143.22046397016373
+      "amplitude": 0.02,
+      "phase": 143.22
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005093976585410102,
-      "phase": 111.96334732965607
+      "amplitude": 0.005,
+      "phase": 111.96
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006822405872911193,
-      "phase": 319.14131637276915
+      "amplitude": 0.007,
+      "phase": 319.14
     }
   ],
   "epoch": {

--- a/data/ticon/hundsmhlen-4960020-deu-wsv.json
+++ b/data/ticon/hundsmhlen-4960020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.0010158294898520114,
-      "phase": 15.508780340420572
+      "amplitude": 0.001,
+      "phase": 15.51
     },
     {
       "name": "N2",
-      "amplitude": 0.0002834566728967568,
-      "phase": 329.4184840077217
+      "amplitude": 0,
+      "phase": 329.42
     },
     {
       "name": "S2",
-      "amplitude": 0.0021731526044868254,
-      "phase": 48.838646920170845
+      "amplitude": 0.002,
+      "phase": 48.84
     },
     {
       "name": "K2",
-      "amplitude": 0.00011505661757759913,
-      "phase": 158.67507034390837
+      "amplitude": 0,
+      "phase": 158.68
     },
     {
       "name": "2N2",
-      "amplitude": 0.00010236884011162239,
-      "phase": 27.044898861967
+      "amplitude": 0,
+      "phase": 27.04
     },
     {
       "name": "S1",
-      "amplitude": 0.004830187556116742,
-      "phase": 221.7781794723039
+      "amplitude": 0.005,
+      "phase": 221.78
     },
     {
       "name": "K1",
-      "amplitude": 0.001500824671843561,
-      "phase": 261.94419198401863
+      "amplitude": 0.002,
+      "phase": 261.94
     },
     {
       "name": "P1",
-      "amplitude": 0.000804554346137086,
-      "phase": 187.7008392110527
+      "amplitude": 0.001,
+      "phase": 187.7
     },
     {
       "name": "O1",
-      "amplitude": 0.00036922901945500336,
-      "phase": 219.8068004851901
+      "amplitude": 0,
+      "phase": 219.81
     },
     {
       "name": "Q1",
-      "amplitude": 0.00021953640821628084,
-      "phase": 199.81240972766508
+      "amplitude": 0,
+      "phase": 199.81
     },
     {
       "name": "M1",
-      "amplitude": 0.00012064202672008536,
-      "phase": 147.83187296775077
+      "amplitude": 0,
+      "phase": 147.83
     },
     {
       "name": "M4",
-      "amplitude": 0.0004121473231221107,
-      "phase": 155.96448351298113
+      "amplitude": 0,
+      "phase": 155.96
     },
     {
       "name": "MM",
-      "amplitude": 0.0006401819881856331,
-      "phase": 318.82474717348214
+      "amplitude": 0.001,
+      "phase": 318.82
     },
     {
       "name": "MF",
-      "amplitude": 0.00013547143122613894,
-      "phase": 171.94116944328107
+      "amplitude": 0,
+      "phase": 171.94
     },
     {
       "name": "SA",
-      "amplitude": 0.012990693490300072,
-      "phase": 307.6744542011604
+      "amplitude": 0.013,
+      "phase": 307.67
     },
     {
       "name": "SSA",
-      "amplitude": 0.0012523614931918563,
-      "phase": 338.2334649155603
+      "amplitude": 0.001,
+      "phase": 338.23
     },
     {
       "name": "T2",
-      "amplitude": 0.0006148629575185753,
-      "phase": 182.72508840090364
+      "amplitude": 0.001,
+      "phase": 182.73
     },
     {
       "name": "J1",
-      "amplitude": 0.00014750527349095802,
-      "phase": 257.76451531973885
+      "amplitude": 0,
+      "phase": 257.76
     },
     {
       "name": "L2",
-      "amplitude": 0.0001222173949491442,
-      "phase": 80.09836099270376
+      "amplitude": 0,
+      "phase": 80.1
     },
     {
       "name": "R2",
-      "amplitude": 0.0003041441808364488,
-      "phase": 59.431071621495505
+      "amplitude": 0,
+      "phase": 59.43
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0002702884656494498,
-      "phase": 221.8689103077465
+      "amplitude": 0,
+      "phase": 221.87
     },
     {
       "name": "MSF",
-      "amplitude": 0.0007343512807979774,
-      "phase": 74.83957229133705
+      "amplitude": 0.001,
+      "phase": 74.84
     },
     {
       "name": "MSQM",
-      "amplitude": 0.000605541197597274,
-      "phase": 76.24429365390654
+      "amplitude": 0.001,
+      "phase": 76.24
     },
     {
       "name": "EP2",
-      "amplitude": 0.000019041762025378233,
-      "phase": 298.192147239747
+      "amplitude": 0,
+      "phase": 298.19
     },
     {
       "name": "M3",
-      "amplitude": 0.00017486905964037404,
-      "phase": 322.4287077048925
+      "amplitude": 0,
+      "phase": 322.43
     },
     {
       "name": "MU2",
-      "amplitude": 0.0001095735323600003,
-      "phase": 214.4086732169375
+      "amplitude": 0,
+      "phase": 214.41
     },
     {
       "name": "MTM",
-      "amplitude": 0.0005858976109650022,
-      "phase": 170.88871012199706
+      "amplitude": 0.001,
+      "phase": 170.89
     },
     {
       "name": "NU2",
-      "amplitude": 0.0001051554065969314,
-      "phase": 331.76784230931867
+      "amplitude": 0,
+      "phase": 331.77
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00007366859240710822,
-      "phase": 108.70798306159998
+      "amplitude": 0,
+      "phase": 108.71
     },
     {
       "name": "MN4",
-      "amplitude": 0.000130983882533087,
-      "phase": 148.14585320998447
+      "amplitude": 0,
+      "phase": 148.15
     },
     {
       "name": "MS4",
-      "amplitude": 0.00048361786413845224,
-      "phase": 319.6770056517532
+      "amplitude": 0,
+      "phase": 319.68
     },
     {
       "name": "N4",
-      "amplitude": 0.000056757196545364794,
-      "phase": 202.4035967682645
+      "amplitude": 0,
+      "phase": 202.4
     },
     {
       "name": "M6",
-      "amplitude": 0.00023064584576492218,
-      "phase": 146.4742693269199
+      "amplitude": 0,
+      "phase": 146.47
     },
     {
       "name": "M8",
-      "amplitude": 0.0000394612263162705,
-      "phase": 324.91358645249784
+      "amplitude": 0,
+      "phase": 324.91
     },
     {
       "name": "S4",
-      "amplitude": 0.0006260853278547002,
-      "phase": 249.51229755460236
+      "amplitude": 0.001,
+      "phase": 249.51
     },
     {
       "name": "OO1",
-      "amplitude": 0.0001458084471910314,
-      "phase": 224.70984992650708
+      "amplitude": 0,
+      "phase": 224.71
     },
     {
       "name": "S3",
-      "amplitude": 0.0012860921520611215,
-      "phase": 220.98941500774444
+      "amplitude": 0.001,
+      "phase": 220.99
     },
     {
       "name": "MA2",
-      "amplitude": 0.00033772101010684546,
-      "phase": 63.95985190800536
+      "amplitude": 0,
+      "phase": 63.96
     },
     {
       "name": "MB2",
-      "amplitude": 0.00025636196823892576,
-      "phase": 347.8711631310496
+      "amplitude": 0,
+      "phase": 347.87
     },
     {
       "name": "T3",
-      "amplitude": 0.0008316686868234864,
-      "phase": 208.81316489117145
+      "amplitude": 0.001,
+      "phase": 208.81
     },
     {
       "name": "R3",
-      "amplitude": 0.00021704278391333632,
-      "phase": 10.137274168768784
+      "amplitude": 0,
+      "phase": 10.14
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00021978952515624175,
-      "phase": 6.0738153293754635
+      "amplitude": 0,
+      "phase": 6.07
     },
     {
       "name": "SGM",
-      "amplitude": 0.00013231271453934947,
-      "phase": 215.42142383297463
+      "amplitude": 0,
+      "phase": 215.42
     },
     {
       "name": "3L2",
-      "amplitude": 0.00013320993329019547,
-      "phase": 129.97561085296655
+      "amplitude": 0,
+      "phase": 129.98
     },
     {
       "name": "3N2",
-      "amplitude": 0.00010905131870489122,
-      "phase": 252.8888999448946
+      "amplitude": 0,
+      "phase": 252.89
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00009927398142299368,
-      "phase": 7.836063545680531
+      "amplitude": 0,
+      "phase": 7.84
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00019016796648704294,
-      "phase": 251.9036840534452
+      "amplitude": 0,
+      "phase": 251.9
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000032666769252122676,
-      "phase": 179.70673386026317
+      "amplitude": 0,
+      "phase": 179.71
     },
     {
       "name": "2MO5",
-      "amplitude": 0.000009239656469626676,
-      "phase": 197.8014285461257
+      "amplitude": 0,
+      "phase": 197.8
     }
   ],
   "epoch": {

--- a/data/ticon/huntebrck-4960070-deu-wsv.json
+++ b/data/ticon/huntebrck-4960070-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4920875104760323,
-      "phase": 27.592896189414546
+      "amplitude": 1.492,
+      "phase": 27.59
     },
     {
       "name": "N2",
-      "amplitude": 0.22502410047737226,
-      "phase": 4.002465090109297
+      "amplitude": 0.225,
+      "phase": 4
     },
     {
       "name": "S2",
-      "amplitude": 0.3582051881160154,
-      "phase": 107.48247402386994
+      "amplitude": 0.358,
+      "phase": 107.48
     },
     {
       "name": "K2",
-      "amplitude": 0.1064930644788523,
-      "phase": 105.24621030450419
+      "amplitude": 0.106,
+      "phase": 105.25
     },
     {
       "name": "2N2",
-      "amplitude": 0.022371740476944763,
-      "phase": 343.2278745733235
+      "amplitude": 0.022,
+      "phase": 343.23
     },
     {
       "name": "S1",
-      "amplitude": 0.016106209238780207,
-      "phase": 76.79364824245226
+      "amplitude": 0.016,
+      "phase": 76.79
     },
     {
       "name": "K1",
-      "amplitude": 0.06301023960675006,
-      "phase": 72.33965397451925
+      "amplitude": 0.063,
+      "phase": 72.34
     },
     {
       "name": "P1",
-      "amplitude": 0.02698244804455027,
-      "phase": 78.04976731334807
+      "amplitude": 0.027,
+      "phase": 78.05
     },
     {
       "name": "O1",
-      "amplitude": 0.07993703369144456,
-      "phase": 278.36471161371384
+      "amplitude": 0.08,
+      "phase": 278.36
     },
     {
       "name": "Q1",
-      "amplitude": 0.021992467007764666,
-      "phase": 215.51899250546003
+      "amplitude": 0.022,
+      "phase": 215.52
     },
     {
       "name": "M1",
-      "amplitude": 0.002045975655636333,
-      "phase": 139.94351601519725
+      "amplitude": 0.002,
+      "phase": 139.94
     },
     {
       "name": "M4",
-      "amplitude": 0.056774860148694234,
-      "phase": 281.6919490795592
+      "amplitude": 0.057,
+      "phase": 281.69
     },
     {
       "name": "MM",
-      "amplitude": 0.012505454832959985,
-      "phase": 90.81976995145578
+      "amplitude": 0.013,
+      "phase": 90.82
     },
     {
       "name": "MF",
-      "amplitude": 0.015477166508066445,
-      "phase": 89.32568814801198
+      "amplitude": 0.015,
+      "phase": 89.33
     },
     {
       "name": "SA",
-      "amplitude": 0.0528464298637343,
-      "phase": 261.14432350782556
+      "amplitude": 0.053,
+      "phase": 261.14
     },
     {
       "name": "SSA",
-      "amplitude": 0.044304973369219874,
-      "phase": 225.97945497025512
+      "amplitude": 0.044,
+      "phase": 225.98
     },
     {
       "name": "T2",
-      "amplitude": 0.02090284046596604,
-      "phase": 79.79305717188106
+      "amplitude": 0.021,
+      "phase": 79.79
     },
     {
       "name": "J1",
-      "amplitude": 0.0043026312911098865,
-      "phase": 200.85278481459724
+      "amplitude": 0.004,
+      "phase": 200.85
     },
     {
       "name": "L2",
-      "amplitude": 0.13896822543344448,
-      "phase": 41.991280712691434
+      "amplitude": 0.139,
+      "phase": 41.99
     },
     {
       "name": "R2",
-      "amplitude": 0.0015498101078020741,
-      "phase": 158.6602030008288
+      "amplitude": 0.002,
+      "phase": 158.66
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004232253719900962,
-      "phase": 156.81029095456643
+      "amplitude": 0.004,
+      "phase": 156.81
     },
     {
       "name": "MSF",
-      "amplitude": 0.06933398114318778,
-      "phase": 65.2383255610099
+      "amplitude": 0.069,
+      "phase": 65.24
     },
     {
       "name": "MSQM",
-      "amplitude": 0.006650344528285861,
-      "phase": 18.554146385561808
+      "amplitude": 0.007,
+      "phase": 18.55
     },
     {
       "name": "EP2",
-      "amplitude": 0.04353129131523758,
-      "phase": 87.03077870370748
+      "amplitude": 0.044,
+      "phase": 87.03
     },
     {
       "name": "M3",
-      "amplitude": 0.003280052887489699,
-      "phase": 106.9563204762083
+      "amplitude": 0.003,
+      "phase": 106.96
     },
     {
       "name": "MU2",
-      "amplitude": 0.21051797872745612,
-      "phase": 110.69937427478601
+      "amplitude": 0.211,
+      "phase": 110.7
     },
     {
       "name": "MTM",
-      "amplitude": 0.001544526148924126,
-      "phase": 149.5171419324563
+      "amplitude": 0.002,
+      "phase": 149.52
     },
     {
       "name": "NU2",
-      "amplitude": 0.1018908233742996,
-      "phase": 338.5510522499978
+      "amplitude": 0.102,
+      "phase": 338.55
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06370559192138418,
-      "phase": 42.110518507984864
+      "amplitude": 0.064,
+      "phase": 42.11
     },
     {
       "name": "MN4",
-      "amplitude": 0.01847121620233552,
-      "phase": 263.49718696930347
+      "amplitude": 0.018,
+      "phase": 263.5
     },
     {
       "name": "MS4",
-      "amplitude": 0.041943092305062206,
-      "phase": 353.9397460602621
+      "amplitude": 0.042,
+      "phase": 353.94
     },
     {
       "name": "N4",
-      "amplitude": 0.003952201621949745,
-      "phase": 244.26418548142587
+      "amplitude": 0.004,
+      "phase": 244.26
     },
     {
       "name": "M6",
-      "amplitude": 0.06760675664095209,
-      "phase": 121.28200907061091
+      "amplitude": 0.068,
+      "phase": 121.28
     },
     {
       "name": "M8",
-      "amplitude": 0.021148826178277055,
-      "phase": 39.15393142195194
+      "amplitude": 0.021,
+      "phase": 39.15
     },
     {
       "name": "S4",
-      "amplitude": 0.005695145819836754,
-      "phase": 135.22508933233632
+      "amplitude": 0.006,
+      "phase": 135.23
     },
     {
       "name": "OO1",
-      "amplitude": 0.002707658241551161,
-      "phase": 237.4802234493767
+      "amplitude": 0.003,
+      "phase": 237.48
     },
     {
       "name": "S3",
-      "amplitude": 0.001390755437935375,
-      "phase": 0.3221776337312008
+      "amplitude": 0.001,
+      "phase": 0.32
     },
     {
       "name": "MA2",
-      "amplitude": 0.05085110359136157,
-      "phase": 348.8541843483157
+      "amplitude": 0.051,
+      "phase": 348.85
     },
     {
       "name": "MB2",
-      "amplitude": 0.01614368358289041,
-      "phase": 167.7090713644434
+      "amplitude": 0.016,
+      "phase": 167.71
     },
     {
       "name": "T3",
-      "amplitude": 0.0011325741561908184,
-      "phase": 76.33249158591155
+      "amplitude": 0.001,
+      "phase": 76.33
     },
     {
       "name": "R3",
-      "amplitude": 0.005261564739403775,
-      "phase": 87.67792301804161
+      "amplitude": 0.005,
+      "phase": 87.68
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0051740322955928465,
-      "phase": 225.70968062435696
+      "amplitude": 0.005,
+      "phase": 225.71
     },
     {
       "name": "SGM",
-      "amplitude": 0.005800149704430669,
-      "phase": 49.127596221540955
+      "amplitude": 0.006,
+      "phase": 49.13
     },
     {
       "name": "3L2",
-      "amplitude": 0.004532331136916458,
-      "phase": 302.1187829997874
+      "amplitude": 0.005,
+      "phase": 302.12
     },
     {
       "name": "3N2",
-      "amplitude": 0.022268245376867758,
-      "phase": 179.46665223819252
+      "amplitude": 0.022,
+      "phase": 179.47
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04120025401955608,
-      "phase": 330.10191883698246
+      "amplitude": 0.041,
+      "phase": 330.1
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06992812184832677,
-      "phase": 194.07861957282935
+      "amplitude": 0.07,
+      "phase": 194.08
     },
     {
       "name": "2MK5",
-      "amplitude": 0.006139983500858578,
-      "phase": 123.62491744961932
+      "amplitude": 0.006,
+      "phase": 123.62
     },
     {
       "name": "2MO5",
-      "amplitude": 0.003588214365787297,
-      "phase": 322.3561599229997
+      "amplitude": 0.004,
+      "phase": 322.36
     }
   ],
   "epoch": {

--- a/data/ticon/husum-9530020-deu-wsv.json
+++ b/data/ticon/husum-9530020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.6009224145122583,
-      "phase": 358.5905756501759
+      "amplitude": 1.601,
+      "phase": 358.59
     },
     {
       "name": "N2",
-      "amplitude": 0.2561801054255784,
-      "phase": 334.5253913697048
+      "amplitude": 0.256,
+      "phase": 334.53
     },
     {
       "name": "S2",
-      "amplitude": 0.4238969912535575,
-      "phase": 73.99974753404103
+      "amplitude": 0.424,
+      "phase": 74
     },
     {
       "name": "K2",
-      "amplitude": 0.12575526136520024,
-      "phase": 72.45482837283862
+      "amplitude": 0.126,
+      "phase": 72.45
     },
     {
       "name": "2N2",
-      "amplitude": 0.028920579316621862,
-      "phase": 313.39534796522963
+      "amplitude": 0.029,
+      "phase": 313.4
     },
     {
       "name": "S1",
-      "amplitude": 0.017437143839255837,
-      "phase": 27.45972095183231
+      "amplitude": 0.017,
+      "phase": 27.46
     },
     {
       "name": "K1",
-      "amplitude": 0.07231460103035517,
-      "phase": 50.57565219628543
+      "amplitude": 0.072,
+      "phase": 50.58
     },
     {
       "name": "P1",
-      "amplitude": 0.033557671162926586,
-      "phase": 47.796580253020466
+      "amplitude": 0.034,
+      "phase": 47.8
     },
     {
       "name": "O1",
-      "amplitude": 0.09413199547320544,
-      "phase": 259.0671951709994
+      "amplitude": 0.094,
+      "phase": 259.07
     },
     {
       "name": "Q1",
-      "amplitude": 0.029847821044245656,
-      "phase": 200.67812996617232
+      "amplitude": 0.03,
+      "phase": 200.68
     },
     {
       "name": "M1",
-      "amplitude": 0.0023531035615506693,
-      "phase": 115.92658424897229
+      "amplitude": 0.002,
+      "phase": 115.93
     },
     {
       "name": "M4",
-      "amplitude": 0.15783437006317771,
-      "phase": 183.1943748768929
+      "amplitude": 0.158,
+      "phase": 183.19
     },
     {
       "name": "MM",
-      "amplitude": 0.027726981043518353,
-      "phase": 171.51766712715835
+      "amplitude": 0.028,
+      "phase": 171.52
     },
     {
       "name": "MF",
-      "amplitude": 0.010092246720409263,
-      "phase": 148.11323757397543
+      "amplitude": 0.01,
+      "phase": 148.11
     },
     {
       "name": "SA",
-      "amplitude": 0.11501319449145159,
-      "phase": 230.14973450821446
+      "amplitude": 0.115,
+      "phase": 230.15
     },
     {
       "name": "SSA",
-      "amplitude": 0.05503425898854183,
-      "phase": 212.65016462448082
+      "amplitude": 0.055,
+      "phase": 212.65
     },
     {
       "name": "T2",
-      "amplitude": 0.01913894145082662,
-      "phase": 50.78134895334102
+      "amplitude": 0.019,
+      "phase": 50.78
     },
     {
       "name": "J1",
-      "amplitude": 0.00459877317873002,
-      "phase": 191.49191748439242
+      "amplitude": 0.005,
+      "phase": 191.49
     },
     {
       "name": "L2",
-      "amplitude": 0.13652946523984053,
-      "phase": 13.350797136206268
+      "amplitude": 0.137,
+      "phase": 13.35
     },
     {
       "name": "R2",
-      "amplitude": 0.005190897279771886,
-      "phase": 75.45338427407125
+      "amplitude": 0.005,
+      "phase": 75.45
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005830496377635285,
-      "phase": 138.4972622403759
+      "amplitude": 0.006,
+      "phase": 138.5
     },
     {
       "name": "MSF",
-      "amplitude": 0.020048565714739786,
-      "phase": 52.70735570675748
+      "amplitude": 0.02,
+      "phase": 52.71
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009026054093228037,
-      "phase": 47.39165408810061
+      "amplitude": 0.009,
+      "phase": 47.39
     },
     {
       "name": "EP2",
-      "amplitude": 0.04282194209939908,
-      "phase": 55.37384819684149
+      "amplitude": 0.043,
+      "phase": 55.37
     },
     {
       "name": "M3",
-      "amplitude": 0.004040437125061553,
-      "phase": 70.02131249949707
+      "amplitude": 0.004,
+      "phase": 70.02
     },
     {
       "name": "MU2",
-      "amplitude": 0.18497625904817724,
-      "phase": 76.98847777653867
+      "amplitude": 0.185,
+      "phase": 76.99
     },
     {
       "name": "MTM",
-      "amplitude": 0.007107693806847662,
-      "phase": 233.64340129317122
+      "amplitude": 0.007,
+      "phase": 233.64
     },
     {
       "name": "NU2",
-      "amplitude": 0.09474662062106003,
-      "phase": 312.27819369073825
+      "amplitude": 0.095,
+      "phase": 312.28
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06494290854422209,
-      "phase": 9.292269474772866
+      "amplitude": 0.065,
+      "phase": 9.29
     },
     {
       "name": "MN4",
-      "amplitude": 0.04968960278965098,
-      "phase": 160.42893880332815
+      "amplitude": 0.05,
+      "phase": 160.43
     },
     {
       "name": "MS4",
-      "amplitude": 0.10453787649462025,
-      "phase": 263.4335312244109
+      "amplitude": 0.105,
+      "phase": 263.43
     },
     {
       "name": "N4",
-      "amplitude": 0.00981205947680771,
-      "phase": 141.30971187683133
+      "amplitude": 0.01,
+      "phase": 141.31
     },
     {
       "name": "M6",
-      "amplitude": 0.030604848835775165,
-      "phase": 48.8494440908367
+      "amplitude": 0.031,
+      "phase": 48.85
     },
     {
       "name": "M8",
-      "amplitude": 0.014108465198701731,
-      "phase": 357.6006932320463
+      "amplitude": 0.014,
+      "phase": 357.6
     },
     {
       "name": "S4",
-      "amplitude": 0.015044281681931242,
-      "phase": 49.67995658044049
+      "amplitude": 0.015,
+      "phase": 49.68
     },
     {
       "name": "OO1",
-      "amplitude": 0.002730955746970988,
-      "phase": 220.27126848407005
+      "amplitude": 0.003,
+      "phase": 220.27
     },
     {
       "name": "S3",
-      "amplitude": 0.0016500640011828163,
-      "phase": 194.06067605599858
+      "amplitude": 0.002,
+      "phase": 194.06
     },
     {
       "name": "MA2",
-      "amplitude": 0.05391874157610326,
-      "phase": 294.5457410562751
+      "amplitude": 0.054,
+      "phase": 294.55
     },
     {
       "name": "MB2",
-      "amplitude": 0.03011843821069521,
-      "phase": 84.26323208168185
+      "amplitude": 0.03,
+      "phase": 84.26
     },
     {
       "name": "T3",
-      "amplitude": 0.0008809023224475253,
-      "phase": 186.6150926971955
+      "amplitude": 0.001,
+      "phase": 186.62
     },
     {
       "name": "R3",
-      "amplitude": 0.003326171426478203,
-      "phase": 9.781628764228685
+      "amplitude": 0.003,
+      "phase": 9.78
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0063155126951238965,
-      "phase": 203.25539120210513
+      "amplitude": 0.006,
+      "phase": 203.26
     },
     {
       "name": "SGM",
-      "amplitude": 0.0018340751417637443,
-      "phase": 33.949275887995896
+      "amplitude": 0.002,
+      "phase": 33.95
     },
     {
       "name": "3L2",
-      "amplitude": 0.00447955603487714,
-      "phase": 275.52941464164894
+      "amplitude": 0.004,
+      "phase": 275.53
     },
     {
       "name": "3N2",
-      "amplitude": 0.0187732810704967,
-      "phase": 154.0407269372149
+      "amplitude": 0.019,
+      "phase": 154.04
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04656830670349417,
-      "phase": 292.3436936441143
+      "amplitude": 0.047,
+      "phase": 292.34
     },
     {
       "name": "2MS6",
-      "amplitude": 0.03797668034111279,
-      "phase": 118.20885990745626
+      "amplitude": 0.038,
+      "phase": 118.21
     },
     {
       "name": "2MK5",
-      "amplitude": 0.007798319469834806,
-      "phase": 55.17030900452113
+      "amplitude": 0.008,
+      "phase": 55.17
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0026675279556108377,
-      "phase": 251.24994161251257
+      "amplitude": 0.003,
+      "phase": 251.25
     }
   ],
   "epoch": {

--- a/data/ticon/ijmuiden_buitenhaven-ijmdbthvn-nld-rws.json
+++ b/data/ticon/ijmuiden_buitenhaven-ijmdbthvn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.6522104400000001,
-      "phase": 115.74636099999998
+      "amplitude": 0.675,
+      "phase": 99.65
     },
     {
       "name": "N2",
-      "amplitude": 0.09044779,
-      "phase": 95.746737
+      "amplitude": 0.094,
+      "phase": 79.8
     },
     {
       "name": "S2",
-      "amplitude": 0.17000028,
-      "phase": 184.257173
+      "amplitude": 0.175,
+      "phase": 168.2
     },
     {
       "name": "K2",
-      "amplitude": 0.05117206999999999,
-      "phase": 185.219264
+      "amplitude": 0.055,
+      "phase": 167.18
     },
     {
       "name": "2N2",
-      "amplitude": 0.01009738,
-      "phase": 62.386752
+      "amplitude": 0.012,
+      "phase": 50.85
     },
     {
       "name": "S1",
-      "amplitude": 0.00953465,
-      "phase": 350.848828
+      "amplitude": 0.013,
+      "phase": 294.84
     },
     {
       "name": "K1",
-      "amplitude": 0.0778698,
-      "phase": 350.825352
+      "amplitude": 0.078,
+      "phase": 342.22
     },
     {
       "name": "P1",
-      "amplitude": 0.03523448,
-      "phase": 341.715096
+      "amplitude": 0.035,
+      "phase": 333.72
     },
     {
       "name": "O1",
-      "amplitude": 0.10999431,
-      "phase": 185.548591
+      "amplitude": 0.11,
+      "phase": 177.7
     },
     {
       "name": "Q1",
-      "amplitude": 0.04042957999999999,
-      "phase": 129.96952299999998
+      "amplitude": 0.04,
+      "phase": 122.55
     },
     {
       "name": "M1",
-      "amplitude": 0.00351161,
-      "phase": 129.76599499999998
+      "amplitude": 0.003,
+      "phase": 354.28
     },
     {
       "name": "M4",
-      "amplitude": 0.17110561000000002,
-      "phase": 159.84790399999997
+      "amplitude": 0.199,
+      "phase": 126.89
     },
     {
       "name": "MM",
-      "amplitude": 0.018802410000000002,
-      "phase": 143.53317800000002
+      "amplitude": 0.02,
+      "phase": 142.91
     },
     {
       "name": "MF",
-      "amplitude": 0.0086719,
-      "phase": 316.134833
+      "amplitude": 0.008,
+      "phase": 313.73
     },
     {
       "name": "SA",
-      "amplitude": 0.11313185,
-      "phase": 224.960382
+      "amplitude": 0.12,
+      "phase": 224.92
     },
     {
       "name": "SSA",
-      "amplitude": 0.03789814,
-      "phase": 185.609889
+      "amplitude": 0.038,
+      "phase": 179.31
     },
     {
       "name": "T2",
-      "amplitude": 0.0355586,
-      "phase": 106.43365
+      "amplitude": 0.012,
+      "phase": 139.76
     },
     {
       "name": "J1",
-      "amplitude": 0.00398984,
-      "phase": 72.10576000000003
+      "amplitude": 0.004,
+      "phase": 64.02
     },
     {
       "name": "L2",
-      "amplitude": 0.06097009,
-      "phase": 133.526256
+      "amplitude": 0.064,
+      "phase": 117.55
     },
     {
       "name": "R2",
-      "amplitude": 0.01927466,
-      "phase": 288.753919
+      "amplitude": 0.001,
+      "phase": 75.65
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0084868,
-      "phase": 69.88366200000002
+      "amplitude": 0.008,
+      "phase": 66.43
     },
     {
       "name": "MSF",
-      "amplitude": 0.036992319999999995,
-      "phase": 34.875088000000005
+      "amplitude": 0.037,
+      "phase": 34.62
     },
     {
       "name": "MSQM",
-      "amplitude": 0.005197770000000001,
-      "phase": 224.474612
+      "amplitude": 0.005,
+      "phase": 221.21
     },
     {
       "name": "EP2",
-      "amplitude": 0.01532346,
-      "phase": 199.980083
+      "amplitude": 0.016,
+      "phase": 184.82
     },
     {
       "name": "M3",
-      "amplitude": 0.00401846,
-      "phase": 282.59497799999997
+      "amplitude": 0.004,
+      "phase": 75.09
     },
     {
       "name": "MU2",
-      "amplitude": 0.08797034,
-      "phase": 219.574344
+      "amplitude": 0.09,
+      "phase": 202.94
     },
     {
       "name": "MTM",
-      "amplitude": 0.00544338,
-      "phase": 297.259055
+      "amplitude": 0.004,
+      "phase": 306.82
     },
     {
       "name": "NU2",
-      "amplitude": 0.04088239,
-      "phase": 79.11822000000001
+      "amplitude": 0.045,
+      "phase": 61.83
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03146849,
-      "phase": 126.95133599999997
+      "amplitude": 0.033,
+      "phase": 113.86
     },
     {
       "name": "MN4",
-      "amplitude": 0.05795068,
-      "phase": 134.999748
+      "amplitude": 0.067,
+      "phase": 102.58
     },
     {
       "name": "MS4",
-      "amplitude": 0.09897627999999999,
-      "phase": 218.286778
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.020109659999999998,
-      "phase": 265.814411
+      "amplitude": 0.115,
+      "phase": 186.42
     },
     {
       "name": "N4",
-      "amplitude": 0.01288011,
-      "phase": 106.32785799999999
+      "amplitude": 0.017,
+      "phase": 69.07
     },
     {
       "name": "M6",
-      "amplitude": 0.02943057,
-      "phase": 255.948826
+      "amplitude": 0.043,
+      "phase": 202.49
     },
     {
       "name": "M8",
-      "amplitude": 0.01433749,
-      "phase": 286.17078
+      "amplitude": 0.029,
+      "phase": 214.18
     },
     {
       "name": "S4",
-      "amplitude": 0.00735403,
-      "phase": 304.804442
+      "amplitude": 0.009,
+      "phase": 267.41
     },
     {
       "name": "OO1",
-      "amplitude": 0.00487962,
-      "phase": 125.96964700000001
+      "amplitude": 0.004,
+      "phase": 114.75
     },
     {
       "name": "S3",
-      "amplitude": 0.00120878,
-      "phase": 25.200912000000017
+      "amplitude": 0,
+      "phase": 139.93
     },
     {
       "name": "MA2",
-      "amplitude": 0.12864734,
-      "phase": 100.94854199999997
+      "amplitude": 0.023,
+      "phase": 90.15
     },
     {
       "name": "MB2",
-      "amplitude": 0.09363839,
-      "phase": 304.587435
+      "amplitude": 0.013,
+      "phase": 146.94
     },
     {
       "name": "T3",
-      "amplitude": 0.00068303,
-      "phase": 35.22177599999998
+      "amplitude": 0.001,
+      "phase": 209.45
     },
     {
       "name": "R3",
-      "amplitude": 0.00216981,
-      "phase": 250.01797299999998
+      "amplitude": 0.002,
+      "phase": 309.28
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00842586,
-      "phase": 112.893551
+      "amplitude": 0.008,
+      "phase": 110.8
     },
     {
       "name": "SGM",
-      "amplitude": 0.0029216999999999997,
-      "phase": 247.374155
+      "amplitude": 0.002,
+      "phase": 83.17
     },
     {
       "name": "3L2",
-      "amplitude": 0.01114501,
-      "phase": 1.799757999999997
+      "amplitude": 0.013,
+      "phase": 73.77
     },
     {
       "name": "3N2",
-      "amplitude": 0.00307288,
-      "phase": 75.37599999999998
+      "amplitude": 0.005,
+      "phase": 268.11
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0258653,
-      "phase": 33.333203000000026
+      "amplitude": 0.027,
+      "phase": 18.85
     },
     {
       "name": "2MS6",
-      "amplitude": 0.03386378,
-      "phase": 306.945125
+      "amplitude": 0.049,
+      "phase": 254.71
     },
     {
       "name": "2MK5",
-      "amplitude": 0.02009665,
-      "phase": 284.340493
+      "amplitude": 0.024,
+      "phase": 327.57
     },
     {
       "name": "2MO5",
-      "amplitude": 0.01580813,
-      "phase": 291.753213
+      "amplitude": 0.02,
+      "phase": 164.19
     }
   ],
   "epoch": {

--- a/data/ticon/ijmuiden_stroommeetpaal-ijmdsmpl-nld-rws.json
+++ b/data/ticon/ijmuiden_stroommeetpaal-ijmdsmpl-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.64627469,
-      "phase": 115.10958399999998
+      "amplitude": 0.668,
+      "phase": 98.16
     },
     {
       "name": "N2",
-      "amplitude": 0.09029156,
-      "phase": 92.58446800000002
+      "amplitude": 0.093,
+      "phase": 76.33
     },
     {
       "name": "S2",
-      "amplitude": 0.16781085999999998,
-      "phase": 183.843281
+      "amplitude": 0.172,
+      "phase": 166.34
     },
     {
       "name": "K2",
-      "amplitude": 0.0480497,
-      "phase": 187.698369
+      "amplitude": 0.053,
+      "phase": 164.48
     },
     {
       "name": "2N2",
-      "amplitude": 0.00865292,
-      "phase": 63.952485000000024
+      "amplitude": 0.009,
+      "phase": 52.34
     },
     {
       "name": "S1",
-      "amplitude": 0.008662,
-      "phase": 356.129665
+      "amplitude": 0.011,
+      "phase": 291.34
     },
     {
       "name": "K1",
-      "amplitude": 0.08064116,
-      "phase": 350.826024
+      "amplitude": 0.081,
+      "phase": 341.87
     },
     {
       "name": "P1",
-      "amplitude": 0.03387163,
-      "phase": 339.873243
+      "amplitude": 0.034,
+      "phase": 333.47
     },
     {
       "name": "O1",
-      "amplitude": 0.10983237000000001,
-      "phase": 186.482762
+      "amplitude": 0.11,
+      "phase": 178.23
     },
     {
       "name": "Q1",
-      "amplitude": 0.03625848,
-      "phase": 129.034127
+      "amplitude": 0.036,
+      "phase": 120.83
     },
     {
       "name": "M1",
-      "amplitude": 0.00049651,
-      "phase": 209.600083
+      "amplitude": 0.002,
+      "phase": 30.52
     },
     {
       "name": "M4",
-      "amplitude": 0.17498081,
-      "phase": 159.21330799999998
+      "amplitude": 0.203,
+      "phase": 124.8
     },
     {
       "name": "MM",
-      "amplitude": 0.01229723,
-      "phase": 141.696711
+      "amplitude": 0.013,
+      "phase": 142.75
     },
     {
       "name": "MF",
-      "amplitude": 0.00826462,
-      "phase": 139.84461999999996
+      "amplitude": 0.008,
+      "phase": 140.6
     },
     {
       "name": "SA",
-      "amplitude": 0.09881954999999999,
-      "phase": 218.265718
+      "amplitude": 0.101,
+      "phase": 216.4
     },
     {
       "name": "SSA",
-      "amplitude": 0.02353853,
-      "phase": 198.154368
+      "amplitude": 0.022,
+      "phase": 198.31
     },
     {
       "name": "T2",
-      "amplitude": 0.03359768,
-      "phase": 101.188871
+      "amplitude": 0.012,
+      "phase": 140.6
     },
     {
       "name": "J1",
-      "amplitude": 0.00375743,
-      "phase": 87.919286
+      "amplitude": 0.004,
+      "phase": 78.27
     },
     {
       "name": "L2",
-      "amplitude": 0.06213122,
-      "phase": 128.44914700000004
+      "amplitude": 0.064,
+      "phase": 110.94
     },
     {
       "name": "R2",
-      "amplitude": 0.02151259,
-      "phase": 296.385666
+      "amplitude": 0.001,
+      "phase": 27.82
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0064570700000000005,
-      "phase": 80.99623099999997
+      "amplitude": 0.007,
+      "phase": 76.8
     },
     {
       "name": "MSF",
-      "amplitude": 0.01834326,
-      "phase": 36.173857999999996
+      "amplitude": 0.018,
+      "phase": 35.74
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00785289,
-      "phase": 75.88552099999998
+      "amplitude": 0.008,
+      "phase": 75.7
     },
     {
       "name": "EP2",
-      "amplitude": 0.017687679999999997,
-      "phase": 198.781458
+      "amplitude": 0.018,
+      "phase": 183.67
     },
     {
       "name": "M3",
-      "amplitude": 0.00465692,
-      "phase": 283.89947
+      "amplitude": 0.005,
+      "phase": 78.57
     },
     {
       "name": "MU2",
-      "amplitude": 0.08459204,
-      "phase": 217.283616
+      "amplitude": 0.088,
+      "phase": 200.48
     },
     {
       "name": "MTM",
-      "amplitude": 0.00505899,
-      "phase": 263.041236
+      "amplitude": 0.005,
+      "phase": 263.24
     },
     {
       "name": "NU2",
-      "amplitude": 0.04015891,
-      "phase": 75.75723099999999
+      "amplitude": 0.042,
+      "phase": 59.16
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.030511200000000002,
-      "phase": 128.53243199999997
+      "amplitude": 0.032,
+      "phase": 109.8
     },
     {
       "name": "MN4",
-      "amplitude": 0.06049775,
-      "phase": 132.19935899999996
+      "amplitude": 0.07,
+      "phase": 98.82
     },
     {
       "name": "MS4",
-      "amplitude": 0.10474677,
-      "phase": 217.212746
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.0355124,
-      "phase": 256.14959799999997
+      "amplitude": 0.119,
+      "phase": 182.66
     },
     {
       "name": "N4",
-      "amplitude": 0.01258947,
-      "phase": 106.39950499999998
+      "amplitude": 0.015,
+      "phase": 74.52
     },
     {
       "name": "M6",
-      "amplitude": 0.03231672,
-      "phase": 252.11666200000002
+      "amplitude": 0.045,
+      "phase": 196.72
     },
     {
       "name": "M8",
-      "amplitude": 0.015706770000000002,
-      "phase": 281.75264500000003
+      "amplitude": 0.03,
+      "phase": 206.64
     },
     {
       "name": "S4",
-      "amplitude": 0.00688709,
-      "phase": 290.912558
+      "amplitude": 0.007,
+      "phase": 255.25
     },
     {
       "name": "OO1",
-      "amplitude": 0.0038659,
-      "phase": 149.888106
+      "amplitude": 0.004,
+      "phase": 132.22
     },
     {
       "name": "S3",
-      "amplitude": 0.00093929,
-      "phase": 27.155957
+      "amplitude": 0,
+      "phase": 89.02
     },
     {
       "name": "MA2",
-      "amplitude": 0.12348879,
-      "phase": 93.86051700000002
+      "amplitude": 0.02,
+      "phase": 82.56
     },
     {
       "name": "MB2",
-      "amplitude": 0.09282432,
-      "phase": 310.934486
+      "amplitude": 0.011,
+      "phase": 124.71
     },
     {
       "name": "T3",
-      "amplitude": 0.0009885,
-      "phase": 21.56488200000001
+      "amplitude": 0.001,
+      "phase": 195.98
     },
     {
       "name": "R3",
-      "amplitude": 0.00234143,
-      "phase": 248.605289
+      "amplitude": 0.003,
+      "phase": 310.54
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00790537,
-      "phase": 131.825607
+      "amplitude": 0.008,
+      "phase": 125.29
     },
     {
       "name": "SGM",
-      "amplitude": 0.0028480499999999995,
-      "phase": 151.650306
+      "amplitude": 0.003,
+      "phase": 319.74
     },
     {
       "name": "3L2",
-      "amplitude": 0.00285335,
-      "phase": 310.472077
+      "amplitude": 0.004,
+      "phase": 36.93
     },
     {
       "name": "3N2",
-      "amplitude": 0.0020108,
-      "phase": 95.86095
+      "amplitude": 0.011,
+      "phase": 259.68
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0253816,
-      "phase": 38.56398300000001
+      "amplitude": 0.026,
+      "phase": 20.86
     },
     {
       "name": "2MS6",
-      "amplitude": 0.036524640000000004,
-      "phase": 303.794208
+      "amplitude": 0.05,
+      "phase": 248.22
     },
     {
       "name": "2MK5",
-      "amplitude": 0.01899894,
-      "phase": 277.490502
+      "amplitude": 0.024,
+      "phase": 322.98
     },
     {
       "name": "2MO5",
-      "amplitude": 0.01563534,
-      "phase": 295.657514
+      "amplitude": 0.02,
+      "phase": 162.93
     }
   ],
   "epoch": {

--- a/data/ticon/ilmenausperrwerkap-5940080-deu-wsv.json
+++ b/data/ticon/ilmenausperrwerkap-5940080-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.214109319008944,
-      "phase": 116.14851740685282
+      "amplitude": 1.214,
+      "phase": 116.15
     },
     {
       "name": "N2",
-      "amplitude": 0.17852740810491133,
-      "phase": 89.83093224809664
+      "amplitude": 0.179,
+      "phase": 89.83
     },
     {
       "name": "S2",
-      "amplitude": 0.27441663761953694,
-      "phase": 196.5341042355381
+      "amplitude": 0.274,
+      "phase": 196.53
     },
     {
       "name": "K2",
-      "amplitude": 0.07874882121993725,
-      "phase": 197.48903674862342
+      "amplitude": 0.079,
+      "phase": 197.49
     },
     {
       "name": "2N2",
-      "amplitude": 0.017923699818842793,
-      "phase": 67.44652790488755
+      "amplitude": 0.018,
+      "phase": 67.45
     },
     {
       "name": "S1",
-      "amplitude": 0.018955475215273025,
-      "phase": 111.80670979742496
+      "amplitude": 0.019,
+      "phase": 111.81
     },
     {
       "name": "K1",
-      "amplitude": 0.06409134051815286,
-      "phase": 126.00627569393896
+      "amplitude": 0.064,
+      "phase": 126.01
     },
     {
       "name": "P1",
-      "amplitude": 0.025240052619743474,
-      "phase": 113.39039750895239
+      "amplitude": 0.025,
+      "phase": 113.39
     },
     {
       "name": "O1",
-      "amplitude": 0.07808106178135499,
-      "phase": 327.1801931396453
+      "amplitude": 0.078,
+      "phase": 327.18
     },
     {
       "name": "Q1",
-      "amplitude": 0.020888549603285168,
-      "phase": 264.8653379778443
+      "amplitude": 0.021,
+      "phase": 264.87
     },
     {
       "name": "M1",
-      "amplitude": 0.0022891124761767073,
-      "phase": 169.06217319887787
+      "amplitude": 0.002,
+      "phase": 169.06
     },
     {
       "name": "M4",
-      "amplitude": 0.17566478589772816,
-      "phase": 155.49522904212063
+      "amplitude": 0.176,
+      "phase": 155.5
     },
     {
       "name": "MM",
-      "amplitude": 0.017983993345188777,
-      "phase": 82.90770433348564
+      "amplitude": 0.018,
+      "phase": 82.91
     },
     {
       "name": "MF",
-      "amplitude": 0.020988245483323367,
-      "phase": 84.14356905569673
+      "amplitude": 0.021,
+      "phase": 84.14
     },
     {
       "name": "SA",
-      "amplitude": 0.2342601678135742,
-      "phase": 323.3074165522888
+      "amplitude": 0.234,
+      "phase": 323.31
     },
     {
       "name": "SSA",
-      "amplitude": 0.07614168946258014,
-      "phase": 291.5131479428479
+      "amplitude": 0.076,
+      "phase": 291.51
     },
     {
       "name": "T2",
-      "amplitude": 0.002906246690356951,
-      "phase": 214.93382773987545
+      "amplitude": 0.003,
+      "phase": 214.93
     },
     {
       "name": "J1",
-      "amplitude": 0.0067657633410891935,
-      "phase": 251.77701082555666
+      "amplitude": 0.007,
+      "phase": 251.78
     },
     {
       "name": "L2",
-      "amplitude": 0.1167886804623966,
-      "phase": 133.54383469095944
+      "amplitude": 0.117,
+      "phase": 133.54
     },
     {
       "name": "R2",
-      "amplitude": 0.018965376234932094,
-      "phase": 279.43719309037857
+      "amplitude": 0.019,
+      "phase": 279.44
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004906946887479165,
-      "phase": 197.59355838792087
+      "amplitude": 0.005,
+      "phase": 197.59
     },
     {
       "name": "MSF",
-      "amplitude": 0.09169723942999285,
-      "phase": 66.47821186462778
+      "amplitude": 0.092,
+      "phase": 66.48
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009291667314307224,
-      "phase": 26.13389929063038
+      "amplitude": 0.009,
+      "phase": 26.13
     },
     {
       "name": "EP2",
-      "amplitude": 0.03396650866874972,
-      "phase": 176.18950363845136
+      "amplitude": 0.034,
+      "phase": 176.19
     },
     {
       "name": "M3",
-      "amplitude": 0.0036106742432054,
-      "phase": 201.24335595127684
+      "amplitude": 0.004,
+      "phase": 201.24
     },
     {
       "name": "MU2",
-      "amplitude": 0.17454653722516808,
-      "phase": 202.62511843296437
+      "amplitude": 0.175,
+      "phase": 202.63
     },
     {
       "name": "MTM",
-      "amplitude": 0.001675084719957659,
-      "phase": 214.99731634148395
+      "amplitude": 0.002,
+      "phase": 215
     },
     {
       "name": "NU2",
-      "amplitude": 0.08419163865620775,
-      "phase": 69.7361415497773
+      "amplitude": 0.084,
+      "phase": 69.74
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.052863339649885446,
-      "phase": 135.37175665736117
+      "amplitude": 0.053,
+      "phase": 135.37
     },
     {
       "name": "MN4",
-      "amplitude": 0.05669712851693253,
-      "phase": 128.5970696571096
+      "amplitude": 0.057,
+      "phase": 128.6
     },
     {
       "name": "MS4",
-      "amplitude": 0.09132196470080618,
-      "phase": 233.42051006684704
+      "amplitude": 0.091,
+      "phase": 233.42
     },
     {
       "name": "N4",
-      "amplitude": 0.010849194982141779,
-      "phase": 107.71317878392858
+      "amplitude": 0.011,
+      "phase": 107.71
     },
     {
       "name": "M6",
-      "amplitude": 0.03303876874927611,
-      "phase": 68.97184379572906
+      "amplitude": 0.033,
+      "phase": 68.97
     },
     {
       "name": "M8",
-      "amplitude": 0.020087946789024442,
-      "phase": 80.48485812047437
+      "amplitude": 0.02,
+      "phase": 80.48
     },
     {
       "name": "S4",
-      "amplitude": 0.006812509935943146,
-      "phase": 24.268187311307656
+      "amplitude": 0.007,
+      "phase": 24.27
     },
     {
       "name": "OO1",
-      "amplitude": 0.0024918836094789333,
-      "phase": 255.76256687321145
+      "amplitude": 0.002,
+      "phase": 255.76
     },
     {
       "name": "S3",
-      "amplitude": 0.0007796780685910441,
-      "phase": 111.7598332582728
+      "amplitude": 0.001,
+      "phase": 111.76
     },
     {
       "name": "MA2",
-      "amplitude": 0.0631149497206062,
-      "phase": 9.530257036233593
+      "amplitude": 0.063,
+      "phase": 9.53
     },
     {
       "name": "MB2",
-      "amplitude": 0.06809582781125381,
-      "phase": 278.7564176930746
+      "amplitude": 0.068,
+      "phase": 278.76
     },
     {
       "name": "T3",
-      "amplitude": 0.0017693133484985165,
-      "phase": 211.94716924318257
+      "amplitude": 0.002,
+      "phase": 211.95
     },
     {
       "name": "R3",
-      "amplitude": 0.005503125193613197,
-      "phase": 232.85612442066503
+      "amplitude": 0.006,
+      "phase": 232.86
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004644812603409522,
-      "phase": 272.3687842839406
+      "amplitude": 0.005,
+      "phase": 272.37
     },
     {
       "name": "SGM",
-      "amplitude": 0.005430801903002043,
-      "phase": 100.72234834340713
+      "amplitude": 0.005,
+      "phase": 100.72
     },
     {
       "name": "3L2",
-      "amplitude": 0.0016324376043866907,
-      "phase": 96.75774270804925
+      "amplitude": 0.002,
+      "phase": 96.76
     },
     {
       "name": "3N2",
-      "amplitude": 0.03840916951542681,
-      "phase": 265.99100746869516
+      "amplitude": 0.038,
+      "phase": 265.99
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03019757332952148,
-      "phase": 65.97805883533158
+      "amplitude": 0.03,
+      "phase": 65.98
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02928455918524888,
-      "phase": 145.53438726611705
+      "amplitude": 0.029,
+      "phase": 145.53
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0028980005541949117,
-      "phase": 68.49681941549619
+      "amplitude": 0.003,
+      "phase": 68.5
     },
     {
       "name": "2MO5",
-      "amplitude": 0.001707520412585957,
-      "phase": 340.5565027104197
+      "amplitude": 0.002,
+      "phase": 340.56
     }
   ],
   "epoch": {

--- a/data/ticon/itzehoehafen-5970042-deu-wsv.json
+++ b/data/ticon/itzehoehafen-5970042-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.9523791016643259,
-      "phase": 77.29966435238435
+      "amplitude": 0.952,
+      "phase": 77.3
     },
     {
       "name": "N2",
-      "amplitude": 0.13765067284445962,
-      "phase": 51.57823227249355
+      "amplitude": 0.138,
+      "phase": 51.58
     },
     {
       "name": "S2",
-      "amplitude": 0.2066740763519823,
-      "phase": 151.25108961971625
+      "amplitude": 0.207,
+      "phase": 151.25
     },
     {
       "name": "K2",
-      "amplitude": 0.06387952776921607,
-      "phase": 153.9536599357466
+      "amplitude": 0.064,
+      "phase": 153.95
     },
     {
       "name": "2N2",
-      "amplitude": 0.010071998406653656,
-      "phase": 32.8907194014522
+      "amplitude": 0.01,
+      "phase": 32.89
     },
     {
       "name": "S1",
-      "amplitude": 0.014789072001111158,
-      "phase": 88.2043714684304
+      "amplitude": 0.015,
+      "phase": 88.2
     },
     {
       "name": "K1",
-      "amplitude": 0.05751493239180841,
-      "phase": 110.93811449038321
+      "amplitude": 0.058,
+      "phase": 110.94
     },
     {
       "name": "P1",
-      "amplitude": 0.022291735750529392,
-      "phase": 107.66009976426898
+      "amplitude": 0.022,
+      "phase": 107.66
     },
     {
       "name": "O1",
-      "amplitude": 0.07211363330556166,
-      "phase": 312.70212323827633
+      "amplitude": 0.072,
+      "phase": 312.7
     },
     {
       "name": "Q1",
-      "amplitude": 0.020038414290300267,
-      "phase": 257.703458085805
+      "amplitude": 0.02,
+      "phase": 257.7
     },
     {
       "name": "M1",
-      "amplitude": 0.0018764482098791687,
-      "phase": 191.40571688189794
+      "amplitude": 0.002,
+      "phase": 191.41
     },
     {
       "name": "M4",
-      "amplitude": 0.11130268590940923,
-      "phase": 57.60267424511551
+      "amplitude": 0.111,
+      "phase": 57.6
     },
     {
       "name": "MM",
-      "amplitude": 0.017952080110990802,
-      "phase": 117.87740015983638
+      "amplitude": 0.018,
+      "phase": 117.88
     },
     {
       "name": "MF",
-      "amplitude": 0.021677287851782617,
-      "phase": 122.199790260523
+      "amplitude": 0.022,
+      "phase": 122.2
     },
     {
       "name": "SA",
-      "amplitude": 0.09793011509975241,
-      "phase": 273.87352488443173
+      "amplitude": 0.098,
+      "phase": 273.87
     },
     {
       "name": "SSA",
-      "amplitude": 0.05507165687228049,
-      "phase": 221.07208325331555
+      "amplitude": 0.055,
+      "phase": 221.07
     },
     {
       "name": "T2",
-      "amplitude": 0.007136018952661619,
-      "phase": 144.65888986743926
+      "amplitude": 0.007,
+      "phase": 144.66
     },
     {
       "name": "J1",
-      "amplitude": 0.005170516919345351,
-      "phase": 223.28331167776196
+      "amplitude": 0.005,
+      "phase": 223.28
     },
     {
       "name": "L2",
-      "amplitude": 0.09293962164529687,
-      "phase": 95.96961306387317
+      "amplitude": 0.093,
+      "phase": 95.97
     },
     {
       "name": "R2",
-      "amplitude": 0.009385082911128016,
-      "phase": 177.24286760931955
+      "amplitude": 0.009,
+      "phase": 177.24
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0033485473380771877,
-      "phase": 158.89047211958143
+      "amplitude": 0.003,
+      "phase": 158.89
     },
     {
       "name": "MSF",
-      "amplitude": 0.07315980208582448,
-      "phase": 69.54404246147834
+      "amplitude": 0.073,
+      "phase": 69.54
     },
     {
       "name": "MSQM",
-      "amplitude": 0.010309667698498007,
-      "phase": 238.04160231549156
+      "amplitude": 0.01,
+      "phase": 238.04
     },
     {
       "name": "EP2",
-      "amplitude": 0.02747544268320436,
-      "phase": 146.18516238665347
+      "amplitude": 0.027,
+      "phase": 146.19
     },
     {
       "name": "M3",
-      "amplitude": 0.0020750279761577606,
-      "phase": 170.58222620417314
+      "amplitude": 0.002,
+      "phase": 170.58
     },
     {
       "name": "MU2",
-      "amplitude": 0.1313850587369803,
-      "phase": 172.52663568345315
+      "amplitude": 0.131,
+      "phase": 172.53
     },
     {
       "name": "MTM",
-      "amplitude": 0.004739865009406724,
-      "phase": 289.37350543608375
+      "amplitude": 0.005,
+      "phase": 289.37
     },
     {
       "name": "NU2",
-      "amplitude": 0.06979463998078769,
-      "phase": 36.44419954112135
+      "amplitude": 0.07,
+      "phase": 36.44
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03714057537540595,
-      "phase": 98.01548543919421
+      "amplitude": 0.037,
+      "phase": 98.02
     },
     {
       "name": "MN4",
-      "amplitude": 0.03524888853019518,
-      "phase": 30.50010179751058
+      "amplitude": 0.035,
+      "phase": 30.5
     },
     {
       "name": "MS4",
-      "amplitude": 0.05825442656444376,
-      "phase": 128.07505414096113
+      "amplitude": 0.058,
+      "phase": 128.08
     },
     {
       "name": "N4",
-      "amplitude": 0.006585260300762058,
-      "phase": 9.559641046321076
+      "amplitude": 0.007,
+      "phase": 9.56
     },
     {
       "name": "M6",
-      "amplitude": 0.04330930293455128,
-      "phase": 291.91879332319246
+      "amplitude": 0.043,
+      "phase": 291.92
     },
     {
       "name": "M8",
-      "amplitude": 0.019544395600853113,
-      "phase": 273.48973603335776
+      "amplitude": 0.02,
+      "phase": 273.49
     },
     {
       "name": "S4",
-      "amplitude": 0.0029955855034297075,
-      "phase": 258.5650477435838
+      "amplitude": 0.003,
+      "phase": 258.57
     },
     {
       "name": "OO1",
-      "amplitude": 0.002881647607003057,
-      "phase": 224.18824574495366
+      "amplitude": 0.003,
+      "phase": 224.19
     },
     {
       "name": "S3",
-      "amplitude": 0.0008542864168140773,
-      "phase": 98.2216357433636
+      "amplitude": 0.001,
+      "phase": 98.22
     },
     {
       "name": "MA2",
-      "amplitude": 0.024642297206109606,
-      "phase": 345.51921155628594
+      "amplitude": 0.025,
+      "phase": 345.52
     },
     {
       "name": "MB2",
-      "amplitude": 0.03816716721212726,
-      "phase": 184.80673370633863
+      "amplitude": 0.038,
+      "phase": 184.81
     },
     {
       "name": "T3",
-      "amplitude": 0.001157418880191268,
-      "phase": 108.2270206370195
+      "amplitude": 0.001,
+      "phase": 108.23
     },
     {
       "name": "R3",
-      "amplitude": 0.005236265151015057,
-      "phase": 154.80249243343053
+      "amplitude": 0.005,
+      "phase": 154.8
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006258329312260966,
-      "phase": 267.6724761223395
+      "amplitude": 0.006,
+      "phase": 267.67
     },
     {
       "name": "SGM",
-      "amplitude": 0.004807385675607426,
-      "phase": 104.56210727459393
+      "amplitude": 0.005,
+      "phase": 104.56
     },
     {
       "name": "3L2",
-      "amplitude": 0.0033542745255476943,
-      "phase": 353.7083765631073
+      "amplitude": 0.003,
+      "phase": 353.71
     },
     {
       "name": "3N2",
-      "amplitude": 0.015135395141762575,
-      "phase": 217.32219419238712
+      "amplitude": 0.015,
+      "phase": 217.32
     },
     {
       "name": "2SM2",
-      "amplitude": 0.023252913140330532,
-      "phase": 23.897078605451213
+      "amplitude": 0.023,
+      "phase": 23.9
     },
     {
       "name": "2MS6",
-      "amplitude": 0.03930899547959189,
-      "phase": 4.1788922115550236
+      "amplitude": 0.039,
+      "phase": 4.18
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0016812358902895776,
-      "phase": 317.48674332410496
+      "amplitude": 0.002,
+      "phase": 317.49
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0030959633334121496,
-      "phase": 231.1493820744162
+      "amplitude": 0.003,
+      "phase": 231.15
     }
   ],
   "epoch": {

--- a/data/ticon/jadeweserport-9430050-deu-wsv.json
+++ b/data/ticon/jadeweserport-9430050-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.6057269862374257,
-      "phase": 325.7680980613156
+      "amplitude": 1.606,
+      "phase": 325.77
     },
     {
       "name": "N2",
-      "amplitude": 0.24923600312186775,
-      "phase": 300.41958752690357
+      "amplitude": 0.249,
+      "phase": 300.42
     },
     {
       "name": "S2",
-      "amplitude": 0.4257119095996344,
-      "phase": 37.846740805099955
+      "amplitude": 0.426,
+      "phase": 37.85
     },
     {
       "name": "K2",
-      "amplitude": 0.12767558613588956,
-      "phase": 36.26274971603084
+      "amplitude": 0.128,
+      "phase": 36.26
     },
     {
       "name": "2N2",
-      "amplitude": 0.02761155142435349,
-      "phase": 289.4071748582944
+      "amplitude": 0.028,
+      "phase": 289.41
     },
     {
       "name": "S1",
-      "amplitude": 0.013830396992396991,
-      "phase": 32.92830731586179
+      "amplitude": 0.014,
+      "phase": 32.93
     },
     {
       "name": "K1",
-      "amplitude": 0.07062252287117943,
-      "phase": 29.948920651243725
+      "amplitude": 0.071,
+      "phase": 29.95
     },
     {
       "name": "P1",
-      "amplitude": 0.031102324877841547,
-      "phase": 33.9117829379029
+      "amplitude": 0.031,
+      "phase": 33.91
     },
     {
       "name": "O1",
-      "amplitude": 0.09274759599925629,
-      "phase": 239.0801151868894
+      "amplitude": 0.093,
+      "phase": 239.08
     },
     {
       "name": "Q1",
-      "amplitude": 0.03019690803574691,
-      "phase": 183.53665442123926
+      "amplitude": 0.03,
+      "phase": 183.54
     },
     {
       "name": "M1",
-      "amplitude": 0.001566512955999401,
-      "phase": 117.24521790076562
+      "amplitude": 0.002,
+      "phase": 117.25
     },
     {
       "name": "M4",
-      "amplitude": 0.0745741749212439,
-      "phase": 127.99298313897259
+      "amplitude": 0.075,
+      "phase": 127.99
     },
     {
       "name": "MM",
-      "amplitude": 0.014513118116757392,
-      "phase": 119.28612394021081
+      "amplitude": 0.015,
+      "phase": 119.29
     },
     {
       "name": "MF",
-      "amplitude": 0.015434130013833959,
-      "phase": 161.87007508653005
+      "amplitude": 0.015,
+      "phase": 161.87
     },
     {
       "name": "SA",
-      "amplitude": 0.10199554984180328,
-      "phase": 231.03251326251933
+      "amplitude": 0.102,
+      "phase": 231.03
     },
     {
       "name": "SSA",
-      "amplitude": 0.03724629317835044,
-      "phase": 221.7081868196714
+      "amplitude": 0.037,
+      "phase": 221.71
     },
     {
       "name": "T2",
-      "amplitude": 0.021672337230536968,
-      "phase": 10.347644618430252
+      "amplitude": 0.022,
+      "phase": 10.35
     },
     {
       "name": "J1",
-      "amplitude": 0.002134550707718783,
-      "phase": 154.8660475755953
+      "amplitude": 0.002,
+      "phase": 154.87
     },
     {
       "name": "L2",
-      "amplitude": 0.13285488959742633,
-      "phase": 343.020346018613
+      "amplitude": 0.133,
+      "phase": 343.02
     },
     {
       "name": "R2",
-      "amplitude": 0.0017182427114135746,
-      "phase": 27.47081909807548
+      "amplitude": 0.002,
+      "phase": 27.47
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006709515168761052,
-      "phase": 115.98361835809425
+      "amplitude": 0.007,
+      "phase": 115.98
     },
     {
       "name": "MSF",
-      "amplitude": 0.005465626587644552,
-      "phase": 148.8106111273023
+      "amplitude": 0.005,
+      "phase": 148.81
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00765101289119601,
-      "phase": 151.54838969344564
+      "amplitude": 0.008,
+      "phase": 151.55
     },
     {
       "name": "EP2",
-      "amplitude": 0.03661445855146513,
-      "phase": 24.811708829177064
+      "amplitude": 0.037,
+      "phase": 24.81
     },
     {
       "name": "M3",
-      "amplitude": 0.004222391484100884,
-      "phase": 15.445704915158728
+      "amplitude": 0.004,
+      "phase": 15.45
     },
     {
       "name": "MU2",
-      "amplitude": 0.16991041367079723,
-      "phase": 50.222368435416854
+      "amplitude": 0.17,
+      "phase": 50.22
     },
     {
       "name": "MTM",
-      "amplitude": 0.007299730907264274,
-      "phase": 255.38300636188438
+      "amplitude": 0.007,
+      "phase": 255.38
     },
     {
       "name": "NU2",
-      "amplitude": 0.09446835537006373,
-      "phase": 283.73802565491854
+      "amplitude": 0.094,
+      "phase": 283.74
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06179160987295809,
-      "phase": 336.0742564362585
+      "amplitude": 0.062,
+      "phase": 336.07
     },
     {
       "name": "MN4",
-      "amplitude": 0.021307920591063637,
-      "phase": 109.66661061432785
+      "amplitude": 0.021,
+      "phase": 109.67
     },
     {
       "name": "MS4",
-      "amplitude": 0.055530606722953395,
-      "phase": 207.5783603670441
+      "amplitude": 0.056,
+      "phase": 207.58
     },
     {
       "name": "N4",
-      "amplitude": 0.004502552579759908,
-      "phase": 103.88815861875759
+      "amplitude": 0.005,
+      "phase": 103.89
     },
     {
       "name": "M6",
-      "amplitude": 0.04116882386915094,
-      "phase": 310.2840813748168
+      "amplitude": 0.041,
+      "phase": 310.28
     },
     {
       "name": "M8",
-      "amplitude": 0.003395614361030836,
-      "phase": 140.2571712228251
+      "amplitude": 0.003,
+      "phase": 140.26
     },
     {
       "name": "S4",
-      "amplitude": 0.008350465681994974,
-      "phase": 349.8742093455518
+      "amplitude": 0.008,
+      "phase": 349.87
     },
     {
       "name": "OO1",
-      "amplitude": 0.003634441296432294,
-      "phase": 171.6442905688948
+      "amplitude": 0.004,
+      "phase": 171.64
     },
     {
       "name": "S3",
-      "amplitude": 0.0005360819485551792,
-      "phase": 228.0681969699758
+      "amplitude": 0.001,
+      "phase": 228.07
     },
     {
       "name": "MA2",
-      "amplitude": 0.0636452121141931,
-      "phase": 275.6508393675738
+      "amplitude": 0.064,
+      "phase": 275.65
     },
     {
       "name": "MB2",
-      "amplitude": 0.019283624875525616,
-      "phase": 57.90693497632668
+      "amplitude": 0.019,
+      "phase": 57.91
     },
     {
       "name": "T3",
-      "amplitude": 0.0011490238797979553,
-      "phase": 105.4618318438188
+      "amplitude": 0.001,
+      "phase": 105.46
     },
     {
       "name": "R3",
-      "amplitude": 0.004678292649209145,
-      "phase": 48.999135632139314
+      "amplitude": 0.005,
+      "phase": 49
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005857648262164427,
-      "phase": 201.38486210346326
+      "amplitude": 0.006,
+      "phase": 201.38
     },
     {
       "name": "SGM",
-      "amplitude": 0.00294573138760746,
-      "phase": 79.2929922013438
+      "amplitude": 0.003,
+      "phase": 79.29
     },
     {
       "name": "3L2",
-      "amplitude": 0.008824573861214735,
-      "phase": 247.48227499639592
+      "amplitude": 0.009,
+      "phase": 247.48
     },
     {
       "name": "3N2",
-      "amplitude": 0.0202499602856431,
-      "phase": 131.58727665480353
+      "amplitude": 0.02,
+      "phase": 131.59
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04328742561331299,
-      "phase": 255.5528910292191
+      "amplitude": 0.043,
+      "phase": 255.55
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04305388500710808,
-      "phase": 19.43891630498956
+      "amplitude": 0.043,
+      "phase": 19.44
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005522982803119319,
-      "phase": 346.22991539245857
+      "amplitude": 0.006,
+      "phase": 346.23
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0041499316959967445,
-      "phase": 165.52694824325818
+      "amplitude": 0.004,
+      "phase": 165.53
     }
   ],
   "epoch": {

--- a/data/ticon/k13a_platform-k13apfm-nld-rws.json
+++ b/data/ticon/k13a_platform-k13apfm-nld-rws.json
@@ -33,253 +33,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.50981273,
-      "phase": 194.8051
+      "amplitude": 0.527,
+      "phase": 178.37
     },
     {
       "name": "N2",
-      "amplitude": 0.0968476,
-      "phase": 178.15562899999998
+      "amplitude": 0.1,
+      "phase": 162
     },
     {
       "name": "S2",
-      "amplitude": 0.18332004000000002,
-      "phase": 251.26495599999998
+      "amplitude": 0.189,
+      "phase": 234.22
     },
     {
       "name": "K2",
-      "amplitude": 0.050356399999999996,
-      "phase": 253.857846
+      "amplitude": 0.055,
+      "phase": 232.14
     },
     {
       "name": "2N2",
-      "amplitude": 0.0134555,
-      "phase": 159.45496100000003
+      "amplitude": 0.014,
+      "phase": 144.07
     },
     {
       "name": "S1",
-      "amplitude": 0.007215620000000001,
-      "phase": 331.865161
+      "amplitude": 0.011,
+      "phase": 267.83
     },
     {
       "name": "K1",
-      "amplitude": 0.08658757,
-      "phase": 339.490607
+      "amplitude": 0.087,
+      "phase": 330.87
     },
     {
       "name": "P1",
-      "amplitude": 0.02877536,
-      "phase": 324.71539
+      "amplitude": 0.029,
+      "phase": 318.12
     },
     {
       "name": "O1",
-      "amplitude": 0.10072583,
-      "phase": 174.62190799999996
+      "amplitude": 0.101,
+      "phase": 166.92
     },
     {
       "name": "Q1",
-      "amplitude": 0.03450827,
-      "phase": 119.69329900000002
+      "amplitude": 0.034,
+      "phase": 112.04
     },
     {
       "name": "M1",
-      "amplitude": 0.00119772,
-      "phase": 235.284962
+      "amplitude": 0.002,
+      "phase": 359.62
     },
     {
       "name": "M4",
-      "amplitude": 0.0174846,
-      "phase": 190.089148
+      "amplitude": 0.02,
+      "phase": 156.25
     },
     {
       "name": "MM",
-      "amplitude": 0.008807829999999999,
-      "phase": 174.74823800000001
+      "amplitude": 0.009,
+      "phase": 173.8
     },
     {
       "name": "MF",
-      "amplitude": 0.007464070000000001,
-      "phase": 187.844361
+      "amplitude": 0.007,
+      "phase": 186.47
     },
     {
       "name": "SA",
-      "amplitude": 0.08508336,
-      "phase": 224.021284
+      "amplitude": 0.086,
+      "phase": 223.32
     },
     {
       "name": "SSA",
-      "amplitude": 0.0069123100000000005,
-      "phase": 173.38471700000002
+      "amplitude": 0.007,
+      "phase": 166.86
     },
     {
       "name": "T2",
-      "amplitude": 0.03474053,
-      "phase": 167.48668799999996
+      "amplitude": 0.009,
+      "phase": 214.39
     },
     {
       "name": "J1",
-      "amplitude": 0.00420825,
-      "phase": 52.55283300000002
+      "amplitude": 0.004,
+      "phase": 44.28
     },
     {
       "name": "L2",
-      "amplitude": 0.029098899999999997,
-      "phase": 180.020681
+      "amplitude": 0.03,
+      "phase": 163.29
     },
     {
       "name": "R2",
-      "amplitude": 0.026416719999999998,
-      "phase": 352.382422
+      "amplitude": 0.003,
+      "phase": 307.59
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00562164,
-      "phase": 79.409265
+      "amplitude": 0.006,
+      "phase": 73.13
     },
     {
       "name": "MSF",
-      "amplitude": 0.005749300000000001,
-      "phase": 6.000858999999991
+      "amplitude": 0.006,
+      "phase": 3.18
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0034242499999999998,
-      "phase": 133.48453900000004
+      "amplitude": 0.003,
+      "phase": 135.78
     },
     {
       "name": "EP2",
-      "amplitude": 0.00735308,
-      "phase": 221.174801
+      "amplitude": 0.007,
+      "phase": 204.44
     },
     {
       "name": "M3",
-      "amplitude": 0.0049888300000000005,
-      "phase": 274.692277
+      "amplitude": 0.005,
+      "phase": 69.93
     },
     {
       "name": "MU2",
-      "amplitude": 0.03618315,
-      "phase": 229.30501
+      "amplitude": 0.038,
+      "phase": 213.71
     },
     {
       "name": "MTM",
-      "amplitude": 0.00410296,
-      "phase": 205.841674
+      "amplitude": 0.004,
+      "phase": 205.63
     },
     {
       "name": "NU2",
-      "amplitude": 0.01970052,
-      "phase": 153.428176
+      "amplitude": 0.02,
+      "phase": 137.41
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.01501172,
-      "phase": 169.77780400000006
+      "amplitude": 0.015,
+      "phase": 153.72
     },
     {
       "name": "MN4",
-      "amplitude": 0.00447291,
-      "phase": 154.38965899999994
+      "amplitude": 0.005,
+      "phase": 124.66
     },
     {
       "name": "MS4",
-      "amplitude": 0.011150690000000001,
-      "phase": 282.758485
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.02011899,
-      "phase": 315.44782399999997
+      "amplitude": 0.013,
+      "phase": 250.03
     },
     {
       "name": "N4",
-      "amplitude": 0.0004997000000000001,
-      "phase": 122.84141599999998
+      "amplitude": 0.001,
+      "phase": 87.64
     },
     {
       "name": "M6",
-      "amplitude": 0.023981,
-      "phase": 211.318836
+      "amplitude": 0.033,
+      "phase": 158.78
     },
     {
       "name": "M8",
-      "amplitude": 0.00429967,
-      "phase": 164.37815999999998
+      "amplitude": 0.008,
+      "phase": 91.1
     },
     {
       "name": "S4",
-      "amplitude": 0.0019022800000000001,
-      "phase": 87.54045300000001
+      "amplitude": 0.002,
+      "phase": 51.94
     },
     {
       "name": "OO1",
-      "amplitude": 0.0038536300000000002,
-      "phase": 120.34921600000001
+      "amplitude": 0.004,
+      "phase": 112.59
     },
     {
       "name": "S3",
-      "amplitude": 0.00105659,
-      "phase": 240.736726
+      "amplitude": 0,
+      "phase": 96.38
     },
     {
       "name": "MA2",
-      "amplitude": 0.08614198999999999,
-      "phase": 171.13315999999998
+      "amplitude": 0.008,
+      "phase": 99.41
     },
     {
       "name": "MB2",
-      "amplitude": 0.08278729,
-      "phase": 33.122297
+      "amplitude": 0.006,
+      "phase": 78.55
     },
     {
       "name": "T3",
-      "amplitude": 0.00035136,
-      "phase": 178.20430199999998
+      "amplitude": 0,
+      "phase": 28.71
     },
     {
       "name": "R3",
-      "amplitude": 0.0032514700000000002,
-      "phase": 70.87064299999997
+      "amplitude": 0.003,
+      "phase": 132.88
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0066651,
-      "phase": 121.827788
+      "amplitude": 0.007,
+      "phase": 115.36
     },
     {
       "name": "SGM",
-      "amplitude": 0.00231858,
-      "phase": 230.545505
+      "amplitude": 0.002,
+      "phase": 39.6
     },
     {
       "name": "3L2",
-      "amplitude": 0.00278993,
-      "phase": 345.448307
+      "amplitude": 0.003,
+      "phase": 71.36
     },
     {
       "name": "3N2",
-      "amplitude": 0.00186541,
-      "phase": 347.875113
+      "amplitude": 0.004,
+      "phase": 266.87
     },
     {
       "name": "2SM2",
-      "amplitude": 0.01283829,
-      "phase": 68.03550899999999
+      "amplitude": 0.013,
+      "phase": 50.81
     },
     {
       "name": "2MS6",
-      "amplitude": 0.020457999999999997,
-      "phase": 259.379163
+      "amplitude": 0.028,
+      "phase": 206.53
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0040233000000000005,
-      "phase": 124.43566699999997
+      "amplitude": 0.005,
+      "phase": 168.08
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0036205900000000004,
-      "phase": 113.42394100000001
+      "amplitude": 0.004,
+      "phase": 339.98
     }
   ],
   "epoch": {

--- a/data/ticon/kappeln-9610035-deu-wsv.json
+++ b/data/ticon/kappeln-9610035-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.027740614117819615,
-      "phase": 138.6179748394204
+      "amplitude": 0.028,
+      "phase": 138.62
     },
     {
       "name": "N2",
-      "amplitude": 0.007970999702449513,
-      "phase": 86.75645131821744
+      "amplitude": 0.008,
+      "phase": 86.76
     },
     {
       "name": "S2",
-      "amplitude": 0.006774839955161127,
-      "phase": 73.90198890624418
+      "amplitude": 0.007,
+      "phase": 73.9
     },
     {
       "name": "K2",
-      "amplitude": 0.0017055469242272057,
-      "phase": 51.95885322304554
+      "amplitude": 0.002,
+      "phase": 51.96
     },
     {
       "name": "2N2",
-      "amplitude": 0.001247073575796354,
-      "phase": 46.40141140107232
+      "amplitude": 0.001,
+      "phase": 46.4
     },
     {
       "name": "S1",
-      "amplitude": 0.006385975576060412,
-      "phase": 221.52313175419363
+      "amplitude": 0.006,
+      "phase": 221.52
     },
     {
       "name": "K1",
-      "amplitude": 0.015359119378793895,
-      "phase": 236.3156206698613
+      "amplitude": 0.015,
+      "phase": 236.32
     },
     {
       "name": "P1",
-      "amplitude": 0.0065525132465475335,
-      "phase": 263.3135512693194
+      "amplitude": 0.007,
+      "phase": 263.31
     },
     {
       "name": "O1",
-      "amplitude": 0.012443517113548524,
-      "phase": 129.90973308117424
+      "amplitude": 0.012,
+      "phase": 129.91
     },
     {
       "name": "Q1",
-      "amplitude": 0.0039876491877108376,
-      "phase": 331.2471661500227
+      "amplitude": 0.004,
+      "phase": 331.25
     },
     {
       "name": "M1",
-      "amplitude": 0.00032719076594775736,
-      "phase": 89.85301489900996
+      "amplitude": 0,
+      "phase": 89.85
     },
     {
       "name": "M4",
-      "amplitude": 0.0013400502220076555,
-      "phase": 223.4268046882919
+      "amplitude": 0.001,
+      "phase": 223.43
     },
     {
       "name": "MM",
-      "amplitude": 0.012844614923399729,
-      "phase": 311.2714766880106
+      "amplitude": 0.013,
+      "phase": 311.27
     },
     {
       "name": "MF",
-      "amplitude": 0.011658841053401595,
-      "phase": 251.57375265290415
+      "amplitude": 0.012,
+      "phase": 251.57
     },
     {
       "name": "SA",
-      "amplitude": 0.03304523630712991,
-      "phase": 186.24917782847126
+      "amplitude": 0.033,
+      "phase": 186.25
     },
     {
       "name": "SSA",
-      "amplitude": 0.013027256793503696,
-      "phase": 291.94642827474627
+      "amplitude": 0.013,
+      "phase": 291.95
     },
     {
       "name": "T2",
-      "amplitude": 0.0005670247853448579,
-      "phase": 71.30617101702842
+      "amplitude": 0.001,
+      "phase": 71.31
     },
     {
       "name": "J1",
-      "amplitude": 0.001320139821121071,
-      "phase": 172.3408519834776
+      "amplitude": 0.001,
+      "phase": 172.34
     },
     {
       "name": "L2",
-      "amplitude": 0.002728538648984841,
-      "phase": 233.116161644685
+      "amplitude": 0.003,
+      "phase": 233.12
     },
     {
       "name": "R2",
-      "amplitude": 0.0006699352532142858,
-      "phase": 140.6083428037973
+      "amplitude": 0.001,
+      "phase": 140.61
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00111884912145237,
-      "phase": 288.1165994447837
+      "amplitude": 0.001,
+      "phase": 288.12
     },
     {
       "name": "MSF",
-      "amplitude": 0.005516376317543006,
-      "phase": 245.69408883777697
+      "amplitude": 0.006,
+      "phase": 245.69
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003463736271796362,
-      "phase": 230.72342045104543
+      "amplitude": 0.003,
+      "phase": 230.72
     },
     {
       "name": "EP2",
-      "amplitude": 0.0017022242877638115,
-      "phase": 267.3754919219467
+      "amplitude": 0.002,
+      "phase": 267.38
     },
     {
       "name": "M3",
-      "amplitude": 0.0002463780005878637,
-      "phase": 6.6876866925450145
+      "amplitude": 0,
+      "phase": 6.69
     },
     {
       "name": "MU2",
-      "amplitude": 0.0070381500255735675,
-      "phase": 305.23426536170126
+      "amplitude": 0.007,
+      "phase": 305.23
     },
     {
       "name": "MTM",
-      "amplitude": 0.003079084335748842,
-      "phase": 322.1471551728265
+      "amplitude": 0.003,
+      "phase": 322.15
     },
     {
       "name": "NU2",
-      "amplitude": 0.0028294539607412266,
-      "phase": 123.6324221513247
+      "amplitude": 0.003,
+      "phase": 123.63
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.001499337926787113,
-      "phase": 230.6144597991287
+      "amplitude": 0.001,
+      "phase": 230.61
     },
     {
       "name": "MN4",
-      "amplitude": 0.00038088118064148236,
-      "phase": 165.08520886708084
+      "amplitude": 0,
+      "phase": 165.09
     },
     {
       "name": "MS4",
-      "amplitude": 0.00021805563912243362,
-      "phase": 13.481327914857559
+      "amplitude": 0,
+      "phase": 13.48
     },
     {
       "name": "N4",
-      "amplitude": 0.00014178242424802708,
-      "phase": 100.98335762318396
+      "amplitude": 0,
+      "phase": 100.98
     },
     {
       "name": "M6",
-      "amplitude": 0.00014248785590243945,
-      "phase": 241.20717348802344
+      "amplitude": 0,
+      "phase": 241.21
     },
     {
       "name": "M8",
-      "amplitude": 0.000039095370695140705,
-      "phase": 234.72616288814984
+      "amplitude": 0,
+      "phase": 234.73
     },
     {
       "name": "S4",
-      "amplitude": 0.00010393470597804956,
-      "phase": 295.03937817843985
+      "amplitude": 0,
+      "phase": 295.04
     },
     {
       "name": "OO1",
-      "amplitude": 0.0014077634767244314,
-      "phase": 153.3673284574761
+      "amplitude": 0.001,
+      "phase": 153.37
     },
     {
       "name": "S3",
-      "amplitude": 0.0001291649833456513,
-      "phase": 205.2469158613303
+      "amplitude": 0,
+      "phase": 205.25
     },
     {
       "name": "MA2",
-      "amplitude": 0.0038434137888208107,
-      "phase": 127.36288956860494
+      "amplitude": 0.004,
+      "phase": 127.36
     },
     {
       "name": "MB2",
-      "amplitude": 0.004038529835461604,
-      "phase": 291.76086589880146
+      "amplitude": 0.004,
+      "phase": 291.76
     },
     {
       "name": "T3",
-      "amplitude": 0.00009170405563876107,
-      "phase": 184.93721500815644
+      "amplitude": 0,
+      "phase": 184.94
     },
     {
       "name": "R3",
-      "amplitude": 0.00017127641116427926,
-      "phase": 256.2125824766591
+      "amplitude": 0,
+      "phase": 256.21
     },
     {
       "name": "RHO1",
-      "amplitude": 0.000370323045185003,
-      "phase": 330.8917416413806
+      "amplitude": 0,
+      "phase": 330.89
     },
     {
       "name": "SGM",
-      "amplitude": 0.0021167923808112677,
-      "phase": 250.28831143766615
+      "amplitude": 0.002,
+      "phase": 250.29
     },
     {
       "name": "3L2",
-      "amplitude": 0.00034765692448097805,
-      "phase": 353.95683369295085
+      "amplitude": 0,
+      "phase": 353.96
     },
     {
       "name": "3N2",
-      "amplitude": 0.0009446071457442016,
-      "phase": 33.24804094253352
+      "amplitude": 0.001,
+      "phase": 33.25
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0009709388212568133,
-      "phase": 199.9543824235839
+      "amplitude": 0.001,
+      "phase": 199.95
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0000886346147684966,
-      "phase": 86.76085828815508
+      "amplitude": 0,
+      "phase": 86.76
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00020254657787779283,
-      "phase": 247.6223859921843
+      "amplitude": 0,
+      "phase": 247.62
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00014272884160545498,
-      "phase": 194.19010280613608
+      "amplitude": 0,
+      "phase": 194.19
     }
   ],
   "epoch": {

--- a/data/ticon/karlshagen-9690085-deu-wsv.json
+++ b/data/ticon/karlshagen-9690085-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.00795626774308976,
-      "phase": 323.93361855016633
+      "amplitude": 0.008,
+      "phase": 323.93
     },
     {
       "name": "N2",
-      "amplitude": 0.002408644113110924,
-      "phase": 281.2426616408318
+      "amplitude": 0.002,
+      "phase": 281.24
     },
     {
       "name": "S2",
-      "amplitude": 0.0017274580637179787,
-      "phase": 294.1260491994103
+      "amplitude": 0.002,
+      "phase": 294.13
     },
     {
       "name": "K2",
-      "amplitude": 0.0008856501028198452,
-      "phase": 268.1893433741195
+      "amplitude": 0.001,
+      "phase": 268.19
     },
     {
       "name": "2N2",
-      "amplitude": 0.0004213997399584175,
-      "phase": 291.3358559978076
+      "amplitude": 0,
+      "phase": 291.34
     },
     {
       "name": "S1",
-      "amplitude": 0.004524641147905823,
-      "phase": 44.658008683945184
+      "amplitude": 0.005,
+      "phase": 44.66
     },
     {
       "name": "K1",
-      "amplitude": 0.004977479528581132,
-      "phase": 173.55529334587663
+      "amplitude": 0.005,
+      "phase": 173.56
     },
     {
       "name": "P1",
-      "amplitude": 0.0007555141631218243,
-      "phase": 150.32702082246385
+      "amplitude": 0.001,
+      "phase": 150.33
     },
     {
       "name": "O1",
-      "amplitude": 0.00867026897645579,
-      "phase": 165.31397557560842
+      "amplitude": 0.009,
+      "phase": 165.31
     },
     {
       "name": "Q1",
-      "amplitude": 0.0012281895386046062,
-      "phase": 124.77145354708648
+      "amplitude": 0.001,
+      "phase": 124.77
     },
     {
       "name": "M1",
-      "amplitude": 0.0004079623892276267,
-      "phase": 66.69028989237819
+      "amplitude": 0,
+      "phase": 66.69
     },
     {
       "name": "M4",
-      "amplitude": 0.00047139937766527536,
-      "phase": 11.38054003278313
+      "amplitude": 0,
+      "phase": 11.38
     },
     {
       "name": "MM",
-      "amplitude": 0.011113278149307425,
-      "phase": 282.54467527248653
+      "amplitude": 0.011,
+      "phase": 282.54
     },
     {
       "name": "MF",
-      "amplitude": 0.007700204168825692,
-      "phase": 279.82085075578266
+      "amplitude": 0.008,
+      "phase": 279.82
     },
     {
       "name": "SA",
-      "amplitude": 0.03622301273475699,
-      "phase": 199.31162886441263
+      "amplitude": 0.036,
+      "phase": 199.31
     },
     {
       "name": "SSA",
-      "amplitude": 0.03441183447256344,
-      "phase": 247.61346356465208
+      "amplitude": 0.034,
+      "phase": 247.61
     },
     {
       "name": "T2",
-      "amplitude": 0.0005816636465357678,
-      "phase": 261.65367003782666
+      "amplitude": 0.001,
+      "phase": 261.65
     },
     {
       "name": "J1",
-      "amplitude": 0.0004443716806241672,
-      "phase": 228.1620920084565
+      "amplitude": 0,
+      "phase": 228.16
     },
     {
       "name": "L2",
-      "amplitude": 0.0007472908522639257,
-      "phase": 79.65760435938114
+      "amplitude": 0.001,
+      "phase": 79.66
     },
     {
       "name": "R2",
-      "amplitude": 0.0004954084577748181,
-      "phase": 80.7978390008634
+      "amplitude": 0,
+      "phase": 80.8
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00005691050799316545,
-      "phase": 349.1895992361958
+      "amplitude": 0,
+      "phase": 349.19
     },
     {
       "name": "MSF",
-      "amplitude": 0.0012144958439640695,
-      "phase": 267.98521267312964
+      "amplitude": 0.001,
+      "phase": 267.99
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003132281346849775,
-      "phase": 199.8086630211271
+      "amplitude": 0.003,
+      "phase": 199.81
     },
     {
       "name": "EP2",
-      "amplitude": 0.0003862750600347937,
-      "phase": 86.94777266290617
+      "amplitude": 0,
+      "phase": 86.95
     },
     {
       "name": "M3",
-      "amplitude": 0.0003552893152192498,
-      "phase": 318.72499576194514
+      "amplitude": 0,
+      "phase": 318.72
     },
     {
       "name": "MU2",
-      "amplitude": 0.0014575561187367635,
-      "phase": 150.84897207649044
+      "amplitude": 0.001,
+      "phase": 150.85
     },
     {
       "name": "MTM",
-      "amplitude": 0.0033174681062423488,
-      "phase": 355.82223528625286
+      "amplitude": 0.003,
+      "phase": 355.82
     },
     {
       "name": "NU2",
-      "amplitude": 0.0006871547068718429,
-      "phase": 331.43447786068367
+      "amplitude": 0.001,
+      "phase": 331.43
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0004413573780337391,
-      "phase": 62.76553882388379
+      "amplitude": 0,
+      "phase": 62.77
     },
     {
       "name": "MN4",
-      "amplitude": 0.00017684706847184294,
-      "phase": 297.26002386942776
+      "amplitude": 0,
+      "phase": 297.26
     },
     {
       "name": "MS4",
-      "amplitude": 0.00021887776377457093,
-      "phase": 181.36069413716564
+      "amplitude": 0,
+      "phase": 181.36
     },
     {
       "name": "N4",
-      "amplitude": 0.0000639238536060369,
-      "phase": 166.66996253576326
+      "amplitude": 0,
+      "phase": 166.67
     },
     {
       "name": "M6",
-      "amplitude": 0.000009182271034284032,
-      "phase": 358.96373712481216
+      "amplitude": 0,
+      "phase": 358.96
     },
     {
       "name": "M8",
-      "amplitude": 0.000056693403599427764,
-      "phase": 318.98928471342856
+      "amplitude": 0,
+      "phase": 318.99
     },
     {
       "name": "S4",
-      "amplitude": 0.000007986648773728041,
-      "phase": 260.42305950029765
+      "amplitude": 0,
+      "phase": 260.42
     },
     {
       "name": "OO1",
-      "amplitude": 0.000121319572188421,
-      "phase": 126.99696642304531
+      "amplitude": 0,
+      "phase": 127
     },
     {
       "name": "S3",
-      "amplitude": 0.0003898129022002852,
-      "phase": 8.167391939223023
+      "amplitude": 0,
+      "phase": 8.17
     },
     {
       "name": "MA2",
-      "amplitude": 0.0011778056775355087,
-      "phase": 340.6043907739699
+      "amplitude": 0.001,
+      "phase": 340.6
     },
     {
       "name": "MB2",
-      "amplitude": 0.00047421449797907777,
-      "phase": 129.48239372160174
+      "amplitude": 0,
+      "phase": 129.48
     },
     {
       "name": "T3",
-      "amplitude": 0.0002457035323462401,
-      "phase": 266.01616327084537
+      "amplitude": 0,
+      "phase": 266.02
     },
     {
       "name": "R3",
-      "amplitude": 0.00020296355094827814,
-      "phase": 14.80348198790847
+      "amplitude": 0,
+      "phase": 14.8
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00002897511742423875,
-      "phase": 108.47276116143064
+      "amplitude": 0,
+      "phase": 108.47
     },
     {
       "name": "SGM",
-      "amplitude": 0.000654857642050081,
-      "phase": 241.6903526874855
+      "amplitude": 0.001,
+      "phase": 241.69
     },
     {
       "name": "3L2",
-      "amplitude": 0.00010300981874353228,
-      "phase": 233.3818002280342
+      "amplitude": 0,
+      "phase": 233.38
     },
     {
       "name": "3N2",
-      "amplitude": 0.00031956915540224144,
-      "phase": 239.67790834082615
+      "amplitude": 0,
+      "phase": 239.68
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00037183514840559835,
-      "phase": 50.601319271709826
+      "amplitude": 0,
+      "phase": 50.6
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000047819118973676225,
-      "phase": 166.58472211289086
+      "amplitude": 0,
+      "phase": 166.58
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000017941523473037422,
-      "phase": 48.68882462615181
+      "amplitude": 0,
+      "phase": 48.69
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0000487761748158317,
-      "phase": 13.603978501953804
+      "amplitude": 0,
+      "phase": 13.6
     }
   ],
   "epoch": {

--- a/data/ticon/karnin-9690084-deu-wsv.json
+++ b/data/ticon/karnin-9690084-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.0028552101319466966,
-      "phase": 91.16114014428956
+      "amplitude": 0.003,
+      "phase": 91.16
     },
     {
       "name": "N2",
-      "amplitude": 0.0006274656730095888,
-      "phase": 59.4397315328485
+      "amplitude": 0.001,
+      "phase": 59.44
     },
     {
       "name": "S2",
-      "amplitude": 0.0017264646399001108,
-      "phase": 169.28771809048544
+      "amplitude": 0.002,
+      "phase": 169.29
     },
     {
       "name": "K2",
-      "amplitude": 0.00010255386441561062,
-      "phase": 173.93408384879524
+      "amplitude": 0,
+      "phase": 173.93
     },
     {
       "name": "2N2",
-      "amplitude": 0.00030667733279638365,
-      "phase": 3.7915307907913416
+      "amplitude": 0,
+      "phase": 3.79
     },
     {
       "name": "S1",
-      "amplitude": 0.005698871337556811,
-      "phase": 140.31496498343
+      "amplitude": 0.006,
+      "phase": 140.31
     },
     {
       "name": "K1",
-      "amplitude": 0.0012678870827371896,
-      "phase": 185.970735501495
+      "amplitude": 0.001,
+      "phase": 185.97
     },
     {
       "name": "P1",
-      "amplitude": 0.0019035472939155263,
-      "phase": 126.9739017494062
+      "amplitude": 0.002,
+      "phase": 126.97
     },
     {
       "name": "O1",
-      "amplitude": 0.003095303587854055,
-      "phase": 238.22239327288494
+      "amplitude": 0.003,
+      "phase": 238.22
     },
     {
       "name": "Q1",
-      "amplitude": 0.0008512057247670563,
-      "phase": 196.8468327660193
+      "amplitude": 0.001,
+      "phase": 196.85
     },
     {
       "name": "M1",
-      "amplitude": 0.00019984221023906052,
-      "phase": 180.15846722938662
+      "amplitude": 0,
+      "phase": 180.16
     },
     {
       "name": "M4",
-      "amplitude": 0.0001227020810239755,
-      "phase": 141.97503232287897
+      "amplitude": 0,
+      "phase": 141.98
     },
     {
       "name": "MM",
-      "amplitude": 0.011251598196040002,
-      "phase": 294.5811945695667
+      "amplitude": 0.011,
+      "phase": 294.58
     },
     {
       "name": "MF",
-      "amplitude": 0.007644242867026796,
-      "phase": 290.16872770746426
+      "amplitude": 0.008,
+      "phase": 290.17
     },
     {
       "name": "SA",
-      "amplitude": 0.024747256702406326,
-      "phase": 216.54015662952574
+      "amplitude": 0.025,
+      "phase": 216.54
     },
     {
       "name": "SSA",
-      "amplitude": 0.03329769279769685,
-      "phase": 258.21409454165536
+      "amplitude": 0.033,
+      "phase": 258.21
     },
     {
       "name": "T2",
-      "amplitude": 0.00014077482863774558,
-      "phase": 217.19870456607907
+      "amplitude": 0,
+      "phase": 217.2
     },
     {
       "name": "J1",
-      "amplitude": 0.00018297742505212402,
-      "phase": 162.7071345022747
+      "amplitude": 0,
+      "phase": 162.71
     },
     {
       "name": "L2",
-      "amplitude": 0.00016307104248123756,
-      "phase": 165.34606123365825
+      "amplitude": 0,
+      "phase": 165.35
     },
     {
       "name": "R2",
-      "amplitude": 0.00010939311831190765,
-      "phase": 66.74183874681444
+      "amplitude": 0,
+      "phase": 66.74
     },
     {
       "name": "2Q1",
-      "amplitude": 0.000016277757254161757,
-      "phase": 106.0289526024302
+      "amplitude": 0,
+      "phase": 106.03
     },
     {
       "name": "MSF",
-      "amplitude": 0.0010898197910900616,
-      "phase": 303.9161053652383
+      "amplitude": 0.001,
+      "phase": 303.92
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0036740729166909215,
-      "phase": 221.4747054423468
+      "amplitude": 0.004,
+      "phase": 221.47
     },
     {
       "name": "EP2",
-      "amplitude": 0.00018016468707333352,
-      "phase": 206.7164762530386
+      "amplitude": 0,
+      "phase": 206.72
     },
     {
       "name": "M3",
-      "amplitude": 0.0001190935329742167,
-      "phase": 114.81405668138046
+      "amplitude": 0,
+      "phase": 114.81
     },
     {
       "name": "MU2",
-      "amplitude": 0.0002745034562557472,
-      "phase": 270.4435681236488
+      "amplitude": 0,
+      "phase": 270.44
     },
     {
       "name": "MTM",
-      "amplitude": 0.0038306533464495416,
-      "phase": 26.62023329372505
+      "amplitude": 0.004,
+      "phase": 26.62
     },
     {
       "name": "NU2",
-      "amplitude": 0.00032412644286507674,
-      "phase": 128.5579305968987
+      "amplitude": 0,
+      "phase": 128.56
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00020422069262536995,
-      "phase": 205.74542241953694
+      "amplitude": 0,
+      "phase": 205.75
     },
     {
       "name": "MN4",
-      "amplitude": 0.00015597535845805554,
-      "phase": 32.92156994198717
+      "amplitude": 0,
+      "phase": 32.92
     },
     {
       "name": "MS4",
-      "amplitude": 0.00011768215734486477,
-      "phase": 62.00583157568906
+      "amplitude": 0,
+      "phase": 62.01
     },
     {
       "name": "N4",
-      "amplitude": 0.00008656898619831067,
-      "phase": 340.42892712642765
+      "amplitude": 0,
+      "phase": 340.43
     },
     {
       "name": "M6",
-      "amplitude": 0.00003357209565520111,
-      "phase": 157.75511593592182
+      "amplitude": 0,
+      "phase": 157.76
     },
     {
       "name": "M8",
-      "amplitude": 0.000059266733157980443,
-      "phase": 148.67902133304995
+      "amplitude": 0,
+      "phase": 148.68
     },
     {
       "name": "S4",
-      "amplitude": 0.00004694987587563361,
-      "phase": 252.3192135140244
+      "amplitude": 0,
+      "phase": 252.32
     },
     {
       "name": "OO1",
-      "amplitude": 0.0002759389010950045,
-      "phase": 89.71493491631134
+      "amplitude": 0,
+      "phase": 89.71
     },
     {
       "name": "S3",
-      "amplitude": 0.00029298360579344364,
-      "phase": 27.626064343813994
+      "amplitude": 0,
+      "phase": 27.63
     },
     {
       "name": "MA2",
-      "amplitude": 0.00038779155412736873,
-      "phase": 24.821560669008136
+      "amplitude": 0,
+      "phase": 24.82
     },
     {
       "name": "MB2",
-      "amplitude": 0.00043769053230885646,
-      "phase": 218.546350173516
+      "amplitude": 0,
+      "phase": 218.55
     },
     {
       "name": "T3",
-      "amplitude": 0.00042731766624509385,
-      "phase": 275.99279380306416
+      "amplitude": 0,
+      "phase": 275.99
     },
     {
       "name": "R3",
-      "amplitude": 0.0003961346959737618,
-      "phase": 30.483917114373753
+      "amplitude": 0,
+      "phase": 30.48
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0002505359751681629,
-      "phase": 275.8453980956891
+      "amplitude": 0,
+      "phase": 275.85
     },
     {
       "name": "SGM",
-      "amplitude": 0.00006291160989537251,
-      "phase": 223.1484408524886
+      "amplitude": 0,
+      "phase": 223.15
     },
     {
       "name": "3L2",
-      "amplitude": 0.0002171237410818788,
-      "phase": 250.50499210662656
+      "amplitude": 0,
+      "phase": 250.5
     },
     {
       "name": "3N2",
-      "amplitude": 0.00009666361341465362,
-      "phase": 90.98618550596422
+      "amplitude": 0,
+      "phase": 90.99
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0001126651726470917,
-      "phase": 166.46712637437702
+      "amplitude": 0,
+      "phase": 166.47
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000043681787696110565,
-      "phase": 56.484127625140616
+      "amplitude": 0,
+      "phase": 56.48
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00007513238925570567,
-      "phase": 166.47305547997894
+      "amplitude": 0,
+      "phase": 166.47
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00005486584661258221,
-      "phase": 311.17012952747456
+      "amplitude": 0,
+      "phase": 311.17
     }
   ],
   "epoch": {

--- a/data/ticon/kielholtenau-9610066-deu-wsv.json
+++ b/data/ticon/kielholtenau-9610066-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.0454847588467194,
-      "phase": 113.73555349642925
+      "amplitude": 0.045,
+      "phase": 113.74
     },
     {
       "name": "N2",
-      "amplitude": 0.013255051316978104,
-      "phase": 60.95018784625887
+      "amplitude": 0.013,
+      "phase": 60.95
     },
     {
       "name": "S2",
-      "amplitude": 0.011924363694564385,
-      "phase": 53.001925694858755
+      "amplitude": 0.012,
+      "phase": 53
     },
     {
       "name": "K2",
-      "amplitude": 0.0029618829155386894,
-      "phase": 30.30538920276291
+      "amplitude": 0.003,
+      "phase": 30.31
     },
     {
       "name": "2N2",
-      "amplitude": 0.0019041931327238618,
-      "phase": 29.93744623300904
+      "amplitude": 0.002,
+      "phase": 29.94
     },
     {
       "name": "S1",
-      "amplitude": 0.006794196452189942,
-      "phase": 180.74313788528684
+      "amplitude": 0.007,
+      "phase": 180.74
     },
     {
       "name": "K1",
-      "amplitude": 0.019758635332937615,
-      "phase": 212.83854481190977
+      "amplitude": 0.02,
+      "phase": 212.84
     },
     {
       "name": "P1",
-      "amplitude": 0.007373515732208129,
-      "phase": 247.8207814089617
+      "amplitude": 0.007,
+      "phase": 247.82
     },
     {
       "name": "O1",
-      "amplitude": 0.01680248221231508,
-      "phase": 106.81937768803391
+      "amplitude": 0.017,
+      "phase": 106.82
     },
     {
       "name": "Q1",
-      "amplitude": 0.005119397811982919,
-      "phase": 310.95867641230575
+      "amplitude": 0.005,
+      "phase": 310.96
     },
     {
       "name": "M1",
-      "amplitude": 0.00012393416517695154,
-      "phase": 153.7770469192186
+      "amplitude": 0,
+      "phase": 153.78
     },
     {
       "name": "M4",
-      "amplitude": 0.00225910870124573,
-      "phase": 201.27017833038707
+      "amplitude": 0.002,
+      "phase": 201.27
     },
     {
       "name": "MM",
-      "amplitude": 0.011388211064649045,
-      "phase": 293.8585105970093
+      "amplitude": 0.011,
+      "phase": 293.86
     },
     {
       "name": "MF",
-      "amplitude": 0.01049904474981921,
-      "phase": 249.9316990089137
+      "amplitude": 0.01,
+      "phase": 249.93
     },
     {
       "name": "SA",
-      "amplitude": 0.03420431988182299,
-      "phase": 176.95828897757087
+      "amplitude": 0.034,
+      "phase": 176.96
     },
     {
       "name": "SSA",
-      "amplitude": 0.014208634900542479,
-      "phase": 276.7705451413623
+      "amplitude": 0.014,
+      "phase": 276.77
     },
     {
       "name": "T2",
-      "amplitude": 0.001027253559434329,
-      "phase": 62.44548917719004
+      "amplitude": 0.001,
+      "phase": 62.45
     },
     {
       "name": "J1",
-      "amplitude": 0.0010284817099504822,
-      "phase": 142.96347119396273
+      "amplitude": 0.001,
+      "phase": 142.96
     },
     {
       "name": "L2",
-      "amplitude": 0.0046176264054221565,
-      "phase": 213.65173558201604
+      "amplitude": 0.005,
+      "phase": 213.65
     },
     {
       "name": "R2",
-      "amplitude": 0.0009150267368446766,
-      "phase": 137.44594715796302
+      "amplitude": 0.001,
+      "phase": 137.45
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0015073646700119877,
-      "phase": 276.2564518494903
+      "amplitude": 0.002,
+      "phase": 276.26
     },
     {
       "name": "MSF",
-      "amplitude": 0.0030912313892740156,
-      "phase": 233.69691777213683
+      "amplitude": 0.003,
+      "phase": 233.7
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004473075475193346,
-      "phase": 215.78604136511268
+      "amplitude": 0.004,
+      "phase": 215.79
     },
     {
       "name": "EP2",
-      "amplitude": 0.0027377581283872174,
-      "phase": 240.92902804269943
+      "amplitude": 0.003,
+      "phase": 240.93
     },
     {
       "name": "M3",
-      "amplitude": 0.0006222213269729102,
-      "phase": 327.4168995309451
+      "amplitude": 0.001,
+      "phase": 327.42
     },
     {
       "name": "MU2",
-      "amplitude": 0.01143384555134708,
-      "phase": 281.731020918817
+      "amplitude": 0.011,
+      "phase": 281.73
     },
     {
       "name": "MTM",
-      "amplitude": 0.003575592054257484,
-      "phase": 344.23949659131716
+      "amplitude": 0.004,
+      "phase": 344.24
     },
     {
       "name": "NU2",
-      "amplitude": 0.0048087088626472185,
-      "phase": 98.64896724955128
+      "amplitude": 0.005,
+      "phase": 98.65
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0024863397273979294,
-      "phase": 204.33485688650913
+      "amplitude": 0.002,
+      "phase": 204.33
     },
     {
       "name": "MN4",
-      "amplitude": 0.0006280267726604115,
-      "phase": 143.6834365264641
+      "amplitude": 0.001,
+      "phase": 143.68
     },
     {
       "name": "MS4",
-      "amplitude": 0.0004249280508625478,
-      "phase": 345.84857449333447
+      "amplitude": 0,
+      "phase": 345.85
     },
     {
       "name": "N4",
-      "amplitude": 0.00015094445225959387,
-      "phase": 125.29308196433647
+      "amplitude": 0,
+      "phase": 125.29
     },
     {
       "name": "M6",
-      "amplitude": 0.0004311096017459446,
-      "phase": 298.91788890435015
+      "amplitude": 0,
+      "phase": 298.92
     },
     {
       "name": "M8",
-      "amplitude": 0.00009071416181315177,
-      "phase": 352.0285804705775
+      "amplitude": 0,
+      "phase": 352.03
     },
     {
       "name": "S4",
-      "amplitude": 0.00029353581379461437,
-      "phase": 268.4691231532255
+      "amplitude": 0,
+      "phase": 268.47
     },
     {
       "name": "OO1",
-      "amplitude": 0.0016897968699981928,
-      "phase": 128.59133641829476
+      "amplitude": 0.002,
+      "phase": 128.59
     },
     {
       "name": "S3",
-      "amplitude": 0.00018398219679237966,
-      "phase": 215.06823552715676
+      "amplitude": 0,
+      "phase": 215.07
     },
     {
       "name": "MA2",
-      "amplitude": 0.006380048701333438,
-      "phase": 103.17029730526883
+      "amplitude": 0.006,
+      "phase": 103.17
     },
     {
       "name": "MB2",
-      "amplitude": 0.006889698762568606,
-      "phase": 264.32153515441814
+      "amplitude": 0.007,
+      "phase": 264.32
     },
     {
       "name": "T3",
-      "amplitude": 0.0003066280724963209,
-      "phase": 170.1838651332714
+      "amplitude": 0,
+      "phase": 170.18
     },
     {
       "name": "R3",
-      "amplitude": 0.00031044594055594797,
-      "phase": 257.4824573386642
+      "amplitude": 0,
+      "phase": 257.48
     },
     {
       "name": "RHO1",
-      "amplitude": 0.000949932976349808,
-      "phase": 278.4592142468309
+      "amplitude": 0.001,
+      "phase": 278.46
     },
     {
       "name": "SGM",
-      "amplitude": 0.0030363796198307176,
-      "phase": 217.37023661753236
+      "amplitude": 0.003,
+      "phase": 217.37
     },
     {
       "name": "3L2",
-      "amplitude": 0.0005447519616715111,
-      "phase": 2.308941924939859
+      "amplitude": 0.001,
+      "phase": 2.31
     },
     {
       "name": "3N2",
-      "amplitude": 0.0015209367736378474,
-      "phase": 19.319164850934385
+      "amplitude": 0.002,
+      "phase": 19.32
     },
     {
       "name": "2SM2",
-      "amplitude": 0.001644622571828134,
-      "phase": 169.4950942285384
+      "amplitude": 0.002,
+      "phase": 169.5
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0004742360570704509,
-      "phase": 10.927859825240091
+      "amplitude": 0,
+      "phase": 10.93
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00018348077924984317,
-      "phase": 135.9569876317654
+      "amplitude": 0,
+      "phase": 135.96
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00015102043862774895,
-      "phase": 244.5304539210473
+      "amplitude": 0,
+      "phase": 244.53
     }
   ],
   "epoch": {

--- a/data/ticon/kloster-9670050-deu-wsv.json
+++ b/data/ticon/kloster-9670050-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.007697577267755407,
-      "phase": 254.55999885057642
+      "amplitude": 0.008,
+      "phase": 254.56
     },
     {
       "name": "N2",
-      "amplitude": 0.0014591748189372597,
-      "phase": 222.06839323747954
+      "amplitude": 0.001,
+      "phase": 222.07
     },
     {
       "name": "S2",
-      "amplitude": 0.003792536624650618,
-      "phase": 257.0288108552514
+      "amplitude": 0.004,
+      "phase": 257.03
     },
     {
       "name": "K2",
-      "amplitude": 0.000579421070472052,
-      "phase": 242.89519847739953
+      "amplitude": 0.001,
+      "phase": 242.9
     },
     {
       "name": "2N2",
-      "amplitude": 0.0001286911364402258,
-      "phase": 234.6823265567972
+      "amplitude": 0,
+      "phase": 234.68
     },
     {
       "name": "S1",
-      "amplitude": 0.0009321273573593965,
-      "phase": 48.84250371980397
+      "amplitude": 0.001,
+      "phase": 48.84
     },
     {
       "name": "K1",
-      "amplitude": 0.007464822623218118,
-      "phase": 192.99339682101206
+      "amplitude": 0.007,
+      "phase": 192.99
     },
     {
       "name": "P1",
-      "amplitude": 0.0023793892393873125,
-      "phase": 206.70468095538294
+      "amplitude": 0.002,
+      "phase": 206.7
     },
     {
       "name": "O1",
-      "amplitude": 0.011259151606392293,
-      "phase": 168.3425802527762
+      "amplitude": 0.011,
+      "phase": 168.34
     },
     {
       "name": "Q1",
-      "amplitude": 0.0012472910919149927,
-      "phase": 114.01961977918859
+      "amplitude": 0.001,
+      "phase": 114.02
     },
     {
       "name": "M1",
-      "amplitude": 0.00041969321175361633,
-      "phase": 77.07831464459292
+      "amplitude": 0,
+      "phase": 77.08
     },
     {
       "name": "M4",
-      "amplitude": 0.0003999772513672969,
-      "phase": 224.78305947981724
+      "amplitude": 0,
+      "phase": 224.78
     },
     {
       "name": "MM",
-      "amplitude": 0.010529216736324428,
-      "phase": 279.0361471491486
+      "amplitude": 0.011,
+      "phase": 279.04
     },
     {
       "name": "MF",
-      "amplitude": 0.008175805929625092,
-      "phase": 267.5812173133644
+      "amplitude": 0.008,
+      "phase": 267.58
     },
     {
       "name": "SA",
-      "amplitude": 0.04576399259372647,
-      "phase": 208.91183922394234
+      "amplitude": 0.046,
+      "phase": 208.91
     },
     {
       "name": "SSA",
-      "amplitude": 0.0325456744924201,
-      "phase": 243.30560832963621
+      "amplitude": 0.033,
+      "phase": 243.31
     },
     {
       "name": "T2",
-      "amplitude": 0.0002464547874877915,
-      "phase": 337.1775441535708
+      "amplitude": 0,
+      "phase": 337.18
     },
     {
       "name": "J1",
-      "amplitude": 0.000562426726065844,
-      "phase": 205.98677625291882
+      "amplitude": 0.001,
+      "phase": 205.99
     },
     {
       "name": "L2",
-      "amplitude": 0.0004609197923325692,
-      "phase": 4.779476501563295
+      "amplitude": 0,
+      "phase": 4.78
     },
     {
       "name": "R2",
-      "amplitude": 0.00011958261088509447,
-      "phase": 240.5795350873358
+      "amplitude": 0,
+      "phase": 240.58
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00006645674085937727,
-      "phase": 202.2401437477553
+      "amplitude": 0,
+      "phase": 202.24
     },
     {
       "name": "MSF",
-      "amplitude": 0.0016118659300473155,
-      "phase": 268.4531489579498
+      "amplitude": 0.002,
+      "phase": 268.45
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0035220549008869264,
-      "phase": 212.8063737666277
+      "amplitude": 0.004,
+      "phase": 212.81
     },
     {
       "name": "EP2",
-      "amplitude": 0.0001907563501009667,
-      "phase": 12.242906991307393
+      "amplitude": 0,
+      "phase": 12.24
     },
     {
       "name": "M3",
-      "amplitude": 0.00022999847767127065,
-      "phase": 199.53106862288186
+      "amplitude": 0,
+      "phase": 199.53
     },
     {
       "name": "MU2",
-      "amplitude": 0.0005277151118542627,
-      "phase": 70.99712279466007
+      "amplitude": 0.001,
+      "phase": 71
     },
     {
       "name": "MTM",
-      "amplitude": 0.002823374338995369,
-      "phase": 335.94520108170485
+      "amplitude": 0.003,
+      "phase": 335.95
     },
     {
       "name": "NU2",
-      "amplitude": 0.0006715865057635855,
-      "phase": 258.0851203480672
+      "amplitude": 0.001,
+      "phase": 258.09
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00028442409184059397,
-      "phase": 351.80083795266904
+      "amplitude": 0,
+      "phase": 351.8
     },
     {
       "name": "MN4",
-      "amplitude": 0.0001634055186847697,
-      "phase": 158.98208600704731
+      "amplitude": 0,
+      "phase": 158.98
     },
     {
       "name": "MS4",
-      "amplitude": 0.00014718232197665336,
-      "phase": 32.40242835404075
+      "amplitude": 0,
+      "phase": 32.4
     },
     {
       "name": "N4",
-      "amplitude": 0.00003015271814563679,
-      "phase": 47.71271516650404
+      "amplitude": 0,
+      "phase": 47.71
     },
     {
       "name": "M6",
-      "amplitude": 0.00003201637307854958,
-      "phase": 313.6274766958078
+      "amplitude": 0,
+      "phase": 313.63
     },
     {
       "name": "M8",
-      "amplitude": 0.000033146488191040427,
-      "phase": 160.4244334010964
+      "amplitude": 0,
+      "phase": 160.42
     },
     {
       "name": "S4",
-      "amplitude": 0.00004455099649720969,
-      "phase": 170.8543976025694
+      "amplitude": 0,
+      "phase": 170.85
     },
     {
       "name": "OO1",
-      "amplitude": 0.000450030078573122,
-      "phase": 158.56666390737087
+      "amplitude": 0,
+      "phase": 158.57
     },
     {
       "name": "S3",
-      "amplitude": 0.000020066596931267204,
-      "phase": 348.52768920834785
+      "amplitude": 0,
+      "phase": 348.53
     },
     {
       "name": "MA2",
-      "amplitude": 0.0004856329687059546,
-      "phase": 197.31088720512292
+      "amplitude": 0,
+      "phase": 197.31
     },
     {
       "name": "MB2",
-      "amplitude": 0.0010369700070801263,
-      "phase": 52.88123737383739
+      "amplitude": 0.001,
+      "phase": 52.88
     },
     {
       "name": "T3",
-      "amplitude": 0.00016535188708648453,
-      "phase": 157.0261165873443
+      "amplitude": 0,
+      "phase": 157.03
     },
     {
       "name": "R3",
-      "amplitude": 0.0001975425046731671,
-      "phase": 268.54933651104915
+      "amplitude": 0,
+      "phase": 268.55
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00019930549828331252,
-      "phase": 143.89771409583824
+      "amplitude": 0,
+      "phase": 143.9
     },
     {
       "name": "SGM",
-      "amplitude": 0.0009862328612235964,
-      "phase": 263.3900219252955
+      "amplitude": 0.001,
+      "phase": 263.39
     },
     {
       "name": "3L2",
-      "amplitude": 0.00008489822454609999,
-      "phase": 184.6134675305549
+      "amplitude": 0,
+      "phase": 184.61
     },
     {
       "name": "3N2",
-      "amplitude": 0.00021632810025768926,
-      "phase": 132.76466587437744
+      "amplitude": 0,
+      "phase": 132.76
     },
     {
       "name": "2SM2",
-      "amplitude": 0.000290186815382525,
-      "phase": 0.8535478384717976
+      "amplitude": 0,
+      "phase": 0.85
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00001600742909966412,
-      "phase": 130.9923368208058
+      "amplitude": 0,
+      "phase": 130.99
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00004808498421077474,
-      "phase": 34.80661514125933
+      "amplitude": 0,
+      "phase": 34.81
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00007190421677961643,
-      "phase": 108.70603968921029
+      "amplitude": 0,
+      "phase": 108.71
     }
   ],
   "epoch": {

--- a/data/ticon/knock-3990010-deu-wsv.json
+++ b/data/ticon/knock-3990010-deu-wsv.json
@@ -1,6 +1,6 @@
 {
   "name": "Knock",
-  "region": "Groningen",
+  "region": "Lower Saxony",
   "country": "Germany",
   "continent": "Europe",
   "latitude": 53.328705,
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3520652446212105,
-      "phase": 303.87709951848905
+      "amplitude": 1.352,
+      "phase": 303.88
     },
     {
       "name": "N2",
-      "amplitude": 0.21449185711739843,
-      "phase": 280.4435067198644
+      "amplitude": 0.214,
+      "phase": 280.44
     },
     {
       "name": "S2",
-      "amplitude": 0.33662460667485344,
-      "phase": 14.970076865161843
+      "amplitude": 0.337,
+      "phase": 14.97
     },
     {
       "name": "K2",
-      "amplitude": 0.10215041648470424,
-      "phase": 11.76906482417246
+      "amplitude": 0.102,
+      "phase": 11.77
     },
     {
       "name": "2N2",
-      "amplitude": 0.02389965930674784,
-      "phase": 260.5469899453775
+      "amplitude": 0.024,
+      "phase": 260.55
     },
     {
       "name": "S1",
-      "amplitude": 0.012834452425982815,
-      "phase": 35.12474420671424
+      "amplitude": 0.013,
+      "phase": 35.12
     },
     {
       "name": "K1",
-      "amplitude": 0.07388740694504567,
-      "phase": 25.458278691969838
+      "amplitude": 0.074,
+      "phase": 25.46
     },
     {
       "name": "P1",
-      "amplitude": 0.03024924431901798,
-      "phase": 32.042245114464606
+      "amplitude": 0.03,
+      "phase": 32.04
     },
     {
       "name": "O1",
-      "amplitude": 0.09011290328905742,
-      "phase": 231.57247424980147
+      "amplitude": 0.09,
+      "phase": 231.57
     },
     {
       "name": "Q1",
-      "amplitude": 0.028777070272865694,
-      "phase": 171.79433075424572
+      "amplitude": 0.029,
+      "phase": 171.79
     },
     {
       "name": "M1",
-      "amplitude": 0.0017204407711910762,
-      "phase": 82.63062616469625
+      "amplitude": 0.002,
+      "phase": 82.63
     },
     {
       "name": "M4",
-      "amplitude": 0.168912960642748,
-      "phase": 74.02957056455074
+      "amplitude": 0.169,
+      "phase": 74.03
     },
     {
       "name": "MM",
-      "amplitude": 0.015093024603286261,
-      "phase": 158.76761606540208
+      "amplitude": 0.015,
+      "phase": 158.77
     },
     {
       "name": "MF",
-      "amplitude": 0.008357880273311379,
-      "phase": 163.9841215280179
+      "amplitude": 0.008,
+      "phase": 163.98
     },
     {
       "name": "SA",
-      "amplitude": 0.08296967405534551,
-      "phase": 224.2155307487949
+      "amplitude": 0.083,
+      "phase": 224.22
     },
     {
       "name": "SSA",
-      "amplitude": 0.034523387770436634,
-      "phase": 205.38872127987702
+      "amplitude": 0.035,
+      "phase": 205.39
     },
     {
       "name": "T2",
-      "amplitude": 0.020027234039007392,
-      "phase": 340.8266537460197
+      "amplitude": 0.02,
+      "phase": 340.83
     },
     {
       "name": "J1",
-      "amplitude": 0.001685215372940435,
-      "phase": 143.820561322176
+      "amplitude": 0.002,
+      "phase": 143.82
     },
     {
       "name": "L2",
-      "amplitude": 0.11308826314558781,
-      "phase": 318.7318842525033
+      "amplitude": 0.113,
+      "phase": 318.73
     },
     {
       "name": "R2",
-      "amplitude": 0.0033235101043723177,
-      "phase": 219.303720002075
+      "amplitude": 0.003,
+      "phase": 219.3
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0060017370174327905,
-      "phase": 117.45519096964682
+      "amplitude": 0.006,
+      "phase": 117.46
     },
     {
       "name": "MSF",
-      "amplitude": 0.014352561260890344,
-      "phase": 51.77488357169523
+      "amplitude": 0.014,
+      "phase": 51.77
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008340408386006509,
-      "phase": 67.92387866845269
+      "amplitude": 0.008,
+      "phase": 67.92
     },
     {
       "name": "EP2",
-      "amplitude": 0.03217588125637036,
-      "phase": 10.274535330418416
+      "amplitude": 0.032,
+      "phase": 10.27
     },
     {
       "name": "M3",
-      "amplitude": 0.0026670138668448587,
-      "phase": 325.2180043671641
+      "amplitude": 0.003,
+      "phase": 325.22
     },
     {
       "name": "MU2",
-      "amplitude": 0.1489714422801094,
-      "phase": 28.947413540397974
+      "amplitude": 0.149,
+      "phase": 28.95
     },
     {
       "name": "MTM",
-      "amplitude": 0.004643283843605394,
-      "phase": 253.30027106576983
+      "amplitude": 0.005,
+      "phase": 253.3
     },
     {
       "name": "NU2",
-      "amplitude": 0.08159850250845356,
-      "phase": 259.82649360492604
+      "amplitude": 0.082,
+      "phase": 259.83
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05184636050153006,
-      "phase": 316.26006964472776
+      "amplitude": 0.052,
+      "phase": 316.26
     },
     {
       "name": "MN4",
-      "amplitude": 0.05475331951315626,
-      "phase": 49.075813800781475
+      "amplitude": 0.055,
+      "phase": 49.08
     },
     {
       "name": "MS4",
-      "amplitude": 0.10139113215006784,
-      "phase": 151.2589259135699
+      "amplitude": 0.101,
+      "phase": 151.26
     },
     {
       "name": "N4",
-      "amplitude": 0.01115587368072401,
-      "phase": 28.00342436198372
+      "amplitude": 0.011,
+      "phase": 28
     },
     {
       "name": "M6",
-      "amplitude": 0.06503628973550916,
-      "phase": 254.70823117057842
+      "amplitude": 0.065,
+      "phase": 254.71
     },
     {
       "name": "M8",
-      "amplitude": 0.009279510328395807,
-      "phase": 49.303818600520856
+      "amplitude": 0.009,
+      "phase": 49.3
     },
     {
       "name": "S4",
-      "amplitude": 0.009399576510982164,
-      "phase": 296.2125214573751
+      "amplitude": 0.009,
+      "phase": 296.21
     },
     {
       "name": "OO1",
-      "amplitude": 0.0027149731995764438,
-      "phase": 186.59478928139995
+      "amplitude": 0.003,
+      "phase": 186.59
     },
     {
       "name": "S3",
-      "amplitude": 0.000316683642943705,
-      "phase": 14.189612937041716
+      "amplitude": 0,
+      "phase": 14.19
     },
     {
       "name": "MA2",
-      "amplitude": 0.05972373305100119,
-      "phase": 266.34229387670035
+      "amplitude": 0.06,
+      "phase": 266.34
     },
     {
       "name": "MB2",
-      "amplitude": 0.004462638401450209,
-      "phase": 144.52514869047786
+      "amplitude": 0.004,
+      "phase": 144.53
     },
     {
       "name": "T3",
-      "amplitude": 0.0006302768329762233,
-      "phase": 34.80347998109198
+      "amplitude": 0.001,
+      "phase": 34.8
     },
     {
       "name": "R3",
-      "amplitude": 0.0037523661038455763,
-      "phase": 2.8207391407526075
+      "amplitude": 0.004,
+      "phase": 2.82
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005254096147100852,
-      "phase": 180.7795808392513
+      "amplitude": 0.005,
+      "phase": 180.78
     },
     {
       "name": "SGM",
-      "amplitude": 0.0031071246802105846,
-      "phase": 61.5076648723487
+      "amplitude": 0.003,
+      "phase": 61.51
     },
     {
       "name": "3L2",
-      "amplitude": 0.004034174812316533,
-      "phase": 211.31104262752737
+      "amplitude": 0.004,
+      "phase": 211.31
     },
     {
       "name": "3N2",
-      "amplitude": 0.013221939055128223,
-      "phase": 116.45627618730936
+      "amplitude": 0.013,
+      "phase": 116.46
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03386792214684732,
-      "phase": 238.18481177124136
+      "amplitude": 0.034,
+      "phase": 238.18
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06240659676732163,
-      "phase": 321.7168376168613
+      "amplitude": 0.062,
+      "phase": 321.72
     },
     {
       "name": "2MK5",
-      "amplitude": 0.009602412740923095,
-      "phase": 297.67017395284665
+      "amplitude": 0.01,
+      "phase": 297.67
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006131329742231575,
-      "phase": 144.19678972170914
+      "amplitude": 0.006,
+      "phase": 144.2
     }
   ],
   "epoch": {

--- a/data/ticon/kollmar-5970025-deu-wsv.json
+++ b/data/ticon/kollmar-5970025-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2562172586683535,
-      "phase": 49.08772204538906
+      "amplitude": 1.256,
+      "phase": 49.09
     },
     {
       "name": "N2",
-      "amplitude": 0.19133997956062604,
-      "phase": 22.828871142448293
+      "amplitude": 0.191,
+      "phase": 22.83
     },
     {
       "name": "S2",
-      "amplitude": 0.2879200301317489,
-      "phase": 122.46133708332849
+      "amplitude": 0.288,
+      "phase": 122.46
     },
     {
       "name": "K2",
-      "amplitude": 0.08644195145369003,
-      "phase": 120.86341063619159
+      "amplitude": 0.086,
+      "phase": 120.86
     },
     {
       "name": "2N2",
-      "amplitude": 0.01998685102037492,
-      "phase": 0.7874511495040792
+      "amplitude": 0.02,
+      "phase": 0.79
     },
     {
       "name": "S1",
-      "amplitude": 0.017152778509732503,
-      "phase": 84.85134550429655
+      "amplitude": 0.017,
+      "phase": 84.85
     },
     {
       "name": "K1",
-      "amplitude": 0.07113123311556172,
-      "phase": 83.02264864208382
+      "amplitude": 0.071,
+      "phase": 83.02
     },
     {
       "name": "P1",
-      "amplitude": 0.03004114773232645,
-      "phase": 79.89492609680929
+      "amplitude": 0.03,
+      "phase": 79.89
     },
     {
       "name": "O1",
-      "amplitude": 0.08976494992285652,
-      "phase": 288.22197786429297
+      "amplitude": 0.09,
+      "phase": 288.22
     },
     {
       "name": "Q1",
-      "amplitude": 0.02635079297226345,
-      "phase": 228.5092832039051
+      "amplitude": 0.026,
+      "phase": 228.51
     },
     {
       "name": "M1",
-      "amplitude": 0.0021205933062981358,
-      "phase": 136.65659411964293
+      "amplitude": 0.002,
+      "phase": 136.66
     },
     {
       "name": "M4",
-      "amplitude": 0.11458389827852065,
-      "phase": 319.56811464422697
+      "amplitude": 0.115,
+      "phase": 319.57
     },
     {
       "name": "MM",
-      "amplitude": 0.01694705465513637,
-      "phase": 143.68032320391455
+      "amplitude": 0.017,
+      "phase": 143.68
     },
     {
       "name": "MF",
-      "amplitude": 0.014377695336900885,
-      "phase": 108.51449941026044
+      "amplitude": 0.014,
+      "phase": 108.51
     },
     {
       "name": "SA",
-      "amplitude": 0.07625997064087564,
-      "phase": 232.12432101122067
+      "amplitude": 0.076,
+      "phase": 232.12
     },
     {
       "name": "SSA",
-      "amplitude": 0.04643743741562396,
-      "phase": 216.8252324461317
+      "amplitude": 0.046,
+      "phase": 216.83
     },
     {
       "name": "T2",
-      "amplitude": 0.01736011986963735,
-      "phase": 103.44392535386191
+      "amplitude": 0.017,
+      "phase": 103.44
     },
     {
       "name": "J1",
-      "amplitude": 0.0054889184176954535,
-      "phase": 213.00951587287975
+      "amplitude": 0.005,
+      "phase": 213.01
     },
     {
       "name": "L2",
-      "amplitude": 0.11135294823721309,
-      "phase": 69.69607214522694
+      "amplitude": 0.111,
+      "phase": 69.7
     },
     {
       "name": "R2",
-      "amplitude": 0.004539071020414261,
-      "phase": 50.7714266394446
+      "amplitude": 0.005,
+      "phase": 50.77
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005826275579009571,
-      "phase": 165.47161914229366
+      "amplitude": 0.006,
+      "phase": 165.47
     },
     {
       "name": "MSF",
-      "amplitude": 0.05652489070271457,
-      "phase": 62.74007152446768
+      "amplitude": 0.057,
+      "phase": 62.74
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009573250740033257,
-      "phase": 46.422255060436385
+      "amplitude": 0.01,
+      "phase": 46.42
     },
     {
       "name": "EP2",
-      "amplitude": 0.03368948314867929,
-      "phase": 115.41092999402292
+      "amplitude": 0.034,
+      "phase": 115.41
     },
     {
       "name": "M3",
-      "amplitude": 0.002397510199610059,
-      "phase": 79.98777380237118
+      "amplitude": 0.002,
+      "phase": 79.99
     },
     {
       "name": "MU2",
-      "amplitude": 0.1619001799466049,
-      "phase": 141.34169956560078
+      "amplitude": 0.162,
+      "phase": 141.34
     },
     {
       "name": "MTM",
-      "amplitude": 0.004255139920563758,
-      "phase": 229.9074359113551
+      "amplitude": 0.004,
+      "phase": 229.91
     },
     {
       "name": "NU2",
-      "amplitude": 0.0844124794415852,
-      "phase": 6.833227342049611
+      "amplitude": 0.084,
+      "phase": 6.83
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04930716641919636,
-      "phase": 66.73857019988333
+      "amplitude": 0.049,
+      "phase": 66.74
     },
     {
       "name": "MN4",
-      "amplitude": 0.03824559059816523,
-      "phase": 295.7633816598388
+      "amplitude": 0.038,
+      "phase": 295.76
     },
     {
       "name": "MS4",
-      "amplitude": 0.066889612720619,
-      "phase": 29.8695004298977
+      "amplitude": 0.067,
+      "phase": 29.87
     },
     {
       "name": "N4",
-      "amplitude": 0.007659126736093125,
-      "phase": 274.7895397099006
+      "amplitude": 0.008,
+      "phase": 274.79
     },
     {
       "name": "M6",
-      "amplitude": 0.0810280372589614,
-      "phase": 204.48582938231755
+      "amplitude": 0.081,
+      "phase": 204.49
     },
     {
       "name": "M8",
-      "amplitude": 0.019856305857975275,
-      "phase": 150.82393663830294
+      "amplitude": 0.02,
+      "phase": 150.82
     },
     {
       "name": "S4",
-      "amplitude": 0.006209352441485898,
-      "phase": 160.79588770046564
+      "amplitude": 0.006,
+      "phase": 160.8
     },
     {
       "name": "OO1",
-      "amplitude": 0.002830890527390051,
-      "phase": 222.53223707608777
+      "amplitude": 0.003,
+      "phase": 222.53
     },
     {
       "name": "S3",
-      "amplitude": 0.0007003184586998667,
-      "phase": 296.70803959657525
+      "amplitude": 0.001,
+      "phase": 296.71
     },
     {
       "name": "MA2",
-      "amplitude": 0.034420908905042444,
-      "phase": 14.223901900487817
+      "amplitude": 0.034,
+      "phase": 14.22
     },
     {
       "name": "MB2",
-      "amplitude": 0.02290790917121304,
-      "phase": 81.5743245019828
+      "amplitude": 0.023,
+      "phase": 81.57
     },
     {
       "name": "T3",
-      "amplitude": 0.00044720396678000774,
-      "phase": 92.31280075192518
+      "amplitude": 0,
+      "phase": 92.31
     },
     {
       "name": "R3",
-      "amplitude": 0.0036162059903676654,
-      "phase": 111.9291150285593
+      "amplitude": 0.004,
+      "phase": 111.93
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005650602851618952,
-      "phase": 230.9437889319098
+      "amplitude": 0.006,
+      "phase": 230.94
     },
     {
       "name": "SGM",
-      "amplitude": 0.0034636826662473494,
-      "phase": 70.79404883077302
+      "amplitude": 0.003,
+      "phase": 70.79
     },
     {
       "name": "3L2",
-      "amplitude": 0.0033350556154527872,
-      "phase": 311.8017462906483
+      "amplitude": 0.003,
+      "phase": 311.8
     },
     {
       "name": "3N2",
-      "amplitude": 0.013426624206428966,
-      "phase": 207.37041072065608
+      "amplitude": 0.013,
+      "phase": 207.37
     },
     {
       "name": "2SM2",
-      "amplitude": 0.029750260092799272,
-      "phase": 352.0375496616678
+      "amplitude": 0.03,
+      "phase": 352.04
     },
     {
       "name": "2MS6",
-      "amplitude": 0.07662520242025898,
-      "phase": 274.03542286149127
+      "amplitude": 0.077,
+      "phase": 274.04
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004595889081683503,
-      "phase": 205.34014571562986
+      "amplitude": 0.005,
+      "phase": 205.34
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0038073019417256444,
-      "phase": 90.16531364613377
+      "amplitude": 0.004,
+      "phase": 90.17
     }
   ],
   "epoch": {

--- a/data/ticon/koserow-9690093-deu-wsv.json
+++ b/data/ticon/koserow-9690093-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.013397988886204769,
-      "phase": 303.03556232835365
+      "amplitude": 0.013,
+      "phase": 303.04
     },
     {
       "name": "N2",
-      "amplitude": 0.0038603210855933027,
-      "phase": 256.49410231535705
+      "amplitude": 0.004,
+      "phase": 256.49
     },
     {
       "name": "S2",
-      "amplitude": 0.002092810509967282,
-      "phase": 277.0224949921338
+      "amplitude": 0.002,
+      "phase": 277.02
     },
     {
       "name": "K2",
-      "amplitude": 0.0009998872723253956,
-      "phase": 229.8619354642117
+      "amplitude": 0.001,
+      "phase": 229.86
     },
     {
       "name": "2N2",
-      "amplitude": 0.0007339708204991718,
-      "phase": 254.58822629962452
+      "amplitude": 0.001,
+      "phase": 254.59
     },
     {
       "name": "S1",
-      "amplitude": 0.007832480033749888,
-      "phase": 19.136682546259806
+      "amplitude": 0.008,
+      "phase": 19.14
     },
     {
       "name": "K1",
-      "amplitude": 0.006824784040887831,
-      "phase": 144.63868077777238
+      "amplitude": 0.007,
+      "phase": 144.64
     },
     {
       "name": "P1",
-      "amplitude": 0.001433697445557111,
-      "phase": 109.2950904950776
+      "amplitude": 0.001,
+      "phase": 109.3
     },
     {
       "name": "O1",
-      "amplitude": 0.012238438228467164,
-      "phase": 141.49820376626076
+      "amplitude": 0.012,
+      "phase": 141.5
     },
     {
       "name": "Q1",
-      "amplitude": 0.0019405858324779324,
-      "phase": 99.59164429471895
+      "amplitude": 0.002,
+      "phase": 99.59
     },
     {
       "name": "M1",
-      "amplitude": 0.0006031232324801081,
-      "phase": 39.2794054765871
+      "amplitude": 0.001,
+      "phase": 39.28
     },
     {
       "name": "M4",
-      "amplitude": 0.0011178341991153968,
-      "phase": 279.4438223203716
+      "amplitude": 0.001,
+      "phase": 279.44
     },
     {
       "name": "MM",
-      "amplitude": 0.01037073750042452,
-      "phase": 275.5260731664824
+      "amplitude": 0.01,
+      "phase": 275.53
     },
     {
       "name": "MF",
-      "amplitude": 0.007734404080356532,
-      "phase": 273.85438199783584
+      "amplitude": 0.008,
+      "phase": 273.85
     },
     {
       "name": "SA",
-      "amplitude": 0.03920863199017514,
-      "phase": 193.5948643867421
+      "amplitude": 0.039,
+      "phase": 193.59
     },
     {
       "name": "SSA",
-      "amplitude": 0.03916370908055606,
-      "phase": 244.2641850713427
+      "amplitude": 0.039,
+      "phase": 244.26
     },
     {
       "name": "T2",
-      "amplitude": 0.0006735302680918732,
-      "phase": 243.8641463555612
+      "amplitude": 0.001,
+      "phase": 243.86
     },
     {
       "name": "J1",
-      "amplitude": 0.0007666493985689871,
-      "phase": 203.57139842901063
+      "amplitude": 0.001,
+      "phase": 203.57
     },
     {
       "name": "L2",
-      "amplitude": 0.0013169880831133299,
-      "phase": 59.73211868254151
+      "amplitude": 0.001,
+      "phase": 59.73
     },
     {
       "name": "R2",
-      "amplitude": 0.0004084235169729403,
-      "phase": 46.150709642497475
+      "amplitude": 0,
+      "phase": 46.15
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00018410385552733024,
-      "phase": 215.5076757596054
+      "amplitude": 0,
+      "phase": 215.51
     },
     {
       "name": "MSF",
-      "amplitude": 0.0007537529326222795,
-      "phase": 257.9871364826821
+      "amplitude": 0.001,
+      "phase": 257.99
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003499814186784112,
-      "phase": 180.2472729202869
+      "amplitude": 0.003,
+      "phase": 180.25
     },
     {
       "name": "EP2",
-      "amplitude": 0.0005984086862571834,
-      "phase": 61.64550262617888
+      "amplitude": 0.001,
+      "phase": 61.65
     },
     {
       "name": "M3",
-      "amplitude": 0.00041815639631359814,
-      "phase": 286.6938969574154
+      "amplitude": 0,
+      "phase": 286.69
     },
     {
       "name": "MU2",
-      "amplitude": 0.0025648302218661467,
-      "phase": 126.69989511502206
+      "amplitude": 0.003,
+      "phase": 126.7
     },
     {
       "name": "MTM",
-      "amplitude": 0.0030603840564176325,
-      "phase": 348.37415477801045
+      "amplitude": 0.003,
+      "phase": 348.37
     },
     {
       "name": "NU2",
-      "amplitude": 0.0012525588884234502,
-      "phase": 309.55159125437496
+      "amplitude": 0.001,
+      "phase": 309.55
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0006446669722567769,
-      "phase": 39.78830079437034
+      "amplitude": 0.001,
+      "phase": 39.79
     },
     {
       "name": "MN4",
-      "amplitude": 0.0004320251343367332,
-      "phase": 213.43611607445868
+      "amplitude": 0,
+      "phase": 213.44
     },
     {
       "name": "MS4",
-      "amplitude": 0.0005047819903852736,
-      "phase": 71.62527249126441
+      "amplitude": 0.001,
+      "phase": 71.63
     },
     {
       "name": "N4",
-      "amplitude": 0.00012952134050614757,
-      "phase": 167.34991102106835
+      "amplitude": 0,
+      "phase": 167.35
     },
     {
       "name": "M6",
-      "amplitude": 0.00033174440156276283,
-      "phase": 77.21103320040862
+      "amplitude": 0,
+      "phase": 77.21
     },
     {
       "name": "M8",
-      "amplitude": 0.000007622450343663885,
-      "phase": 119.50517325006109
+      "amplitude": 0,
+      "phase": 119.51
     },
     {
       "name": "S4",
-      "amplitude": 0.0001154050122057079,
-      "phase": 37.911724117305084
+      "amplitude": 0,
+      "phase": 37.91
     },
     {
       "name": "OO1",
-      "amplitude": 0.00016803391607291264,
-      "phase": 150.91074107296635
+      "amplitude": 0,
+      "phase": 150.91
     },
     {
       "name": "S3",
-      "amplitude": 0.000686073194858891,
-      "phase": 303.7583781655567
+      "amplitude": 0.001,
+      "phase": 303.76
     },
     {
       "name": "MA2",
-      "amplitude": 0.001609118374816854,
-      "phase": 311.22826037639595
+      "amplitude": 0.002,
+      "phase": 311.23
     },
     {
       "name": "MB2",
-      "amplitude": 0.0013820250533549837,
-      "phase": 91.14175765649122
+      "amplitude": 0.001,
+      "phase": 91.14
     },
     {
       "name": "T3",
-      "amplitude": 0.000478055081019311,
-      "phase": 176.74248221577625
+      "amplitude": 0,
+      "phase": 176.74
     },
     {
       "name": "R3",
-      "amplitude": 0.0004010784144951709,
-      "phase": 301.792042198612
+      "amplitude": 0,
+      "phase": 301.79
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00042244768508385954,
-      "phase": 133.06000541050503
+      "amplitude": 0,
+      "phase": 133.06
     },
     {
       "name": "SGM",
-      "amplitude": 0.0010086360404093877,
-      "phase": 227.92333888180062
+      "amplitude": 0.001,
+      "phase": 227.92
     },
     {
       "name": "3L2",
-      "amplitude": 0.00020295889698507792,
-      "phase": 167.78645105845328
+      "amplitude": 0,
+      "phase": 167.79
     },
     {
       "name": "3N2",
-      "amplitude": 0.0004115671342213954,
-      "phase": 196.80250022973388
+      "amplitude": 0,
+      "phase": 196.8
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0005515211757772975,
-      "phase": 26.99604248628731
+      "amplitude": 0.001,
+      "phase": 27
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00024221322776608151,
-      "phase": 166.2563737875662
+      "amplitude": 0,
+      "phase": 166.26
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00008837984314268169,
-      "phase": 319.33114688223446
+      "amplitude": 0,
+      "phase": 319.33
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00008956665493406094,
-      "phase": 164.42749716478886
+      "amplitude": 0,
+      "phase": 164.43
     }
   ],
   "epoch": {

--- a/data/ticon/krautsandreede-5970031-deu-wsv.json
+++ b/data/ticon/krautsandreede-5970031-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2861920370288913,
-      "phase": 42.81452406905845
+      "amplitude": 1.286,
+      "phase": 42.81
     },
     {
       "name": "N2",
-      "amplitude": 0.19602059760739599,
-      "phase": 16.142344902091963
+      "amplitude": 0.196,
+      "phase": 16.14
     },
     {
       "name": "S2",
-      "amplitude": 0.2969775577184061,
-      "phase": 115.2629369809498
+      "amplitude": 0.297,
+      "phase": 115.26
     },
     {
       "name": "K2",
-      "amplitude": 0.09032584834897593,
-      "phase": 112.89549793791974
+      "amplitude": 0.09,
+      "phase": 112.9
     },
     {
       "name": "2N2",
-      "amplitude": 0.01611903480369336,
-      "phase": 339.5274126767689
+      "amplitude": 0.016,
+      "phase": 339.53
     },
     {
       "name": "S1",
-      "amplitude": 0.018193499433969206,
-      "phase": 80.6688484167039
+      "amplitude": 0.018,
+      "phase": 80.67
     },
     {
       "name": "K1",
-      "amplitude": 0.07144063521276585,
-      "phase": 80.74955703346421
+      "amplitude": 0.071,
+      "phase": 80.75
     },
     {
       "name": "P1",
-      "amplitude": 0.02939208944259324,
-      "phase": 80.52521080326073
+      "amplitude": 0.029,
+      "phase": 80.53
     },
     {
       "name": "O1",
-      "amplitude": 0.09048487805890526,
-      "phase": 284.72203041691137
+      "amplitude": 0.09,
+      "phase": 284.72
     },
     {
       "name": "Q1",
-      "amplitude": 0.028924217797887734,
-      "phase": 226.83887677842503
+      "amplitude": 0.029,
+      "phase": 226.84
     },
     {
       "name": "M1",
-      "amplitude": 0.0007551615342754882,
-      "phase": 165.39965039522576
+      "amplitude": 0.001,
+      "phase": 165.4
     },
     {
       "name": "M4",
-      "amplitude": 0.1224600585425416,
-      "phase": 304.6395885241726
+      "amplitude": 0.122,
+      "phase": 304.64
     },
     {
       "name": "MM",
-      "amplitude": 0.0558136442846568,
-      "phase": 92.77160790531832
+      "amplitude": 0.056,
+      "phase": 92.77
     },
     {
       "name": "MF",
-      "amplitude": 0.02623652027494011,
-      "phase": 121.85626368353502
+      "amplitude": 0.026,
+      "phase": 121.86
     },
     {
       "name": "SA",
-      "amplitude": 0.07993484666768497,
-      "phase": 251.31428966543342
+      "amplitude": 0.08,
+      "phase": 251.31
     },
     {
       "name": "SSA",
-      "amplitude": 0.05381885222225082,
-      "phase": 222.13621582386506
+      "amplitude": 0.054,
+      "phase": 222.14
     },
     {
       "name": "T2",
-      "amplitude": 0.020917580670170268,
-      "phase": 93.29509491072213
+      "amplitude": 0.021,
+      "phase": 93.3
     },
     {
       "name": "J1",
-      "amplitude": 0.006235475535384045,
-      "phase": 194.59278836350668
+      "amplitude": 0.006,
+      "phase": 194.59
     },
     {
       "name": "L2",
-      "amplitude": 0.13140197558079447,
-      "phase": 53.99060731421645
+      "amplitude": 0.131,
+      "phase": 53.99
     },
     {
       "name": "R2",
-      "amplitude": 0.005415088353095863,
-      "phase": 34.18960554529542
+      "amplitude": 0.005,
+      "phase": 34.19
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005966236996270408,
-      "phase": 141.70929338827892
+      "amplitude": 0.006,
+      "phase": 141.71
     },
     {
       "name": "MSF",
-      "amplitude": 0.050780358417242905,
-      "phase": 66.11876867155013
+      "amplitude": 0.051,
+      "phase": 66.12
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009695852656631533,
-      "phase": 245.75208915780036
+      "amplitude": 0.01,
+      "phase": 245.75
     },
     {
       "name": "EP2",
-      "amplitude": 0.034374128216507725,
-      "phase": 113.24629770388708
+      "amplitude": 0.034,
+      "phase": 113.25
     },
     {
       "name": "M3",
-      "amplitude": 0.0034859305271618844,
-      "phase": 49.9098156686199
+      "amplitude": 0.003,
+      "phase": 49.91
     },
     {
       "name": "MU2",
-      "amplitude": 0.16919873825569384,
-      "phase": 135.91360905907845
+      "amplitude": 0.169,
+      "phase": 135.91
     },
     {
       "name": "MTM",
-      "amplitude": 0.012071643382460643,
-      "phase": 225.0256268601344
+      "amplitude": 0.012,
+      "phase": 225.03
     },
     {
       "name": "NU2",
-      "amplitude": 0.08791308017468061,
-      "phase": 2.6635619694857837
+      "amplitude": 0.088,
+      "phase": 2.66
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04831812774570631,
-      "phase": 59.443281813015915
+      "amplitude": 0.048,
+      "phase": 59.44
     },
     {
       "name": "MN4",
-      "amplitude": 0.04107558154247113,
-      "phase": 280.5965025077502
+      "amplitude": 0.041,
+      "phase": 280.6
     },
     {
       "name": "MS4",
-      "amplitude": 0.07127262399938683,
-      "phase": 14.379145863467045
+      "amplitude": 0.071,
+      "phase": 14.38
     },
     {
       "name": "N4",
-      "amplitude": 0.007039325717568275,
-      "phase": 252.63832394808242
+      "amplitude": 0.007,
+      "phase": 252.64
     },
     {
       "name": "M6",
-      "amplitude": 0.0847928596881155,
-      "phase": 187.3827161947449
+      "amplitude": 0.085,
+      "phase": 187.38
     },
     {
       "name": "M8",
-      "amplitude": 0.019197512539287274,
-      "phase": 126.55179436509377
+      "amplitude": 0.019,
+      "phase": 126.55
     },
     {
       "name": "S4",
-      "amplitude": 0.007619664382544817,
-      "phase": 146.48201845712993
+      "amplitude": 0.008,
+      "phase": 146.48
     },
     {
       "name": "OO1",
-      "amplitude": 0.005030854504127343,
-      "phase": 197.3289025656762
+      "amplitude": 0.005,
+      "phase": 197.33
     },
     {
       "name": "S3",
-      "amplitude": 0.0005788190172648056,
-      "phase": 353.9322318602526
+      "amplitude": 0.001,
+      "phase": 353.93
     },
     {
       "name": "MA2",
-      "amplitude": 0.03694395126210972,
-      "phase": 15.797371594079152
+      "amplitude": 0.037,
+      "phase": 15.8
     },
     {
       "name": "MB2",
-      "amplitude": 0.021265796889702933,
-      "phase": 68.28040673886647
+      "amplitude": 0.021,
+      "phase": 68.28
     },
     {
       "name": "T3",
-      "amplitude": 0.00038436577758760944,
-      "phase": 298.8226230713597
+      "amplitude": 0,
+      "phase": 298.82
     },
     {
       "name": "R3",
-      "amplitude": 0.004254758594436559,
-      "phase": 108.82718564826229
+      "amplitude": 0.004,
+      "phase": 108.83
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00615077932780202,
-      "phase": 247.16904800862937
+      "amplitude": 0.006,
+      "phase": 247.17
     },
     {
       "name": "SGM",
-      "amplitude": 0.0038804092456640156,
-      "phase": 116.94252858901928
+      "amplitude": 0.004,
+      "phase": 116.94
     },
     {
       "name": "3L2",
-      "amplitude": 0.03769611251941304,
-      "phase": 301.8367880275714
+      "amplitude": 0.038,
+      "phase": 301.84
     },
     {
       "name": "3N2",
-      "amplitude": 0.013918025030076463,
-      "phase": 227.20244224088364
+      "amplitude": 0.014,
+      "phase": 227.2
     },
     {
       "name": "2SM2",
-      "amplitude": 0.030677807017560288,
-      "phase": 342.6259842561213
+      "amplitude": 0.031,
+      "phase": 342.63
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08165919183637932,
-      "phase": 255.3861457666506
+      "amplitude": 0.082,
+      "phase": 255.39
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004727557545859631,
-      "phase": 192.92066864621086
+      "amplitude": 0.005,
+      "phase": 192.92
     },
     {
       "name": "2MO5",
-      "amplitude": 0.003882917761344948,
-      "phase": 74.13367681607508
+      "amplitude": 0.004,
+      "phase": 74.13
     }
   ],
   "epoch": {

--- a/data/ticon/krckausperrwerkap-5970024-deu-wsv.json
+++ b/data/ticon/krckausperrwerkap-5970024-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2623315148357672,
-      "phase": 53.91252502622683
+      "amplitude": 1.262,
+      "phase": 53.91
     },
     {
       "name": "N2",
-      "amplitude": 0.1929226437087264,
-      "phase": 27.66319847291976
+      "amplitude": 0.193,
+      "phase": 27.66
     },
     {
       "name": "S2",
-      "amplitude": 0.2915106591616331,
-      "phase": 127.46618091484248
+      "amplitude": 0.292,
+      "phase": 127.47
     },
     {
       "name": "K2",
-      "amplitude": 0.08779815556522358,
-      "phase": 125.70016105297293
+      "amplitude": 0.088,
+      "phase": 125.7
     },
     {
       "name": "2N2",
-      "amplitude": 0.022003781841222533,
-      "phase": 356.4084809983202
+      "amplitude": 0.022,
+      "phase": 356.41
     },
     {
       "name": "S1",
-      "amplitude": 0.018479258077272395,
-      "phase": 83.4754679331952
+      "amplitude": 0.018,
+      "phase": 83.48
     },
     {
       "name": "K1",
-      "amplitude": 0.06951682812312601,
-      "phase": 85.63679367737302
+      "amplitude": 0.07,
+      "phase": 85.64
     },
     {
       "name": "P1",
-      "amplitude": 0.029726904866814088,
-      "phase": 83.80649843048207
+      "amplitude": 0.03,
+      "phase": 83.81
     },
     {
       "name": "O1",
-      "amplitude": 0.09017749614622432,
-      "phase": 290.5694020598938
+      "amplitude": 0.09,
+      "phase": 290.57
     },
     {
       "name": "Q1",
-      "amplitude": 0.025688941874546206,
-      "phase": 228.51730478421513
+      "amplitude": 0.026,
+      "phase": 228.52
     },
     {
       "name": "M1",
-      "amplitude": 0.0011099129398705273,
-      "phase": 129.30584225372309
+      "amplitude": 0.001,
+      "phase": 129.31
     },
     {
       "name": "M4",
-      "amplitude": 0.12329608773751338,
-      "phase": 332.8116423325045
+      "amplitude": 0.123,
+      "phase": 332.81
     },
     {
       "name": "MM",
-      "amplitude": 0.01605620604324794,
-      "phase": 116.24323083454351
+      "amplitude": 0.016,
+      "phase": 116.24
     },
     {
       "name": "MF",
-      "amplitude": 0.011745749915798938,
-      "phase": 101.0776039419465
+      "amplitude": 0.012,
+      "phase": 101.08
     },
     {
       "name": "SA",
-      "amplitude": 0.06670924562402,
-      "phase": 250.30114372319957
+      "amplitude": 0.067,
+      "phase": 250.3
     },
     {
       "name": "SSA",
-      "amplitude": 0.05737971259876331,
-      "phase": 244.05288503462816
+      "amplitude": 0.057,
+      "phase": 244.05
     },
     {
       "name": "T2",
-      "amplitude": 0.01575041717954086,
-      "phase": 110.49360575474986
+      "amplitude": 0.016,
+      "phase": 110.49
     },
     {
       "name": "J1",
-      "amplitude": 0.005200724395116515,
-      "phase": 229.31436618843108
+      "amplitude": 0.005,
+      "phase": 229.31
     },
     {
       "name": "L2",
-      "amplitude": 0.1078423330174545,
-      "phase": 72.8602150312683
+      "amplitude": 0.108,
+      "phase": 72.86
     },
     {
       "name": "R2",
-      "amplitude": 0.005879311672234242,
-      "phase": 66.00877365113394
+      "amplitude": 0.006,
+      "phase": 66.01
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006422828664625271,
-      "phase": 177.92632561784023
+      "amplitude": 0.006,
+      "phase": 177.93
     },
     {
       "name": "MSF",
-      "amplitude": 0.0498267284409356,
-      "phase": 57.05167813395002
+      "amplitude": 0.05,
+      "phase": 57.05
     },
     {
       "name": "MSQM",
-      "amplitude": 0.02310230030807329,
-      "phase": 54.20971624023292
+      "amplitude": 0.023,
+      "phase": 54.21
     },
     {
       "name": "EP2",
-      "amplitude": 0.03321701840666151,
-      "phase": 120.59329342444079
+      "amplitude": 0.033,
+      "phase": 120.59
     },
     {
       "name": "M3",
-      "amplitude": 0.002037608926101054,
-      "phase": 108.4370788250032
+      "amplitude": 0.002,
+      "phase": 108.44
     },
     {
       "name": "MU2",
-      "amplitude": 0.1641679052130832,
-      "phase": 146.4812326054368
+      "amplitude": 0.164,
+      "phase": 146.48
     },
     {
       "name": "MTM",
-      "amplitude": 0.006951468444049614,
-      "phase": 274.8875297248219
+      "amplitude": 0.007,
+      "phase": 274.89
     },
     {
       "name": "NU2",
-      "amplitude": 0.08481465253239828,
-      "phase": 11.846542774730722
+      "amplitude": 0.085,
+      "phase": 11.85
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04983398297517523,
-      "phase": 71.084921124365
+      "amplitude": 0.05,
+      "phase": 71.08
     },
     {
       "name": "MN4",
-      "amplitude": 0.04168432132080302,
-      "phase": 308.53238091352637
+      "amplitude": 0.042,
+      "phase": 308.53
     },
     {
       "name": "MS4",
-      "amplitude": 0.07153113371367024,
-      "phase": 43.4452904051206
+      "amplitude": 0.072,
+      "phase": 43.45
     },
     {
       "name": "N4",
-      "amplitude": 0.007336123836896344,
-      "phase": 280.8629799783742
+      "amplitude": 0.007,
+      "phase": 280.86
     },
     {
       "name": "M6",
-      "amplitude": 0.08751614451148332,
-      "phase": 220.73159451014203
+      "amplitude": 0.088,
+      "phase": 220.73
     },
     {
       "name": "M8",
-      "amplitude": 0.02602342020697246,
-      "phase": 176.33624291024546
+      "amplitude": 0.026,
+      "phase": 176.34
     },
     {
       "name": "S4",
-      "amplitude": 0.00674930976287957,
-      "phase": 173.48242740583214
+      "amplitude": 0.007,
+      "phase": 173.48
     },
     {
       "name": "OO1",
-      "amplitude": 0.00339069223844491,
-      "phase": 256.9671980716305
+      "amplitude": 0.003,
+      "phase": 256.97
     },
     {
       "name": "S3",
-      "amplitude": 0.0008840740164208423,
-      "phase": 274.9677861935936
+      "amplitude": 0.001,
+      "phase": 274.97
     },
     {
       "name": "MA2",
-      "amplitude": 0.02992661551358212,
-      "phase": 4.387320626609096
+      "amplitude": 0.03,
+      "phase": 4.39
     },
     {
       "name": "MB2",
-      "amplitude": 0.026661415294230956,
-      "phase": 91.4573788459486
+      "amplitude": 0.027,
+      "phase": 91.46
     },
     {
       "name": "T3",
-      "amplitude": 0.0013648586011804657,
-      "phase": 108.54145415992673
+      "amplitude": 0.001,
+      "phase": 108.54
     },
     {
       "name": "R3",
-      "amplitude": 0.00349181477443944,
-      "phase": 114.16187744456113
+      "amplitude": 0.003,
+      "phase": 114.16
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006606843614293164,
-      "phase": 218.17401151282348
+      "amplitude": 0.007,
+      "phase": 218.17
     },
     {
       "name": "SGM",
-      "amplitude": 0.00489826172213166,
-      "phase": 32.82233831325573
+      "amplitude": 0.005,
+      "phase": 32.82
     },
     {
       "name": "3L2",
-      "amplitude": 0.0025060505684648773,
-      "phase": 270.9210012481524
+      "amplitude": 0.003,
+      "phase": 270.92
     },
     {
       "name": "3N2",
-      "amplitude": 0.012787371188637533,
-      "phase": 202.46094430869945
+      "amplitude": 0.013,
+      "phase": 202.46
     },
     {
       "name": "2SM2",
-      "amplitude": 0.031215226619221204,
-      "phase": 357.08514227980794
+      "amplitude": 0.031,
+      "phase": 357.09
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08371433079692368,
-      "phase": 290.637188090618
+      "amplitude": 0.084,
+      "phase": 290.64
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004683349879114086,
-      "phase": 221.9130057787164
+      "amplitude": 0.005,
+      "phase": 221.91
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004233349761353744,
-      "phase": 105.8183725590385
+      "amplitude": 0.004,
+      "phase": 105.82
     }
   ],
   "epoch": {

--- a/data/ticon/krckausperrwerkbp-5970023-deu-wsv.json
+++ b/data/ticon/krckausperrwerkbp-5970023-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2520587179932563,
-      "phase": 53.61287958778945
+      "amplitude": 1.252,
+      "phase": 53.61
     },
     {
       "name": "N2",
-      "amplitude": 0.18937445514780088,
-      "phase": 27.839093781846827
+      "amplitude": 0.189,
+      "phase": 27.84
     },
     {
       "name": "S2",
-      "amplitude": 0.28346635462653763,
-      "phase": 128.17994178697012
+      "amplitude": 0.283,
+      "phase": 128.18
     },
     {
       "name": "K2",
-      "amplitude": 0.08736391589506207,
-      "phase": 127.88402013627194
+      "amplitude": 0.087,
+      "phase": 127.88
     },
     {
       "name": "2N2",
-      "amplitude": 0.02024866680147327,
-      "phase": 3.5549878635725918
+      "amplitude": 0.02,
+      "phase": 3.55
     },
     {
       "name": "S1",
-      "amplitude": 0.0168424899507913,
-      "phase": 64.49062923374481
+      "amplitude": 0.017,
+      "phase": 64.49
     },
     {
       "name": "K1",
-      "amplitude": 0.06643188285106699,
-      "phase": 84.69242857599443
+      "amplitude": 0.066,
+      "phase": 84.69
     },
     {
       "name": "P1",
-      "amplitude": 0.029687781891861206,
-      "phase": 82.21481091288331
+      "amplitude": 0.03,
+      "phase": 82.21
     },
     {
       "name": "O1",
-      "amplitude": 0.08689052583089474,
-      "phase": 290.10928694758775
+      "amplitude": 0.087,
+      "phase": 290.11
     },
     {
       "name": "Q1",
-      "amplitude": 0.02739532668182349,
-      "phase": 229.97688177680067
+      "amplitude": 0.027,
+      "phase": 229.98
     },
     {
       "name": "M1",
-      "amplitude": 0.0020902396559633798,
-      "phase": 133.43235453494356
+      "amplitude": 0.002,
+      "phase": 133.43
     },
     {
       "name": "M4",
-      "amplitude": 0.1240803543418325,
-      "phase": 328.52767136824986
+      "amplitude": 0.124,
+      "phase": 328.53
     },
     {
       "name": "MM",
-      "amplitude": 0.017462488721899636,
-      "phase": 147.10661248360577
+      "amplitude": 0.017,
+      "phase": 147.11
     },
     {
       "name": "MF",
-      "amplitude": 0.013315018016703687,
-      "phase": 110.11723923925877
+      "amplitude": 0.013,
+      "phase": 110.12
     },
     {
       "name": "SA",
-      "amplitude": 0.06748869062098915,
-      "phase": 219.0215294964592
+      "amplitude": 0.067,
+      "phase": 219.02
     },
     {
       "name": "SSA",
-      "amplitude": 0.04357814501642463,
-      "phase": 234.19270417279006
+      "amplitude": 0.044,
+      "phase": 234.19
     },
     {
       "name": "T2",
-      "amplitude": 0.015733090544933236,
-      "phase": 105.17800778220567
+      "amplitude": 0.016,
+      "phase": 105.18
     },
     {
       "name": "J1",
-      "amplitude": 0.004282409486709809,
-      "phase": 219.94390331099677
+      "amplitude": 0.004,
+      "phase": 219.94
     },
     {
       "name": "L2",
-      "amplitude": 0.11246008094915495,
-      "phase": 73.43466379476553
+      "amplitude": 0.112,
+      "phase": 73.43
     },
     {
       "name": "R2",
-      "amplitude": 0.00798899292560335,
-      "phase": 74.1424338837474
+      "amplitude": 0.008,
+      "phase": 74.14
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004836095668973865,
-      "phase": 166.3024552329241
+      "amplitude": 0.005,
+      "phase": 166.3
     },
     {
       "name": "MSF",
-      "amplitude": 0.056714204480322716,
-      "phase": 63.29942693454393
+      "amplitude": 0.057,
+      "phase": 63.3
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007374777811036559,
-      "phase": 42.507689593845384
+      "amplitude": 0.007,
+      "phase": 42.51
     },
     {
       "name": "EP2",
-      "amplitude": 0.03573634305232682,
-      "phase": 116.08608247858626
+      "amplitude": 0.036,
+      "phase": 116.09
     },
     {
       "name": "M3",
-      "amplitude": 0.0020135142828491726,
-      "phase": 93.71466651872248
+      "amplitude": 0.002,
+      "phase": 93.71
     },
     {
       "name": "MU2",
-      "amplitude": 0.1657433928473026,
-      "phase": 146.22802514717046
+      "amplitude": 0.166,
+      "phase": 146.23
     },
     {
       "name": "MTM",
-      "amplitude": 0.0098031483921184,
-      "phase": 223.37527916289972
+      "amplitude": 0.01,
+      "phase": 223.38
     },
     {
       "name": "NU2",
-      "amplitude": 0.0859807644999564,
-      "phase": 12.217379550004807
+      "amplitude": 0.086,
+      "phase": 12.22
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05028204916121267,
-      "phase": 72.47063738197403
+      "amplitude": 0.05,
+      "phase": 72.47
     },
     {
       "name": "MN4",
-      "amplitude": 0.040894178198995774,
-      "phase": 304.20096304701934
+      "amplitude": 0.041,
+      "phase": 304.2
     },
     {
       "name": "MS4",
-      "amplitude": 0.07374606528943255,
-      "phase": 40.360338310104794
+      "amplitude": 0.074,
+      "phase": 40.36
     },
     {
       "name": "N4",
-      "amplitude": 0.007564504567503493,
-      "phase": 282.65463167428493
+      "amplitude": 0.008,
+      "phase": 282.65
     },
     {
       "name": "M6",
-      "amplitude": 0.08470830408639343,
-      "phase": 219.48247635015218
+      "amplitude": 0.085,
+      "phase": 219.48
     },
     {
       "name": "M8",
-      "amplitude": 0.024930752674118494,
-      "phase": 171.27581771587143
+      "amplitude": 0.025,
+      "phase": 171.28
     },
     {
       "name": "S4",
-      "amplitude": 0.0066077443299343425,
-      "phase": 172.4476800591899
+      "amplitude": 0.007,
+      "phase": 172.45
     },
     {
       "name": "OO1",
-      "amplitude": 0.002688090677955426,
-      "phase": 256.844857378135
+      "amplitude": 0.003,
+      "phase": 256.84
     },
     {
       "name": "S3",
-      "amplitude": 0.002111166032109142,
-      "phase": 19.771135484486592
+      "amplitude": 0.002,
+      "phase": 19.77
     },
     {
       "name": "MA2",
-      "amplitude": 0.03455262904604317,
-      "phase": 10.030386730585462
+      "amplitude": 0.035,
+      "phase": 10.03
     },
     {
       "name": "MB2",
-      "amplitude": 0.03402064774774711,
-      "phase": 92.91540891620559
+      "amplitude": 0.034,
+      "phase": 92.92
     },
     {
       "name": "T3",
-      "amplitude": 0.0009366430198290605,
-      "phase": 70.18952654883003
+      "amplitude": 0.001,
+      "phase": 70.19
     },
     {
       "name": "R3",
-      "amplitude": 0.005065302205333787,
-      "phase": 107.60216824544807
+      "amplitude": 0.005,
+      "phase": 107.6
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00643516276946344,
-      "phase": 236.73845860383943
+      "amplitude": 0.006,
+      "phase": 236.74
     },
     {
       "name": "SGM",
-      "amplitude": 0.0036282366013262587,
-      "phase": 66.57973083484035
+      "amplitude": 0.004,
+      "phase": 66.58
     },
     {
       "name": "3L2",
-      "amplitude": 0.003984321815018092,
-      "phase": 330.7758593964258
+      "amplitude": 0.004,
+      "phase": 330.78
     },
     {
       "name": "3N2",
-      "amplitude": 0.015861388819817634,
-      "phase": 189.5744162527611
+      "amplitude": 0.016,
+      "phase": 189.57
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0325161038797736,
-      "phase": 355.70034822250904
+      "amplitude": 0.033,
+      "phase": 355.7
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08048137123527536,
-      "phase": 289.83471034238346
+      "amplitude": 0.08,
+      "phase": 289.83
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0038565301317332644,
-      "phase": 223.86662606787903
+      "amplitude": 0.004,
+      "phase": 223.87
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004256625069828314,
-      "phase": 118.3202751641968
+      "amplitude": 0.004,
+      "phase": 118.32
     }
   ],
   "epoch": {

--- a/data/ticon/l9_platform-l9pfm-nld-rws.json
+++ b/data/ticon/l9_platform-l9pfm-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.67513673,
-      "phase": 224.106811
+      "amplitude": 0.698,
+      "phase": 206.96
     },
     {
       "name": "N2",
-      "amplitude": 0.11500843,
-      "phase": 201.455565
+      "amplitude": 0.119,
+      "phase": 184.55
     },
     {
       "name": "S2",
-      "amplitude": 0.19520391,
-      "phase": 284.063237
+      "amplitude": 0.201,
+      "phase": 266.27
     },
     {
       "name": "K2",
-      "amplitude": 0.05406333,
-      "phase": 290.357686
+      "amplitude": 0.06,
+      "phase": 265.54
     },
     {
       "name": "2N2",
-      "amplitude": 0.015678110000000002,
-      "phase": 180.570131
+      "amplitude": 0.016,
+      "phase": 162.77
     },
     {
       "name": "S1",
-      "amplitude": 0.0047973,
-      "phase": 5.60705200000001
+      "amplitude": 0.007,
+      "phase": 287.15
     },
     {
       "name": "K1",
-      "amplitude": 0.0695486,
-      "phase": 357.816092
+      "amplitude": 0.069,
+      "phase": 348.91
     },
     {
       "name": "P1",
-      "amplitude": 0.02474833,
-      "phase": 350.407313
+      "amplitude": 0.025,
+      "phase": 344.59
     },
     {
       "name": "O1",
-      "amplitude": 0.08425884,
-      "phase": 201.256894
+      "amplitude": 0.084,
+      "phase": 193.21
     },
     {
       "name": "Q1",
-      "amplitude": 0.0298872,
-      "phase": 143.26399300000003
+      "amplitude": 0.03,
+      "phase": 135.11
     },
     {
       "name": "M1",
-      "amplitude": 0.0015540999999999999,
-      "phase": 343.879659
+      "amplitude": 0.002,
+      "phase": 52.1
     },
     {
       "name": "M4",
-      "amplitude": 0.05321343,
-      "phase": 318.480764
+      "amplitude": 0.063,
+      "phase": 279.58
     },
     {
       "name": "MM",
-      "amplitude": 0.0119077,
-      "phase": 195.9734
+      "amplitude": 0.012,
+      "phase": 192.89
     },
     {
       "name": "MF",
-      "amplitude": 0.013818200000000001,
-      "phase": 154.590595
+      "amplitude": 0.013,
+      "phase": 155.06
     },
     {
       "name": "SA",
-      "amplitude": 0.10283246,
-      "phase": 224.776895
+      "amplitude": 0.107,
+      "phase": 224.49
     },
     {
       "name": "SSA",
-      "amplitude": 0.023332850000000002,
-      "phase": 172.10715700000003
+      "amplitude": 0.025,
+      "phase": 171.61
     },
     {
       "name": "T2",
-      "amplitude": 0.03621816,
-      "phase": 197.347013
+      "amplitude": 0.01,
+      "phase": 247.05
     },
     {
       "name": "J1",
-      "amplitude": 0.00231744,
-      "phase": 83.33109300000001
+      "amplitude": 0.002,
+      "phase": 74.02
     },
     {
       "name": "L2",
-      "amplitude": 0.04588521,
-      "phase": 236.23047400000002
+      "amplitude": 0.047,
+      "phase": 216.49
     },
     {
       "name": "R2",
-      "amplitude": 0.02614767,
-      "phase": 24.46459299999998
+      "amplitude": 0.002,
+      "phase": 291.73
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00589374,
-      "phase": 77.05716699999999
+      "amplitude": 0.006,
+      "phase": 73.17
     },
     {
       "name": "MSF",
-      "amplitude": 0.00873845,
-      "phase": 50.25604900000002
+      "amplitude": 0.009,
+      "phase": 49.66
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00282693,
-      "phase": 113.11697600000002
+      "amplitude": 0.003,
+      "phase": 115.55
     },
     {
       "name": "EP2",
-      "amplitude": 0.01055456,
-      "phase": 295.165029
+      "amplitude": 0.01,
+      "phase": 275.4
     },
     {
       "name": "M3",
-      "amplitude": 0.00347586,
-      "phase": 341.048129
+      "amplitude": 0.004,
+      "phase": 134.82
     },
     {
       "name": "MU2",
-      "amplitude": 0.04477794,
-      "phase": 309.914036
+      "amplitude": 0.047,
+      "phase": 292.22
     },
     {
       "name": "MTM",
-      "amplitude": 0.0032737300000000003,
-      "phase": 239.969368
+      "amplitude": 0.003,
+      "phase": 235.72
     },
     {
       "name": "NU2",
-      "amplitude": 0.0340862,
-      "phase": 188.707683
+      "amplitude": 0.035,
+      "phase": 171.11
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02080162,
-      "phase": 227.650123
+      "amplitude": 0.022,
+      "phase": 208.92
     },
     {
       "name": "MN4",
-      "amplitude": 0.01766452,
-      "phase": 292.61420599999997
+      "amplitude": 0.021,
+      "phase": 255.54
     },
     {
       "name": "MS4",
-      "amplitude": 0.03395654,
-      "phase": 23.49560200000002
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.032586119999999996,
-      "phase": 357.728498
+      "amplitude": 0.04,
+      "phase": 347.14
     },
     {
       "name": "N4",
-      "amplitude": 0.00450839,
-      "phase": 267.523596
+      "amplitude": 0.005,
+      "phase": 230.93
     },
     {
       "name": "M6",
-      "amplitude": 0.03147809,
-      "phase": 26.879294000000016
+      "amplitude": 0.043,
+      "phase": 329.99
     },
     {
       "name": "M8",
-      "amplitude": 0.00332793,
-      "phase": 185.999018
+      "amplitude": 0.006,
+      "phase": 97.75
     },
     {
       "name": "S4",
-      "amplitude": 0.00343941,
-      "phase": 147.741739
+      "amplitude": 0.004,
+      "phase": 114.11
     },
     {
       "name": "OO1",
-      "amplitude": 0.00182978,
-      "phase": 160.065159
+      "amplitude": 0.003,
+      "phase": 133.44
     },
     {
       "name": "S3",
-      "amplitude": 0.00113896,
-      "phase": 269.053882
+      "amplitude": 0.001,
+      "phase": 67.47
     },
     {
       "name": "MA2",
-      "amplitude": 0.12025285999999999,
-      "phase": 197.331748
+      "amplitude": 0.015,
+      "phase": 154.54
     },
     {
       "name": "MB2",
-      "amplitude": 0.10527172,
-      "phase": 59.333822
+      "amplitude": 0.005,
+      "phase": 289.79
     },
     {
       "name": "T3",
-      "amplitude": 0.00102385,
-      "phase": 159.21967599999994
+      "amplitude": 0.001,
+      "phase": 329.41
     },
     {
       "name": "R3",
-      "amplitude": 0.0016578,
-      "phase": 141.93823299999997
+      "amplitude": 0.002,
+      "phase": 195.35
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00603576,
-      "phase": 145.21929999999998
+      "amplitude": 0.006,
+      "phase": 142.28
     },
     {
       "name": "SGM",
-      "amplitude": 0.0028103499999999997,
-      "phase": 237.676713
+      "amplitude": 0.003,
+      "phase": 52.28
     },
     {
       "name": "3L2",
-      "amplitude": 0.00473977,
-      "phase": 52.64963799999998
+      "amplitude": 0.004,
+      "phase": 114.36
     },
     {
       "name": "3N2",
-      "amplitude": 0.00152353,
-      "phase": 288.72007
+      "amplitude": 0.005,
+      "phase": 351.66
     },
     {
       "name": "2SM2",
-      "amplitude": 0.01463384,
-      "phase": 134.27378
+      "amplitude": 0.015,
+      "phase": 116.34
     },
     {
       "name": "2MS6",
-      "amplitude": 0.029128539999999998,
-      "phase": 85.232708
+      "amplitude": 0.039,
+      "phase": 28.55
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00271063,
-      "phase": 344.462146
+      "amplitude": 0.003,
+      "phase": 21.38
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00033725,
-      "phase": 171.09582
+      "amplitude": 0,
+      "phase": 31.85
     }
   ],
   "epoch": {

--- a/data/ticon/langballigau-9610015-deu-wsv.json
+++ b/data/ticon/langballigau-9610015-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.05195895168636015,
-      "phase": 112.78112336961527
+      "amplitude": 0.052,
+      "phase": 112.78
     },
     {
       "name": "N2",
-      "amplitude": 0.01507081257984736,
-      "phase": 61.277865921225896
+      "amplitude": 0.015,
+      "phase": 61.28
     },
     {
       "name": "S2",
-      "amplitude": 0.013427549551036628,
-      "phase": 50.07071429559585
+      "amplitude": 0.013,
+      "phase": 50.07
     },
     {
       "name": "K2",
-      "amplitude": 0.003264797368532422,
-      "phase": 28.394543431279658
+      "amplitude": 0.003,
+      "phase": 28.39
     },
     {
       "name": "2N2",
-      "amplitude": 0.0022267764247357277,
-      "phase": 30.365425929766673
+      "amplitude": 0.002,
+      "phase": 30.37
     },
     {
       "name": "S1",
-      "amplitude": 0.008683576010185268,
-      "phase": 193.17877056440173
+      "amplitude": 0.009,
+      "phase": 193.18
     },
     {
       "name": "K1",
-      "amplitude": 0.0215285587562102,
-      "phase": 211.00033089331518
+      "amplitude": 0.022,
+      "phase": 211
     },
     {
       "name": "P1",
-      "amplitude": 0.008340919278144976,
-      "phase": 241.90530281959025
+      "amplitude": 0.008,
+      "phase": 241.91
     },
     {
       "name": "O1",
-      "amplitude": 0.01787863435998357,
-      "phase": 105.90802737857666
+      "amplitude": 0.018,
+      "phase": 105.91
     },
     {
       "name": "Q1",
-      "amplitude": 0.0053073404141228755,
-      "phase": 305.6938736805218
+      "amplitude": 0.005,
+      "phase": 305.69
     },
     {
       "name": "M1",
-      "amplitude": 0.00020588895892136892,
-      "phase": 150.7871395169684
+      "amplitude": 0,
+      "phase": 150.79
     },
     {
       "name": "M4",
-      "amplitude": 0.002181400253981496,
-      "phase": 176.54424032630322
+      "amplitude": 0.002,
+      "phase": 176.54
     },
     {
       "name": "MM",
-      "amplitude": 0.011605182447564241,
-      "phase": 291.40693380700105
+      "amplitude": 0.012,
+      "phase": 291.41
     },
     {
       "name": "MF",
-      "amplitude": 0.010988185983945917,
-      "phase": 248.66327728845135
+      "amplitude": 0.011,
+      "phase": 248.66
     },
     {
       "name": "SA",
-      "amplitude": 0.036068026858850064,
-      "phase": 188.0940516683742
+      "amplitude": 0.036,
+      "phase": 188.09
     },
     {
       "name": "SSA",
-      "amplitude": 0.013827731687543962,
-      "phase": 284.53108160282176
+      "amplitude": 0.014,
+      "phase": 284.53
     },
     {
       "name": "T2",
-      "amplitude": 0.0008719977035273361,
-      "phase": 51.00817223762823
+      "amplitude": 0.001,
+      "phase": 51.01
     },
     {
       "name": "J1",
-      "amplitude": 0.0013729291220746917,
-      "phase": 135.08412905247167
+      "amplitude": 0.001,
+      "phase": 135.08
     },
     {
       "name": "L2",
-      "amplitude": 0.005016297482302836,
-      "phase": 214.1002516037324
+      "amplitude": 0.005,
+      "phase": 214.1
     },
     {
       "name": "R2",
-      "amplitude": 0.0010129525857907272,
-      "phase": 108.0567251808202
+      "amplitude": 0.001,
+      "phase": 108.06
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0015680328536706134,
-      "phase": 269.192370237375
+      "amplitude": 0.002,
+      "phase": 269.19
     },
     {
       "name": "MSF",
-      "amplitude": 0.002943450571987942,
-      "phase": 226.89662945471957
+      "amplitude": 0.003,
+      "phase": 226.9
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00498157506435189,
-      "phase": 221.08155054249556
+      "amplitude": 0.005,
+      "phase": 221.08
     },
     {
       "name": "EP2",
-      "amplitude": 0.002997845910711653,
-      "phase": 242.64108982192465
+      "amplitude": 0.003,
+      "phase": 242.64
     },
     {
       "name": "M3",
-      "amplitude": 0.00033438769645121696,
-      "phase": 348.59650907577054
+      "amplitude": 0,
+      "phase": 348.6
     },
     {
       "name": "MU2",
-      "amplitude": 0.012785116838995601,
-      "phase": 282.0118107511286
+      "amplitude": 0.013,
+      "phase": 282.01
     },
     {
       "name": "MTM",
-      "amplitude": 0.0037330472955908103,
-      "phase": 334.71550148299684
+      "amplitude": 0.004,
+      "phase": 334.72
     },
     {
       "name": "NU2",
-      "amplitude": 0.005631692286807747,
-      "phase": 98.6279746628307
+      "amplitude": 0.006,
+      "phase": 98.63
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.002923962359895084,
-      "phase": 206.1941020417367
+      "amplitude": 0.003,
+      "phase": 206.19
     },
     {
       "name": "MN4",
-      "amplitude": 0.0006770587910230343,
-      "phase": 116.2818687675952
+      "amplitude": 0.001,
+      "phase": 116.28
     },
     {
       "name": "MS4",
-      "amplitude": 0.00043583759528788486,
-      "phase": 314.48169718185056
+      "amplitude": 0,
+      "phase": 314.48
     },
     {
       "name": "N4",
-      "amplitude": 0.0001759949007977821,
-      "phase": 94.99177482516473
+      "amplitude": 0,
+      "phase": 94.99
     },
     {
       "name": "M6",
-      "amplitude": 0.0012522149402419613,
-      "phase": 175.1844834306221
+      "amplitude": 0.001,
+      "phase": 175.18
     },
     {
       "name": "M8",
-      "amplitude": 0.00004323595553286821,
-      "phase": 181.6902743223819
+      "amplitude": 0,
+      "phase": 181.69
     },
     {
       "name": "S4",
-      "amplitude": 0.0001672433594187177,
-      "phase": 265.31669122843914
+      "amplitude": 0,
+      "phase": 265.32
     },
     {
       "name": "OO1",
-      "amplitude": 0.0016397182448401179,
-      "phase": 121.35413031341955
+      "amplitude": 0.002,
+      "phase": 121.35
     },
     {
       "name": "S3",
-      "amplitude": 0.00028934755519314056,
-      "phase": 204.07621809054575
+      "amplitude": 0,
+      "phase": 204.08
     },
     {
       "name": "MA2",
-      "amplitude": 0.007837136439134295,
-      "phase": 104.98716414660873
+      "amplitude": 0.008,
+      "phase": 104.99
     },
     {
       "name": "MB2",
-      "amplitude": 0.00813195582141663,
-      "phase": 267.030813031904
+      "amplitude": 0.008,
+      "phase": 267.03
     },
     {
       "name": "T3",
-      "amplitude": 0.00011710967617469976,
-      "phase": 62.46541191105223
+      "amplitude": 0,
+      "phase": 62.47
     },
     {
       "name": "R3",
-      "amplitude": 0.00011015615724100061,
-      "phase": 205.5727184428855
+      "amplitude": 0,
+      "phase": 205.57
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0009993719082622297,
-      "phase": 259.7041652486388
+      "amplitude": 0.001,
+      "phase": 259.7
     },
     {
       "name": "SGM",
-      "amplitude": 0.003174123197095171,
-      "phase": 213.04596629687373
+      "amplitude": 0.003,
+      "phase": 213.05
     },
     {
       "name": "3L2",
-      "amplitude": 0.0006519586260584102,
-      "phase": 1.7036213993941374
+      "amplitude": 0.001,
+      "phase": 1.7
     },
     {
       "name": "3N2",
-      "amplitude": 0.0016072788539033835,
-      "phase": 17.146686669944813
+      "amplitude": 0.002,
+      "phase": 17.15
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0020140733841794768,
-      "phase": 170.24522756973454
+      "amplitude": 0.002,
+      "phase": 170.25
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0010898066047740611,
-      "phase": 278.3506653658452
+      "amplitude": 0.001,
+      "phase": 278.35
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0000721204054770758,
-      "phase": 292.01397824690156
+      "amplitude": 0,
+      "phase": 292.01
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00026979420175796283,
-      "phase": 135.6180644691088
+      "amplitude": 0,
+      "phase": 135.62
     }
   ],
   "epoch": {

--- a/data/ticon/langeoog-9390010-deu-wsv.json
+++ b/data/ticon/langeoog-9390010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.1872404472275275,
-      "phase": 298.95304564997133
+      "amplitude": 1.187,
+      "phase": 298.95
     },
     {
       "name": "N2",
-      "amplitude": 0.19123479161213228,
-      "phase": 274.18864547840826
+      "amplitude": 0.191,
+      "phase": 274.19
     },
     {
       "name": "S2",
-      "amplitude": 0.315627751848189,
-      "phase": 7.0442778662412024
+      "amplitude": 0.316,
+      "phase": 7.04
     },
     {
       "name": "K2",
-      "amplitude": 0.09445084599755413,
-      "phase": 4.96451693989377
+      "amplitude": 0.094,
+      "phase": 4.96
     },
     {
       "name": "2N2",
-      "amplitude": 0.021951865881101325,
-      "phase": 255.7602796370311
+      "amplitude": 0.022,
+      "phase": 255.76
     },
     {
       "name": "S1",
-      "amplitude": 0.007615581045793287,
-      "phase": 18.141677165593592
+      "amplitude": 0.008,
+      "phase": 18.14
     },
     {
       "name": "K1",
-      "amplitude": 0.06810398626046595,
-      "phase": 18.83504975711719
+      "amplitude": 0.068,
+      "phase": 18.84
     },
     {
       "name": "P1",
-      "amplitude": 0.0281100998524991,
-      "phase": 24.619168478162862
+      "amplitude": 0.028,
+      "phase": 24.62
     },
     {
       "name": "O1",
-      "amplitude": 0.08767814145435898,
-      "phase": 228.5475386670439
+      "amplitude": 0.088,
+      "phase": 228.55
     },
     {
       "name": "Q1",
-      "amplitude": 0.028153758790949435,
-      "phase": 170.6620231075931
+      "amplitude": 0.028,
+      "phase": 170.66
     },
     {
       "name": "M1",
-      "amplitude": 0.0016101352262804633,
-      "phase": 82.30612410658614
+      "amplitude": 0.002,
+      "phase": 82.31
     },
     {
       "name": "M4",
-      "amplitude": 0.014042729136837278,
-      "phase": 59.67458927452009
+      "amplitude": 0.014,
+      "phase": 59.67
     },
     {
       "name": "MM",
-      "amplitude": 0.024262983915651678,
-      "phase": 174.6652911059665
+      "amplitude": 0.024,
+      "phase": 174.67
     },
     {
       "name": "MF",
-      "amplitude": 0.01000462568628507,
-      "phase": 175.90577027039228
+      "amplitude": 0.01,
+      "phase": 175.91
     },
     {
       "name": "SA",
-      "amplitude": 0.10543703066586037,
-      "phase": 225.6559309810168
+      "amplitude": 0.105,
+      "phase": 225.66
     },
     {
       "name": "SSA",
-      "amplitude": 0.03715077945507707,
-      "phase": 207.87919714417103
+      "amplitude": 0.037,
+      "phase": 207.88
     },
     {
       "name": "T2",
-      "amplitude": 0.016523413812413967,
-      "phase": 344.0497967985363
+      "amplitude": 0.017,
+      "phase": 344.05
     },
     {
       "name": "J1",
-      "amplitude": 0.0013782978196952658,
-      "phase": 131.58427754491777
+      "amplitude": 0.001,
+      "phase": 131.58
     },
     {
       "name": "L2",
-      "amplitude": 0.09098021447595155,
-      "phase": 315.55035305547943
+      "amplitude": 0.091,
+      "phase": 315.55
     },
     {
       "name": "R2",
-      "amplitude": 0.00311439522470948,
-      "phase": 356.5339944273283
+      "amplitude": 0.003,
+      "phase": 356.53
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005707763527945112,
-      "phase": 116.18683069090673
+      "amplitude": 0.006,
+      "phase": 116.19
     },
     {
       "name": "MSF",
-      "amplitude": 0.005508309896695806,
-      "phase": 27.326498368690693
+      "amplitude": 0.006,
+      "phase": 27.33
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008629843824952,
-      "phase": 56.231123048637244
+      "amplitude": 0.009,
+      "phase": 56.23
     },
     {
       "name": "EP2",
-      "amplitude": 0.026112129416521284,
-      "phase": 6.718355418125668
+      "amplitude": 0.026,
+      "phase": 6.72
     },
     {
       "name": "M3",
-      "amplitude": 0.003921586499087103,
-      "phase": 298.9158290339963
+      "amplitude": 0.004,
+      "phase": 298.92
     },
     {
       "name": "MU2",
-      "amplitude": 0.11266911481354626,
-      "phase": 27.513692978548363
+      "amplitude": 0.113,
+      "phase": 27.51
     },
     {
       "name": "MTM",
-      "amplitude": 0.005214247781763598,
-      "phase": 246.13149144354838
+      "amplitude": 0.005,
+      "phase": 246.13
     },
     {
       "name": "NU2",
-      "amplitude": 0.06698098285989952,
-      "phase": 259.16805327875
+      "amplitude": 0.067,
+      "phase": 259.17
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.043296181660748737,
-      "phase": 309.80283353112594
+      "amplitude": 0.043,
+      "phase": 309.8
     },
     {
       "name": "MN4",
-      "amplitude": 0.004322512183873994,
-      "phase": 70.6813658272871
+      "amplitude": 0.004,
+      "phase": 70.68
     },
     {
       "name": "MS4",
-      "amplitude": 0.023089887348986517,
-      "phase": 134.9350590486065
+      "amplitude": 0.023,
+      "phase": 134.94
     },
     {
       "name": "N4",
-      "amplitude": 0.0014186629898359552,
-      "phase": 50.82509333776255
+      "amplitude": 0.001,
+      "phase": 50.83
     },
     {
       "name": "M6",
-      "amplitude": 0.05610286112697096,
-      "phase": 236.66457626719532
+      "amplitude": 0.056,
+      "phase": 236.66
     },
     {
       "name": "M8",
-      "amplitude": 0.012424844402002647,
-      "phase": 96.87412858148173
+      "amplitude": 0.012,
+      "phase": 96.87
     },
     {
       "name": "S4",
-      "amplitude": 0.00549068250920234,
-      "phase": 260.7710933163913
+      "amplitude": 0.005,
+      "phase": 260.77
     },
     {
       "name": "OO1",
-      "amplitude": 0.002468445526407071,
-      "phase": 181.88753154673338
+      "amplitude": 0.002,
+      "phase": 181.89
     },
     {
       "name": "S3",
-      "amplitude": 0.000643586254385807,
-      "phase": 104.11841030362297
+      "amplitude": 0.001,
+      "phase": 104.12
     },
     {
       "name": "MA2",
-      "amplitude": 0.03638071581979054,
-      "phase": 247.25646972640453
+      "amplitude": 0.036,
+      "phase": 247.26
     },
     {
       "name": "MB2",
-      "amplitude": 0.021374853089980293,
-      "phase": 27.031290243353908
+      "amplitude": 0.021,
+      "phase": 27.03
     },
     {
       "name": "T3",
-      "amplitude": 0.0006384012821600771,
-      "phase": 321.3424882021352
+      "amplitude": 0.001,
+      "phase": 321.34
     },
     {
       "name": "R3",
-      "amplitude": 0.003147875044513921,
-      "phase": 347.1464832102353
+      "amplitude": 0.003,
+      "phase": 347.15
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005600569560073723,
-      "phase": 175.632417903327
+      "amplitude": 0.006,
+      "phase": 175.63
     },
     {
       "name": "SGM",
-      "amplitude": 0.002249626389296171,
-      "phase": 48.36337370758349
+      "amplitude": 0.002,
+      "phase": 48.36
     },
     {
       "name": "3L2",
-      "amplitude": 0.00375369146273278,
-      "phase": 208.76685155067838
+      "amplitude": 0.004,
+      "phase": 208.77
     },
     {
       "name": "3N2",
-      "amplitude": 0.01357978455942652,
-      "phase": 96.31832327361019
+      "amplitude": 0.014,
+      "phase": 96.32
     },
     {
       "name": "2SM2",
-      "amplitude": 0.029182035018583807,
-      "phase": 226.17022450424565
+      "amplitude": 0.029,
+      "phase": 226.17
     },
     {
       "name": "2MS6",
-      "amplitude": 0.057571439705648285,
-      "phase": 300.95082930638875
+      "amplitude": 0.058,
+      "phase": 300.95
     },
     {
       "name": "2MK5",
-      "amplitude": 0.006375472365351296,
-      "phase": 236.28877532508952
+      "amplitude": 0.006,
+      "phase": 236.29
     },
     {
       "name": "2MO5",
-      "amplitude": 0.003264706551515319,
-      "phase": 71.41161424269586
+      "amplitude": 0.003,
+      "phase": 71.41
     }
   ],
   "epoch": {

--- a/data/ticon/lauterbach-9670063-deu-wsv.json
+++ b/data/ticon/lauterbach-9670063-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.015328649078721428,
-      "phase": 304.423503136828
+      "amplitude": 0.015,
+      "phase": 304.42
     },
     {
       "name": "N2",
-      "amplitude": 0.0046545232284927514,
-      "phase": 260.11725184738646
+      "amplitude": 0.005,
+      "phase": 260.12
     },
     {
       "name": "S2",
-      "amplitude": 0.004234678255715204,
-      "phase": 257.40908522112454
+      "amplitude": 0.004,
+      "phase": 257.41
     },
     {
       "name": "K2",
-      "amplitude": 0.0018347389940579259,
-      "phase": 248.57138896850233
+      "amplitude": 0.002,
+      "phase": 248.57
     },
     {
       "name": "2N2",
-      "amplitude": 0.0007521940788698126,
-      "phase": 274.3685126774619
+      "amplitude": 0.001,
+      "phase": 274.37
     },
     {
       "name": "S1",
-      "amplitude": 0.006796611311612762,
-      "phase": 33.62924183957546
+      "amplitude": 0.007,
+      "phase": 33.63
     },
     {
       "name": "K1",
-      "amplitude": 0.00794210156906258,
-      "phase": 150.85129360312948
+      "amplitude": 0.008,
+      "phase": 150.85
     },
     {
       "name": "P1",
-      "amplitude": 0.0015959550589620805,
-      "phase": 137.831521728261
+      "amplitude": 0.002,
+      "phase": 137.83
     },
     {
       "name": "O1",
-      "amplitude": 0.013723630687091449,
-      "phase": 144.09332609802726
+      "amplitude": 0.014,
+      "phase": 144.09
     },
     {
       "name": "Q1",
-      "amplitude": 0.0019094453249647039,
-      "phase": 106.12005503821314
+      "amplitude": 0.002,
+      "phase": 106.12
     },
     {
       "name": "M1",
-      "amplitude": 0.0006588071530999677,
-      "phase": 42.94368853149467
+      "amplitude": 0.001,
+      "phase": 42.94
     },
     {
       "name": "M4",
-      "amplitude": 0.0017163050719873946,
-      "phase": 356.7457987325814
+      "amplitude": 0.002,
+      "phase": 356.75
     },
     {
       "name": "MM",
-      "amplitude": 0.011897312536469062,
-      "phase": 281.35245299442283
+      "amplitude": 0.012,
+      "phase": 281.35
     },
     {
       "name": "MF",
-      "amplitude": 0.008660524928044038,
-      "phase": 272.39312279278704
+      "amplitude": 0.009,
+      "phase": 272.39
     },
     {
       "name": "SA",
-      "amplitude": 0.04197627874024733,
-      "phase": 197.4461092788513
+      "amplitude": 0.042,
+      "phase": 197.45
     },
     {
       "name": "SSA",
-      "amplitude": 0.03353188093136903,
-      "phase": 246.17494319083607
+      "amplitude": 0.034,
+      "phase": 246.17
     },
     {
       "name": "T2",
-      "amplitude": 0.0010588944177229117,
-      "phase": 239.2550139375951
+      "amplitude": 0.001,
+      "phase": 239.26
     },
     {
       "name": "J1",
-      "amplitude": 0.0007262475047498232,
-      "phase": 202.68776860639778
+      "amplitude": 0.001,
+      "phase": 202.69
     },
     {
       "name": "L2",
-      "amplitude": 0.0016906097788081025,
-      "phase": 64.99831578063618
+      "amplitude": 0.002,
+      "phase": 65
     },
     {
       "name": "R2",
-      "amplitude": 0.0006279298845058911,
-      "phase": 28.032492749965513
+      "amplitude": 0.001,
+      "phase": 28.03
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00018702838582560722,
-      "phase": 213.46731415572447
+      "amplitude": 0,
+      "phase": 213.47
     },
     {
       "name": "MSF",
-      "amplitude": 0.0009459064776218138,
-      "phase": 247.27235344578474
+      "amplitude": 0.001,
+      "phase": 247.27
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0038993352759483313,
-      "phase": 201.0143081353974
+      "amplitude": 0.004,
+      "phase": 201.01
     },
     {
       "name": "EP2",
-      "amplitude": 0.0007378944439563445,
-      "phase": 70.69361860468518
+      "amplitude": 0.001,
+      "phase": 70.69
     },
     {
       "name": "M3",
-      "amplitude": 0.000738026015195507,
-      "phase": 297.7982135847136
+      "amplitude": 0.001,
+      "phase": 297.8
     },
     {
       "name": "MU2",
-      "amplitude": 0.0028595497917338827,
-      "phase": 126.83995239177
+      "amplitude": 0.003,
+      "phase": 126.84
     },
     {
       "name": "MTM",
-      "amplitude": 0.0035468564689124416,
-      "phase": 344.30364817263404
+      "amplitude": 0.004,
+      "phase": 344.3
     },
     {
       "name": "NU2",
-      "amplitude": 0.001367400787122325,
-      "phase": 305.50688111192574
+      "amplitude": 0.001,
+      "phase": 305.51
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0008138563239374826,
-      "phase": 54.39501159910333
+      "amplitude": 0.001,
+      "phase": 54.4
     },
     {
       "name": "MN4",
-      "amplitude": 0.0006843982695296677,
-      "phase": 289.6859257188719
+      "amplitude": 0.001,
+      "phase": 289.69
     },
     {
       "name": "MS4",
-      "amplitude": 0.000783486138142672,
-      "phase": 162.91369932634768
+      "amplitude": 0.001,
+      "phase": 162.91
     },
     {
       "name": "N4",
-      "amplitude": 0.00008222075814743505,
-      "phase": 205.8501828574655
+      "amplitude": 0,
+      "phase": 205.85
     },
     {
       "name": "M6",
-      "amplitude": 0.00014275095898579965,
-      "phase": 180.1070717323872
+      "amplitude": 0,
+      "phase": 180.11
     },
     {
       "name": "M8",
-      "amplitude": 0.000014403414024430773,
-      "phase": 257.85042186131096
+      "amplitude": 0,
+      "phase": 257.85
     },
     {
       "name": "S4",
-      "amplitude": 0.00006114229468942928,
-      "phase": 86.64704793251275
+      "amplitude": 0,
+      "phase": 86.65
     },
     {
       "name": "OO1",
-      "amplitude": 0.0005218640464481981,
-      "phase": 92.66111766590996
+      "amplitude": 0.001,
+      "phase": 92.66
     },
     {
       "name": "S3",
-      "amplitude": 0.0008546263326761897,
-      "phase": 357.70343869401046
+      "amplitude": 0.001,
+      "phase": 357.7
     },
     {
       "name": "MA2",
-      "amplitude": 0.0012642233922956576,
-      "phase": 315.3530244623006
+      "amplitude": 0.001,
+      "phase": 315.35
     },
     {
       "name": "MB2",
-      "amplitude": 0.0017735545114919641,
-      "phase": 79.99024429243559
+      "amplitude": 0.002,
+      "phase": 79.99
     },
     {
       "name": "T3",
-      "amplitude": 0.0008126603813335618,
-      "phase": 259.5796372781775
+      "amplitude": 0.001,
+      "phase": 259.58
     },
     {
       "name": "R3",
-      "amplitude": 0.0008349953119615173,
-      "phase": 4.743247079531841
+      "amplitude": 0.001,
+      "phase": 4.74
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00004550485091575924,
-      "phase": 257.78298593900774
+      "amplitude": 0,
+      "phase": 257.78
     },
     {
       "name": "SGM",
-      "amplitude": 0.0011334411196575753,
-      "phase": 233.26287221012785
+      "amplitude": 0.001,
+      "phase": 233.26
     },
     {
       "name": "3L2",
-      "amplitude": 0.00027088979970485216,
-      "phase": 242.0936045486897
+      "amplitude": 0,
+      "phase": 242.09
     },
     {
       "name": "3N2",
-      "amplitude": 0.0004281292626507533,
-      "phase": 221.577425318675
+      "amplitude": 0,
+      "phase": 221.58
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0007490385480079524,
-      "phase": 41.07076697080714
+      "amplitude": 0.001,
+      "phase": 41.07
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0001135950064068445,
-      "phase": 271.23339903895413
+      "amplitude": 0,
+      "phase": 271.23
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00009355559569442972,
-      "phase": 355.3548733111546
+      "amplitude": 0,
+      "phase": 355.35
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00002880616998736008,
-      "phase": 293.764745635205
+      "amplitude": 0,
+      "phase": 293.76
     }
   ],
   "epoch": {

--- a/data/ticon/lauwersoog-lauwog-nld-rws.json
+++ b/data/ticon/lauwersoog-lauwog-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.0052781899999998,
-      "phase": 263.620989
+      "amplitude": 1.049,
+      "phase": 251.6
     },
     {
       "name": "N2",
-      "amplitude": 0.16346682,
-      "phase": 238.71248
+      "amplitude": 0.172,
+      "phase": 228.22
     },
     {
       "name": "S2",
-      "amplitude": 0.27108077,
-      "phase": 328.266966
+      "amplitude": 0.281,
+      "phase": 315.89
     },
     {
       "name": "K2",
-      "amplitude": 0.07469350999999999,
-      "phase": 330.080668
+      "amplitude": 0.081,
+      "phase": 314.54
     },
     {
       "name": "2N2",
-      "amplitude": 0.02176077,
-      "phase": 207.476585
+      "amplitude": 0.024,
+      "phase": 198.47
     },
     {
       "name": "S1",
-      "amplitude": 0.00746254,
-      "phase": 22.431691
+      "amplitude": 0.009,
+      "phase": 335.7
     },
     {
       "name": "K1",
-      "amplitude": 0.06755745,
-      "phase": 10.372148999999979
+      "amplitude": 0.068,
+      "phase": 4.06
     },
     {
       "name": "P1",
-      "amplitude": 0.0279271,
-      "phase": 10.095745000000022
+      "amplitude": 0.029,
+      "phase": 4.75
     },
     {
       "name": "O1",
-      "amplitude": 0.08793402,
-      "phase": 215.944135
+      "amplitude": 0.088,
+      "phase": 210.63
     },
     {
       "name": "Q1",
-      "amplitude": 0.02990725,
-      "phase": 161.27095600000007
+      "amplitude": 0.03,
+      "phase": 155.72
     },
     {
       "name": "M1",
-      "amplitude": 0.00156978,
-      "phase": 219.947669
+      "amplitude": 0.001,
+      "phase": 20.11
     },
     {
       "name": "M4",
-      "amplitude": 0.09131689,
-      "phase": 355.397677
+      "amplitude": 0.109,
+      "phase": 331.78
     },
     {
       "name": "MM",
-      "amplitude": 0.018831379999999998,
-      "phase": 148.76711899999998
+      "amplitude": 0.019,
+      "phase": 145.58
     },
     {
       "name": "MF",
-      "amplitude": 0.009782560000000001,
-      "phase": 186.110071
+      "amplitude": 0.01,
+      "phase": 188.78
     },
     {
       "name": "SA",
-      "amplitude": 0.10715572,
-      "phase": 226.482849
+      "amplitude": 0.121,
+      "phase": 226.67
     },
     {
       "name": "SSA",
-      "amplitude": 0.04493277,
-      "phase": 185.23556
+      "amplitude": 0.047,
+      "phase": 174.18
     },
     {
       "name": "T2",
-      "amplitude": 0.04175698,
-      "phase": 246.443275
+      "amplitude": 0.009,
+      "phase": 272.16
     },
     {
       "name": "J1",
-      "amplitude": 0.00214871,
-      "phase": 104.75100099999997
+      "amplitude": 0.002,
+      "phase": 100.86
     },
     {
       "name": "L2",
-      "amplitude": 0.07293695,
-      "phase": 277.048904
+      "amplitude": 0.076,
+      "phase": 265.73
     },
     {
       "name": "R2",
-      "amplitude": 0.02268023,
-      "phase": 84.20908099999997
+      "amplitude": 0.003,
+      "phase": 176.04
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00625182,
-      "phase": 87.23950300000001
+      "amplitude": 0.006,
+      "phase": 87.79
     },
     {
       "name": "MSF",
-      "amplitude": 0.01961573,
-      "phase": 46.50614999999999
+      "amplitude": 0.02,
+      "phase": 47.75
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0075768,
-      "phase": 22.014055999999982
+      "amplitude": 0.008,
+      "phase": 23.08
     },
     {
       "name": "EP2",
-      "amplitude": 0.01681432,
-      "phase": 331.092592
+      "amplitude": 0.018,
+      "phase": 318.21
     },
     {
       "name": "M3",
-      "amplitude": 0.00453603,
-      "phase": 59.105181000000016
+      "amplitude": 0.005,
+      "phase": 222.83
     },
     {
       "name": "MU2",
-      "amplitude": 0.08861977,
-      "phase": 355.049626
+      "amplitude": 0.091,
+      "phase": 342.83
     },
     {
       "name": "MTM",
-      "amplitude": 0.012059750000000001,
-      "phase": 240.456102
+      "amplitude": 0.011,
+      "phase": 231.22
     },
     {
       "name": "NU2",
-      "amplitude": 0.053329579999999994,
-      "phase": 227.165531
+      "amplitude": 0.057,
+      "phase": 213.14
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03399414,
-      "phase": 265.866614
+      "amplitude": 0.038,
+      "phase": 256.38
     },
     {
       "name": "MN4",
-      "amplitude": 0.02960232,
-      "phase": 329.288285
+      "amplitude": 0.036,
+      "phase": 306.03
     },
     {
       "name": "MS4",
-      "amplitude": 0.060041729999999995,
-      "phase": 71.29208299999999
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03291835,
-      "phase": 63.28313400000002
+      "amplitude": 0.071,
+      "phase": 49.21
     },
     {
       "name": "N4",
-      "amplitude": 0.007760479999999999,
-      "phase": 311.404847
+      "amplitude": 0.01,
+      "phase": 287.02
     },
     {
       "name": "M6",
-      "amplitude": 0.028072620000000003,
-      "phase": 156.382155
+      "amplitude": 0.039,
+      "phase": 123.25
     },
     {
       "name": "M8",
-      "amplitude": 0.0042654599999999996,
-      "phase": 345.248886
+      "amplitude": 0.008,
+      "phase": 311.99
     },
     {
       "name": "S4",
-      "amplitude": 0.00799762,
-      "phase": 210.981234
+      "amplitude": 0.008,
+      "phase": 190.33
     },
     {
       "name": "OO1",
-      "amplitude": 0.0021122199999999997,
-      "phase": 127.73306500000001
+      "amplitude": 0.003,
+      "phase": 120.26
     },
     {
       "name": "S3",
-      "amplitude": 0.0005844499999999999,
-      "phase": 93.22901999999999
+      "amplitude": 0,
+      "phase": 242.63
     },
     {
       "name": "MA2",
-      "amplitude": 0.15121621,
-      "phase": 239.354718
+      "amplitude": 0.042,
+      "phase": 192.57
     },
     {
       "name": "MB2",
-      "amplitude": 0.11706541,
-      "phase": 102.91778699999998
+      "amplitude": 0.005,
+      "phase": 293.36
     },
     {
       "name": "T3",
-      "amplitude": 0.0015508800000000001,
-      "phase": 169.44379200000003
+      "amplitude": 0.002,
+      "phase": 335.01
     },
     {
       "name": "R3",
-      "amplitude": 0.00266418,
-      "phase": 234.465576
+      "amplitude": 0.003,
+      "phase": 295.68
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006074199999999999,
-      "phase": 140.95238800000004
+      "amplitude": 0.006,
+      "phase": 137.79
     },
     {
       "name": "SGM",
-      "amplitude": 0.00367368,
-      "phase": 268.454636
+      "amplitude": 0.003,
+      "phase": 87.39
     },
     {
       "name": "3L2",
-      "amplitude": 0.0092655,
-      "phase": 51.26489800000002
+      "amplitude": 0.007,
+      "phase": 158.79
     },
     {
       "name": "3N2",
-      "amplitude": 0.011685939999999999,
-      "phase": 160.64146600000004
+      "amplitude": 0.014,
+      "phase": 78.02
     },
     {
       "name": "2SM2",
-      "amplitude": 0.023986610000000002,
-      "phase": 181.296858
+      "amplitude": 0.025,
+      "phase": 171.61
     },
     {
       "name": "2MS6",
-      "amplitude": 0.026594470000000002,
-      "phase": 216.179484
+      "amplitude": 0.037,
+      "phase": 181.32
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00533922,
-      "phase": 105.804438
+      "amplitude": 0.007,
+      "phase": 159.02
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0017847499999999999,
-      "phase": 108.94826
+      "amplitude": 0.003,
+      "phase": 1.38
     }
   ],
   "epoch": {

--- a/data/ticon/lbeckbauhof-9620090-deu-wsv.json
+++ b/data/ticon/lbeckbauhof-9620090-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.06981129304378482,
-      "phase": 169.59662623644317
+      "amplitude": 0.07,
+      "phase": 169.6
     },
     {
       "name": "N2",
-      "amplitude": 0.015587106329081774,
-      "phase": 108.89766525990274
+      "amplitude": 0.016,
+      "phase": 108.9
     },
     {
       "name": "S2",
-      "amplitude": 0.01352153921673947,
-      "phase": 150.3946290704905
+      "amplitude": 0.014,
+      "phase": 150.39
     },
     {
       "name": "K2",
-      "amplitude": 0.0033987348740218276,
-      "phase": 141.13921416960136
+      "amplitude": 0.003,
+      "phase": 141.14
     },
     {
       "name": "2N2",
-      "amplitude": 0.0018074145665282699,
-      "phase": 67.99889074454762
+      "amplitude": 0.002,
+      "phase": 68
     },
     {
       "name": "S1",
-      "amplitude": 0.0050947283034045625,
-      "phase": 115.068996063692
+      "amplitude": 0.005,
+      "phase": 115.07
     },
     {
       "name": "K1",
-      "amplitude": 0.014269772332160025,
-      "phase": 194.41659520932478
+      "amplitude": 0.014,
+      "phase": 194.42
     },
     {
       "name": "P1",
-      "amplitude": 0.002874376098392518,
-      "phase": 231.26827042716303
+      "amplitude": 0.003,
+      "phase": 231.27
     },
     {
       "name": "O1",
-      "amplitude": 0.019067579907728022,
-      "phase": 121.70658194720977
+      "amplitude": 0.019,
+      "phase": 121.71
     },
     {
       "name": "Q1",
-      "amplitude": 0.0024117464439876012,
-      "phase": 339.6992512567788
+      "amplitude": 0.002,
+      "phase": 339.7
     },
     {
       "name": "M1",
-      "amplitude": 0.0003869375793530179,
-      "phase": 16.001282012047227
+      "amplitude": 0,
+      "phase": 16
     },
     {
       "name": "M4",
-      "amplitude": 0.002891492136571131,
-      "phase": 354.7782768744406
+      "amplitude": 0.003,
+      "phase": 354.78
     },
     {
       "name": "MM",
-      "amplitude": 0.012234616632585458,
-      "phase": 301.3991195342738
+      "amplitude": 0.012,
+      "phase": 301.4
     },
     {
       "name": "MF",
-      "amplitude": 0.010160095364133929,
-      "phase": 259.5242257160291
+      "amplitude": 0.01,
+      "phase": 259.52
     },
     {
       "name": "SA",
-      "amplitude": 0.02988699684835523,
-      "phase": 156.57638262787464
+      "amplitude": 0.03,
+      "phase": 156.58
     },
     {
       "name": "SSA",
-      "amplitude": 0.01951453155246133,
-      "phase": 274.5045580501131
+      "amplitude": 0.02,
+      "phase": 274.5
     },
     {
       "name": "T2",
-      "amplitude": 0.0010485987783604152,
-      "phase": 119.55178617187465
+      "amplitude": 0.001,
+      "phase": 119.55
     },
     {
       "name": "J1",
-      "amplitude": 0.0009907117019764759,
-      "phase": 152.659416446754
+      "amplitude": 0.001,
+      "phase": 152.66
     },
     {
       "name": "L2",
-      "amplitude": 0.006564009863535867,
-      "phase": 261.80630918536224
+      "amplitude": 0.007,
+      "phase": 261.81
     },
     {
       "name": "R2",
-      "amplitude": 0.0008816806425976132,
-      "phase": 204.13015906276922
+      "amplitude": 0.001,
+      "phase": 204.13
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0008195317988124982,
-      "phase": 264.5211722536244
+      "amplitude": 0.001,
+      "phase": 264.52
     },
     {
       "name": "MSF",
-      "amplitude": 0.0029057712997441264,
-      "phase": 234.79389373872755
+      "amplitude": 0.003,
+      "phase": 234.79
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004291251059246842,
-      "phase": 203.94950482137614
+      "amplitude": 0.004,
+      "phase": 203.95
     },
     {
       "name": "EP2",
-      "amplitude": 0.003365534780548849,
-      "phase": 272.5226777921415
+      "amplitude": 0.003,
+      "phase": 272.52
     },
     {
       "name": "M3",
-      "amplitude": 0.0007859688490791464,
-      "phase": 1.6221460783603447
+      "amplitude": 0.001,
+      "phase": 1.62
     },
     {
       "name": "MU2",
-      "amplitude": 0.013065797821103401,
-      "phase": 316.3917956333115
+      "amplitude": 0.013,
+      "phase": 316.39
     },
     {
       "name": "MTM",
-      "amplitude": 0.003834058450437129,
-      "phase": 353.1355733529981
+      "amplitude": 0.004,
+      "phase": 353.14
     },
     {
       "name": "NU2",
-      "amplitude": 0.0050741913419804306,
-      "phase": 147.48012574101165
+      "amplitude": 0.005,
+      "phase": 147.48
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0033612052400389214,
-      "phase": 259.47449609065177
+      "amplitude": 0.003,
+      "phase": 259.47
     },
     {
       "name": "MN4",
-      "amplitude": 0.0009528670529148167,
-      "phase": 282.8997824983654
+      "amplitude": 0.001,
+      "phase": 282.9
     },
     {
       "name": "MS4",
-      "amplitude": 0.0008750154220311479,
-      "phase": 161.4024107645513
+      "amplitude": 0.001,
+      "phase": 161.4
     },
     {
       "name": "N4",
-      "amplitude": 0.00013302984443939718,
-      "phase": 208.0568498244216
+      "amplitude": 0,
+      "phase": 208.06
     },
     {
       "name": "M6",
-      "amplitude": 0.001698455808396552,
-      "phase": 303.80338341420065
+      "amplitude": 0.002,
+      "phase": 303.8
     },
     {
       "name": "M8",
-      "amplitude": 0.00007876708491073408,
-      "phase": 185.94916731045873
+      "amplitude": 0,
+      "phase": 185.95
     },
     {
       "name": "S4",
-      "amplitude": 0.00017255505109429046,
-      "phase": 249.93459889996865
+      "amplitude": 0,
+      "phase": 249.93
     },
     {
       "name": "OO1",
-      "amplitude": 0.0014602682227847319,
-      "phase": 144.31908851533365
+      "amplitude": 0.001,
+      "phase": 144.32
     },
     {
       "name": "S3",
-      "amplitude": 0.0011484413670213107,
-      "phase": 40.535416536678554
+      "amplitude": 0.001,
+      "phase": 40.54
     },
     {
       "name": "MA2",
-      "amplitude": 0.006789456642936471,
-      "phase": 127.83449705948311
+      "amplitude": 0.007,
+      "phase": 127.83
     },
     {
       "name": "MB2",
-      "amplitude": 0.007765509189702864,
-      "phase": 295.2462093566069
+      "amplitude": 0.008,
+      "phase": 295.25
     },
     {
       "name": "T3",
-      "amplitude": 0.0013703290374925104,
-      "phase": 299.82643029077485
+      "amplitude": 0.001,
+      "phase": 299.83
     },
     {
       "name": "R3",
-      "amplitude": 0.0013441081555287037,
-      "phase": 40.493626877024894
+      "amplitude": 0.001,
+      "phase": 40.49
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0004563689768060968,
-      "phase": 274.45112360631344
+      "amplitude": 0,
+      "phase": 274.45
     },
     {
       "name": "SGM",
-      "amplitude": 0.002606091755278597,
-      "phase": 225.90160747446637
+      "amplitude": 0.003,
+      "phase": 225.9
     },
     {
       "name": "3L2",
-      "amplitude": 0.00008776936428359551,
-      "phase": 48.58698927147924
+      "amplitude": 0,
+      "phase": 48.59
     },
     {
       "name": "3N2",
-      "amplitude": 0.0013739153205929613,
-      "phase": 50.23001420460446
+      "amplitude": 0.001,
+      "phase": 50.23
     },
     {
       "name": "2SM2",
-      "amplitude": 0.002106008174150308,
-      "phase": 260.7639855425938
+      "amplitude": 0.002,
+      "phase": 260.76
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0013569778040486463,
-      "phase": 45.81958980610011
+      "amplitude": 0.001,
+      "phase": 45.82
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00021970819708369012,
-      "phase": 22.962632513191124
+      "amplitude": 0,
+      "phase": 22.96
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0005991811961810016,
-      "phase": 195.14285938062955
+      "amplitude": 0.001,
+      "phase": 195.14
     }
   ],
   "epoch": {

--- a/data/ticon/ledasperrwerkup-3880050-deu-wsv.json
+++ b/data/ticon/ledasperrwerkup-3880050-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4390072406868966,
-      "phase": 341.446592273903
+      "amplitude": 1.439,
+      "phase": 341.45
     },
     {
       "name": "N2",
-      "amplitude": 0.2190958791673983,
-      "phase": 318.8820561169969
+      "amplitude": 0.219,
+      "phase": 318.88
     },
     {
       "name": "S2",
-      "amplitude": 0.3477695435168386,
-      "phase": 59.93615100234314
+      "amplitude": 0.348,
+      "phase": 59.94
     },
     {
       "name": "K2",
-      "amplitude": 0.10211071356819419,
-      "phase": 59.0106930664831
+      "amplitude": 0.102,
+      "phase": 59.01
     },
     {
       "name": "2N2",
-      "amplitude": 0.019499560889905246,
-      "phase": 306.59288066561857
+      "amplitude": 0.019,
+      "phase": 306.59
     },
     {
       "name": "S1",
-      "amplitude": 0.018406217323411682,
-      "phase": 90.05046041280843
+      "amplitude": 0.018,
+      "phase": 90.05
     },
     {
       "name": "K1",
-      "amplitude": 0.07370786386191845,
-      "phase": 52.016489937738584
+      "amplitude": 0.074,
+      "phase": 52.02
     },
     {
       "name": "P1",
-      "amplitude": 0.03000940608453698,
-      "phase": 45.531262521809026
+      "amplitude": 0.03,
+      "phase": 45.53
     },
     {
       "name": "O1",
-      "amplitude": 0.08552312710882334,
-      "phase": 256.11435929383623
+      "amplitude": 0.086,
+      "phase": 256.11
     },
     {
       "name": "Q1",
-      "amplitude": 0.024281826521022738,
-      "phase": 191.5551839405639
+      "amplitude": 0.024,
+      "phase": 191.56
     },
     {
       "name": "M1",
-      "amplitude": 0.002551541154718598,
-      "phase": 110.08161980086618
+      "amplitude": 0.003,
+      "phase": 110.08
     },
     {
       "name": "M4",
-      "amplitude": 0.1569058412453152,
-      "phase": 199.89403963864166
+      "amplitude": 0.157,
+      "phase": 199.89
     },
     {
       "name": "MM",
-      "amplitude": 0.016238763370204645,
-      "phase": 69.9454431163042
+      "amplitude": 0.016,
+      "phase": 69.95
     },
     {
       "name": "MF",
-      "amplitude": 0.007061295893631987,
-      "phase": 61.036590096538305
+      "amplitude": 0.007,
+      "phase": 61.04
     },
     {
       "name": "SA",
-      "amplitude": 0.07434512724203282,
-      "phase": 249.941000252481
+      "amplitude": 0.074,
+      "phase": 249.94
     },
     {
       "name": "SSA",
-      "amplitude": 0.03791856759456106,
-      "phase": 240.45912037868004
+      "amplitude": 0.038,
+      "phase": 240.46
     },
     {
       "name": "T2",
-      "amplitude": 0.021112070767330467,
-      "phase": 1.21198794607011
+      "amplitude": 0.021,
+      "phase": 1.21
     },
     {
       "name": "J1",
-      "amplitude": 0.0052294703849187114,
-      "phase": 164.06727356522333
+      "amplitude": 0.005,
+      "phase": 164.07
     },
     {
       "name": "L2",
-      "amplitude": 0.13628508340857273,
-      "phase": 353.39621289150756
+      "amplitude": 0.136,
+      "phase": 353.4
     },
     {
       "name": "R2",
-      "amplitude": 0.014808698711922193,
-      "phase": 192.60806099032166
+      "amplitude": 0.015,
+      "phase": 192.61
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0036598639904196584,
-      "phase": 132.90248072917456
+      "amplitude": 0.004,
+      "phase": 132.9
     },
     {
       "name": "MSF",
-      "amplitude": 0.0525971236335637,
-      "phase": 43.07447141813401
+      "amplitude": 0.053,
+      "phase": 43.07
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0050722257677024785,
-      "phase": 34.92509715909307
+      "amplitude": 0.005,
+      "phase": 34.93
     },
     {
       "name": "EP2",
-      "amplitude": 0.039816249131821635,
-      "phase": 49.49739305694959
+      "amplitude": 0.04,
+      "phase": 49.5
     },
     {
       "name": "M3",
-      "amplitude": 0.003992205860890601,
-      "phase": 29.08360812139398
+      "amplitude": 0.004,
+      "phase": 29.08
     },
     {
       "name": "MU2",
-      "amplitude": 0.18905348481992024,
-      "phase": 65.08006227192595
+      "amplitude": 0.189,
+      "phase": 65.08
     },
     {
       "name": "MTM",
-      "amplitude": 0.005383152695928963,
-      "phase": 19.152338312957795
+      "amplitude": 0.005,
+      "phase": 19.15
     },
     {
       "name": "NU2",
-      "amplitude": 0.09550520987549738,
-      "phase": 292.96440235505776
+      "amplitude": 0.096,
+      "phase": 292.96
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06283271424114883,
-      "phase": 355.64437990339417
+      "amplitude": 0.063,
+      "phase": 355.64
     },
     {
       "name": "MN4",
-      "amplitude": 0.04997868406667952,
-      "phase": 175.8759326789966
+      "amplitude": 0.05,
+      "phase": 175.88
     },
     {
       "name": "MS4",
-      "amplitude": 0.09504241819317878,
-      "phase": 282.8481258682876
+      "amplitude": 0.095,
+      "phase": 282.85
     },
     {
       "name": "N4",
-      "amplitude": 0.009191136172683814,
-      "phase": 159.79550144723203
+      "amplitude": 0.009,
+      "phase": 159.8
     },
     {
       "name": "M6",
-      "amplitude": 0.0927491161437319,
-      "phase": 41.93449495720279
+      "amplitude": 0.093,
+      "phase": 41.93
     },
     {
       "name": "M8",
-      "amplitude": 0.029334952076920738,
-      "phase": 267.00474456981783
+      "amplitude": 0.029,
+      "phase": 267
     },
     {
       "name": "S4",
-      "amplitude": 0.009835771233238642,
-      "phase": 80.65319441577572
+      "amplitude": 0.01,
+      "phase": 80.65
     },
     {
       "name": "OO1",
-      "amplitude": 0.0027761608248503644,
-      "phase": 191.43140432633666
+      "amplitude": 0.003,
+      "phase": 191.43
     },
     {
       "name": "S3",
-      "amplitude": 0.0020328067974683408,
-      "phase": 309.5675965309022
+      "amplitude": 0.002,
+      "phase": 309.57
     },
     {
       "name": "MA2",
-      "amplitude": 0.07855466153348095,
-      "phase": 295.356062415214
+      "amplitude": 0.079,
+      "phase": 295.36
     },
     {
       "name": "MB2",
-      "amplitude": 0.04753371517931941,
-      "phase": 176.64522521631034
+      "amplitude": 0.048,
+      "phase": 176.65
     },
     {
       "name": "T3",
-      "amplitude": 0.0004554888595569306,
-      "phase": 6.340768292964583
+      "amplitude": 0,
+      "phase": 6.34
     },
     {
       "name": "R3",
-      "amplitude": 0.007543969630181809,
-      "phase": 28.760841428444337
+      "amplitude": 0.008,
+      "phase": 28.76
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006198088625006794,
-      "phase": 222.14301520153748
+      "amplitude": 0.006,
+      "phase": 222.14
     },
     {
       "name": "SGM",
-      "amplitude": 0.006639138760872395,
-      "phase": 53.825584322763916
+      "amplitude": 0.007,
+      "phase": 53.83
     },
     {
       "name": "3L2",
-      "amplitude": 0.002184554857358178,
-      "phase": 272.7684435371801
+      "amplitude": 0.002,
+      "phase": 272.77
     },
     {
       "name": "3N2",
-      "amplitude": 0.026903874891706845,
-      "phase": 129.4181258942251
+      "amplitude": 0.027,
+      "phase": 129.42
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03789230511106725,
-      "phase": 280.63976827168955
+      "amplitude": 0.038,
+      "phase": 280.64
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0855339545111439,
-      "phase": 114.8071090340577
+      "amplitude": 0.086,
+      "phase": 114.81
     },
     {
       "name": "2MK5",
-      "amplitude": 0.01178010239936863,
-      "phase": 71.28118645936212
+      "amplitude": 0.012,
+      "phase": 71.28
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00789481708395333,
-      "phase": 282.1695718170036
+      "amplitude": 0.008,
+      "phase": 282.17
     }
   ],
   "epoch": {

--- a/data/ticon/leerort-3910010-deu-wsv.json
+++ b/data/ticon/leerort-3910010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.5035523619285542,
-      "phase": 337.90012690446713
+      "amplitude": 1.504,
+      "phase": 337.9
     },
     {
       "name": "N2",
-      "amplitude": 0.23062646042916018,
-      "phase": 315.8779369125165
+      "amplitude": 0.231,
+      "phase": 315.88
     },
     {
       "name": "S2",
-      "amplitude": 0.3661537368185416,
-      "phase": 56.311660229677955
+      "amplitude": 0.366,
+      "phase": 56.31
     },
     {
       "name": "K2",
-      "amplitude": 0.10774557779138054,
-      "phase": 55.131334499595084
+      "amplitude": 0.108,
+      "phase": 55.13
     },
     {
       "name": "2N2",
-      "amplitude": 0.02246640601602865,
-      "phase": 300.66901419680545
+      "amplitude": 0.022,
+      "phase": 300.67
     },
     {
       "name": "S1",
-      "amplitude": 0.01747619816367302,
-      "phase": 76.35855975499715
+      "amplitude": 0.017,
+      "phase": 76.36
     },
     {
       "name": "K1",
-      "amplitude": 0.07426011359140683,
-      "phase": 49.39089964012055
+      "amplitude": 0.074,
+      "phase": 49.39
     },
     {
       "name": "P1",
-      "amplitude": 0.03263542581041611,
-      "phase": 46.521437060769074
+      "amplitude": 0.033,
+      "phase": 46.52
     },
     {
       "name": "O1",
-      "amplitude": 0.08803064874576551,
-      "phase": 254.31103981837867
+      "amplitude": 0.088,
+      "phase": 254.31
     },
     {
       "name": "Q1",
-      "amplitude": 0.02511984047056316,
-      "phase": 191.57660111684743
+      "amplitude": 0.025,
+      "phase": 191.58
     },
     {
       "name": "M1",
-      "amplitude": 0.002531112113453013,
-      "phase": 113.4251469325045
+      "amplitude": 0.003,
+      "phase": 113.43
     },
     {
       "name": "M4",
-      "amplitude": 0.1608193015757256,
-      "phase": 187.32599968361438
+      "amplitude": 0.161,
+      "phase": 187.33
     },
     {
       "name": "MM",
-      "amplitude": 0.01354930274818856,
-      "phase": 88.37982681284313
+      "amplitude": 0.014,
+      "phase": 88.38
     },
     {
       "name": "MF",
-      "amplitude": 0.0063958009034456725,
-      "phase": 68.29960005330167
+      "amplitude": 0.006,
+      "phase": 68.3
     },
     {
       "name": "SA",
-      "amplitude": 0.0787428236314754,
-      "phase": 250.92531225323597
+      "amplitude": 0.079,
+      "phase": 250.93
     },
     {
       "name": "SSA",
-      "amplitude": 0.03805334044092293,
-      "phase": 241.6888852383005
+      "amplitude": 0.038,
+      "phase": 241.69
     },
     {
       "name": "T2",
-      "amplitude": 0.020646335714774953,
-      "phase": 1.8431030602274063
+      "amplitude": 0.021,
+      "phase": 1.84
     },
     {
       "name": "J1",
-      "amplitude": 0.004575178916687474,
-      "phase": 167.37490180528448
+      "amplitude": 0.005,
+      "phase": 167.37
     },
     {
       "name": "L2",
-      "amplitude": 0.14012634635788598,
-      "phase": 349.92974949497966
+      "amplitude": 0.14,
+      "phase": 349.93
     },
     {
       "name": "R2",
-      "amplitude": 0.012590509705877996,
-      "phase": 196.32608888688995
+      "amplitude": 0.013,
+      "phase": 196.33
     },
     {
       "name": "2Q1",
-      "amplitude": 0.003959857605298981,
-      "phase": 132.50214176579073
+      "amplitude": 0.004,
+      "phase": 132.5
     },
     {
       "name": "MSF",
-      "amplitude": 0.046322109254306014,
-      "phase": 40.403873411403026
+      "amplitude": 0.046,
+      "phase": 40.4
     },
     {
       "name": "MSQM",
-      "amplitude": 0.006545940595742798,
-      "phase": 50.77122325599555
+      "amplitude": 0.007,
+      "phase": 50.77
     },
     {
       "name": "EP2",
-      "amplitude": 0.040938691179376784,
-      "phase": 45.479853044173524
+      "amplitude": 0.041,
+      "phase": 45.48
     },
     {
       "name": "M3",
-      "amplitude": 0.0038108230593482677,
-      "phase": 28.364505693582316
+      "amplitude": 0.004,
+      "phase": 28.36
     },
     {
       "name": "MU2",
-      "amplitude": 0.1984576497956352,
-      "phase": 60.67880455203738
+      "amplitude": 0.198,
+      "phase": 60.68
     },
     {
       "name": "MTM",
-      "amplitude": 0.00540228626883535,
-      "phase": 0.38247366391090054
+      "amplitude": 0.005,
+      "phase": 0.38
     },
     {
       "name": "NU2",
-      "amplitude": 0.09836716293365103,
-      "phase": 289.16788650366016
+      "amplitude": 0.098,
+      "phase": 289.17
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06531838261926572,
-      "phase": 350.6299517667985
+      "amplitude": 0.065,
+      "phase": 350.63
     },
     {
       "name": "MN4",
-      "amplitude": 0.051222032704904975,
-      "phase": 163.46599552989733
+      "amplitude": 0.051,
+      "phase": 163.47
     },
     {
       "name": "MS4",
-      "amplitude": 0.09599072258496802,
-      "phase": 270.49474977372415
+      "amplitude": 0.096,
+      "phase": 270.49
     },
     {
       "name": "N4",
-      "amplitude": 0.010358942514848143,
-      "phase": 146.7868384911044
+      "amplitude": 0.01,
+      "phase": 146.79
     },
     {
       "name": "M6",
-      "amplitude": 0.09337282997701508,
-      "phase": 24.409719640321498
+      "amplitude": 0.093,
+      "phase": 24.41
     },
     {
       "name": "M8",
-      "amplitude": 0.027417376156956386,
-      "phase": 239.4039512046648
+      "amplitude": 0.027,
+      "phase": 239.4
     },
     {
       "name": "S4",
-      "amplitude": 0.010792428703497722,
-      "phase": 68.87636283609135
+      "amplitude": 0.011,
+      "phase": 68.88
     },
     {
       "name": "OO1",
-      "amplitude": 0.003195127620389016,
-      "phase": 196.17002214911645
+      "amplitude": 0.003,
+      "phase": 196.17
     },
     {
       "name": "S3",
-      "amplitude": 0.0012053963123834547,
-      "phase": 310.8707112700119
+      "amplitude": 0.001,
+      "phase": 310.87
     },
     {
       "name": "MA2",
-      "amplitude": 0.08168617264232599,
-      "phase": 292.98115150218916
+      "amplitude": 0.082,
+      "phase": 292.98
     },
     {
       "name": "MB2",
-      "amplitude": 0.03931974836623031,
-      "phase": 173.98434245771546
+      "amplitude": 0.039,
+      "phase": 173.98
     },
     {
       "name": "T3",
-      "amplitude": 0.000908922313599216,
-      "phase": 2.7744267615680087
+      "amplitude": 0.001,
+      "phase": 2.77
     },
     {
       "name": "R3",
-      "amplitude": 0.006285848706861353,
-      "phase": 25.117780758051083
+      "amplitude": 0.006,
+      "phase": 25.12
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005424990191172173,
-      "phase": 220.10030391964293
+      "amplitude": 0.005,
+      "phase": 220.1
     },
     {
       "name": "SGM",
-      "amplitude": 0.005958661453336263,
-      "phase": 41.07416239189564
+      "amplitude": 0.006,
+      "phase": 41.07
     },
     {
       "name": "3L2",
-      "amplitude": 0.0010789390160669476,
-      "phase": 204.18706240528516
+      "amplitude": 0.001,
+      "phase": 204.19
     },
     {
       "name": "3N2",
-      "amplitude": 0.026795416403979665,
-      "phase": 129.49077361403198
+      "amplitude": 0.027,
+      "phase": 129.49
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04035443299925856,
-      "phase": 276.5676801381549
+      "amplitude": 0.04,
+      "phase": 276.57
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08617056165210543,
-      "phase": 96.2431522999484
+      "amplitude": 0.086,
+      "phase": 96.24
     },
     {
       "name": "2MK5",
-      "amplitude": 0.012082414790869701,
-      "phase": 59.71991534887479
+      "amplitude": 0.012,
+      "phase": 59.72
     },
     {
       "name": "2MO5",
-      "amplitude": 0.008415917074382445,
-      "phase": 266.5495105665435
+      "amplitude": 0.008,
+      "phase": 266.55
     }
   ],
   "epoch": {

--- a/data/ticon/leuchtturmalteweser-9460040-deu-wsv.json
+++ b/data/ticon/leuchtturmalteweser-9460040-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3295178413789066,
-      "phase": 310.61501978175806
+      "amplitude": 1.33,
+      "phase": 310.62
     },
     {
       "name": "N2",
-      "amplitude": 0.21257952532341542,
-      "phase": 285.28725054272496
+      "amplitude": 0.213,
+      "phase": 285.29
     },
     {
       "name": "S2",
-      "amplitude": 0.35168980660733457,
-      "phase": 19.079521677169055
+      "amplitude": 0.352,
+      "phase": 19.08
     },
     {
       "name": "K2",
-      "amplitude": 0.10491198259925036,
-      "phase": 17.200287781133113
+      "amplitude": 0.105,
+      "phase": 17.2
     },
     {
       "name": "2N2",
-      "amplitude": 0.023695894151463445,
-      "phase": 264.96330738222235
+      "amplitude": 0.024,
+      "phase": 264.96
     },
     {
       "name": "S1",
-      "amplitude": 0.009840590110307645,
-      "phase": 14.161325446227579
+      "amplitude": 0.01,
+      "phase": 14.16
     },
     {
       "name": "K1",
-      "amplitude": 0.0709133413403877,
-      "phase": 20.60364150849165
+      "amplitude": 0.071,
+      "phase": 20.6
     },
     {
       "name": "P1",
-      "amplitude": 0.02899439167604728,
-      "phase": 26.987693983115605
+      "amplitude": 0.029,
+      "phase": 26.99
     },
     {
       "name": "O1",
-      "amplitude": 0.09234421792493479,
-      "phase": 231.49259489855282
+      "amplitude": 0.092,
+      "phase": 231.49
     },
     {
       "name": "Q1",
-      "amplitude": 0.029331255043750854,
-      "phase": 173.52059460718033
+      "amplitude": 0.029,
+      "phase": 173.52
     },
     {
       "name": "M1",
-      "amplitude": 0.0016341610214438804,
-      "phase": 83.2732750448688
+      "amplitude": 0.002,
+      "phase": 83.27
     },
     {
       "name": "M4",
-      "amplitude": 0.06524366869896818,
-      "phase": 138.5428336150984
+      "amplitude": 0.065,
+      "phase": 138.54
     },
     {
       "name": "MM",
-      "amplitude": 0.024050644890453228,
-      "phase": 178.40861840537104
+      "amplitude": 0.024,
+      "phase": 178.41
     },
     {
       "name": "MF",
-      "amplitude": 0.01037044644501222,
-      "phase": 180.04986618678547
+      "amplitude": 0.01,
+      "phase": 180.05
     },
     {
       "name": "SA",
-      "amplitude": 0.11323417462599066,
-      "phase": 220.94338703884745
+      "amplitude": 0.113,
+      "phase": 220.94
     },
     {
       "name": "SSA",
-      "amplitude": 0.03672204762531656,
-      "phase": 206.54319338429246
+      "amplitude": 0.037,
+      "phase": 206.54
     },
     {
       "name": "T2",
-      "amplitude": 0.019721551656255193,
-      "phase": 359.25696926620066
+      "amplitude": 0.02,
+      "phase": 359.26
     },
     {
       "name": "J1",
-      "amplitude": 0.001680722113541555,
-      "phase": 135.7047232136008
+      "amplitude": 0.002,
+      "phase": 135.7
     },
     {
       "name": "L2",
-      "amplitude": 0.10388053704631826,
-      "phase": 328.20577751224636
+      "amplitude": 0.104,
+      "phase": 328.21
     },
     {
       "name": "R2",
-      "amplitude": 0.00327058432520327,
-      "phase": 357.4533756851406
+      "amplitude": 0.003,
+      "phase": 357.45
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005898797983239926,
-      "phase": 117.28759327832307
+      "amplitude": 0.006,
+      "phase": 117.29
     },
     {
       "name": "MSF",
-      "amplitude": 0.003643289098295208,
-      "phase": 354.03515141299624
+      "amplitude": 0.004,
+      "phase": 354.04
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007786279722561647,
-      "phase": 67.15958155586867
+      "amplitude": 0.008,
+      "phase": 67.16
     },
     {
       "name": "EP2",
-      "amplitude": 0.029147847737388734,
-      "phase": 15.944597830684472
+      "amplitude": 0.029,
+      "phase": 15.94
     },
     {
       "name": "M3",
-      "amplitude": 0.0038401368714823564,
-      "phase": 318.79405733822114
+      "amplitude": 0.004,
+      "phase": 318.79
     },
     {
       "name": "MU2",
-      "amplitude": 0.12759073751525493,
-      "phase": 39.472845300905476
+      "amplitude": 0.128,
+      "phase": 39.47
     },
     {
       "name": "MTM",
-      "amplitude": 0.005194404507573911,
-      "phase": 239.29465005060104
+      "amplitude": 0.005,
+      "phase": 239.29
     },
     {
       "name": "NU2",
-      "amplitude": 0.07554533445968306,
-      "phase": 270.6524736522324
+      "amplitude": 0.076,
+      "phase": 270.65
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.049570007069617936,
-      "phase": 322.0260272405403
+      "amplitude": 0.05,
+      "phase": 322.03
     },
     {
       "name": "MN4",
-      "amplitude": 0.022974469494916952,
-      "phase": 120.40504288333165
+      "amplitude": 0.023,
+      "phase": 120.41
     },
     {
       "name": "MS4",
-      "amplitude": 0.045405878311773444,
-      "phase": 199.77932827986254
+      "amplitude": 0.045,
+      "phase": 199.78
     },
     {
       "name": "N4",
-      "amplitude": 0.005283783699074947,
-      "phase": 100.50976792514041
+      "amplitude": 0.005,
+      "phase": 100.51
     },
     {
       "name": "M6",
-      "amplitude": 0.05085001878114774,
-      "phase": 307.4424587088276
+      "amplitude": 0.051,
+      "phase": 307.44
     },
     {
       "name": "M8",
-      "amplitude": 0.006017571186402863,
-      "phase": 151.0438048020796
+      "amplitude": 0.006,
+      "phase": 151.04
     },
     {
       "name": "S4",
-      "amplitude": 0.005953624436166526,
-      "phase": 311.2425000699273
+      "amplitude": 0.006,
+      "phase": 311.24
     },
     {
       "name": "OO1",
-      "amplitude": 0.0023353171119548793,
-      "phase": 191.8728771100422
+      "amplitude": 0.002,
+      "phase": 191.87
     },
     {
       "name": "S3",
-      "amplitude": 0.0003699949924451973,
-      "phase": 131.60974736953324
+      "amplitude": 0,
+      "phase": 131.61
     },
     {
       "name": "MA2",
-      "amplitude": 0.041307753961301465,
-      "phase": 260.1301131667671
+      "amplitude": 0.041,
+      "phase": 260.13
     },
     {
       "name": "MB2",
-      "amplitude": 0.02430167432370942,
-      "phase": 32.30068498280832
+      "amplitude": 0.024,
+      "phase": 32.3
     },
     {
       "name": "T3",
-      "amplitude": 0.00036789946701660316,
-      "phase": 3.986827332351936
+      "amplitude": 0,
+      "phase": 3.99
     },
     {
       "name": "R3",
-      "amplitude": 0.002348467717708176,
-      "phase": 6.939928671006612
+      "amplitude": 0.002,
+      "phase": 6.94
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005812496038431323,
-      "phase": 179.5275339558218
+      "amplitude": 0.006,
+      "phase": 179.53
     },
     {
       "name": "SGM",
-      "amplitude": 0.0023970292072042826,
-      "phase": 50.31429892234007
+      "amplitude": 0.002,
+      "phase": 50.31
     },
     {
       "name": "3L2",
-      "amplitude": 0.00380769981372267,
-      "phase": 217.97638142241934
+      "amplitude": 0.004,
+      "phase": 217.98
     },
     {
       "name": "3N2",
-      "amplitude": 0.01684588443873384,
-      "phase": 114.46261627054128
+      "amplitude": 0.017,
+      "phase": 114.46
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03321996731310886,
-      "phase": 240.53087116410717
+      "amplitude": 0.033,
+      "phase": 240.53
     },
     {
       "name": "2MS6",
-      "amplitude": 0.050579723619623845,
-      "phase": 8.317454719479542
+      "amplitude": 0.051,
+      "phase": 8.32
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00204393055756606,
-      "phase": 15.933528118038112
+      "amplitude": 0.002,
+      "phase": 15.93
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0034764172060633464,
-      "phase": 264.2045077855257
+      "amplitude": 0.003,
+      "phase": 264.2
     }
   ],
   "epoch": {

--- a/data/ticon/lhort-5960010-deu-wsv.json
+++ b/data/ticon/lhort-5960010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.406575522273051,
-      "phase": 67.58813908278228
+      "amplitude": 1.407,
+      "phase": 67.59
     },
     {
       "name": "N2",
-      "amplitude": 0.21173469882267962,
-      "phase": 41.07765910211941
+      "amplitude": 0.212,
+      "phase": 41.08
     },
     {
       "name": "S2",
-      "amplitude": 0.32199485008022716,
-      "phase": 143.50013669578362
+      "amplitude": 0.322,
+      "phase": 143.5
     },
     {
       "name": "K2",
-      "amplitude": 0.09687261286415227,
-      "phase": 141.99212078805715
+      "amplitude": 0.097,
+      "phase": 141.99
     },
     {
       "name": "2N2",
-      "amplitude": 0.021876700867140008,
-      "phase": 19.629162961692657
+      "amplitude": 0.022,
+      "phase": 19.63
     },
     {
       "name": "S1",
-      "amplitude": 0.018799902736812278,
-      "phase": 94.29338138574212
+      "amplitude": 0.019,
+      "phase": 94.29
     },
     {
       "name": "K1",
-      "amplitude": 0.07119395671470673,
-      "phase": 91.65512716689278
+      "amplitude": 0.071,
+      "phase": 91.66
     },
     {
       "name": "P1",
-      "amplitude": 0.03065605210334717,
-      "phase": 89.1973232055712
+      "amplitude": 0.031,
+      "phase": 89.2
     },
     {
       "name": "O1",
-      "amplitude": 0.08958286384139603,
-      "phase": 297.0171649036177
+      "amplitude": 0.09,
+      "phase": 297.02
     },
     {
       "name": "Q1",
-      "amplitude": 0.025933112632467302,
-      "phase": 237.38816329502254
+      "amplitude": 0.026,
+      "phase": 237.39
     },
     {
       "name": "M1",
-      "amplitude": 0.002305280623837429,
-      "phase": 147.8103150940393
+      "amplitude": 0.002,
+      "phase": 147.81
     },
     {
       "name": "M4",
-      "amplitude": 0.09977258698653498,
-      "phase": 12.278773133438108
+      "amplitude": 0.1,
+      "phase": 12.28
     },
     {
       "name": "MM",
-      "amplitude": 0.016715795378947695,
-      "phase": 143.8613242353992
+      "amplitude": 0.017,
+      "phase": 143.86
     },
     {
       "name": "MF",
-      "amplitude": 0.014277714795520681,
-      "phase": 108.27455338974698
+      "amplitude": 0.014,
+      "phase": 108.27
     },
     {
       "name": "SA",
-      "amplitude": 0.0689832131579032,
-      "phase": 241.81932397033893
+      "amplitude": 0.069,
+      "phase": 241.82
     },
     {
       "name": "SSA",
-      "amplitude": 0.049611832112280596,
-      "phase": 225.296420567636
+      "amplitude": 0.05,
+      "phase": 225.3
     },
     {
       "name": "T2",
-      "amplitude": 0.019909411715657167,
-      "phase": 120.80075015906198
+      "amplitude": 0.02,
+      "phase": 120.8
     },
     {
       "name": "J1",
-      "amplitude": 0.005521197473794376,
-      "phase": 221.8315087977581
+      "amplitude": 0.006,
+      "phase": 221.83
     },
     {
       "name": "L2",
-      "amplitude": 0.12701307816910967,
-      "phase": 87.68139098489945
+      "amplitude": 0.127,
+      "phase": 87.68
     },
     {
       "name": "R2",
-      "amplitude": 0.0038789902992673944,
-      "phase": 50.966183636559606
+      "amplitude": 0.004,
+      "phase": 50.97
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005725038441396135,
-      "phase": 173.27511101378377
+      "amplitude": 0.006,
+      "phase": 173.28
     },
     {
       "name": "MSF",
-      "amplitude": 0.05574090989848381,
-      "phase": 63.60423000925846
+      "amplitude": 0.056,
+      "phase": 63.6
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009509062660024556,
-      "phase": 48.21444352044966
+      "amplitude": 0.01,
+      "phase": 48.21
     },
     {
       "name": "EP2",
-      "amplitude": 0.03890102132654725,
-      "phase": 132.52589369763473
+      "amplitude": 0.039,
+      "phase": 132.53
     },
     {
       "name": "M3",
-      "amplitude": 0.0025395742834699686,
-      "phase": 124.83871900214086
+      "amplitude": 0.003,
+      "phase": 124.84
     },
     {
       "name": "MU2",
-      "amplitude": 0.18967814699765956,
-      "phase": 158.679757996965
+      "amplitude": 0.19,
+      "phase": 158.68
     },
     {
       "name": "MTM",
-      "amplitude": 0.004099765272702525,
-      "phase": 231.36682311905082
+      "amplitude": 0.004,
+      "phase": 231.37
     },
     {
       "name": "NU2",
-      "amplitude": 0.096067239432691,
-      "phase": 24.050015474299414
+      "amplitude": 0.096,
+      "phase": 24.05
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.056590614683152594,
-      "phase": 85.3410791762737
+      "amplitude": 0.057,
+      "phase": 85.34
     },
     {
       "name": "MN4",
-      "amplitude": 0.033466697743460234,
-      "phase": 348.09861703442357
+      "amplitude": 0.033,
+      "phase": 348.1
     },
     {
       "name": "MS4",
-      "amplitude": 0.05624782621308354,
-      "phase": 83.54560640839986
+      "amplitude": 0.056,
+      "phase": 83.55
     },
     {
       "name": "N4",
-      "amplitude": 0.0068824589229555845,
-      "phase": 326.8035415997474
+      "amplitude": 0.007,
+      "phase": 326.8
     },
     {
       "name": "M6",
-      "amplitude": 0.0734544025100674,
-      "phase": 253.47900345326605
+      "amplitude": 0.073,
+      "phase": 253.48
     },
     {
       "name": "M8",
-      "amplitude": 0.026008797946293648,
-      "phase": 203.1991049175998
+      "amplitude": 0.026,
+      "phase": 203.2
     },
     {
       "name": "S4",
-      "amplitude": 0.005272974596970015,
-      "phase": 214.7042870570868
+      "amplitude": 0.005,
+      "phase": 214.7
     },
     {
       "name": "OO1",
-      "amplitude": 0.002913688156803278,
-      "phase": 230.4998076300844
+      "amplitude": 0.003,
+      "phase": 230.5
     },
     {
       "name": "S3",
-      "amplitude": 0.0007070356455650047,
-      "phase": 2.3358174833836074
+      "amplitude": 0.001,
+      "phase": 2.34
     },
     {
       "name": "MA2",
-      "amplitude": 0.04392065225763887,
-      "phase": 33.16322375085008
+      "amplitude": 0.044,
+      "phase": 33.16
     },
     {
       "name": "MB2",
-      "amplitude": 0.017121472689099467,
-      "phase": 89.79976009395989
+      "amplitude": 0.017,
+      "phase": 89.8
     },
     {
       "name": "T3",
-      "amplitude": 0.0007811192104250582,
-      "phase": 135.7207055792967
+      "amplitude": 0.001,
+      "phase": 135.72
     },
     {
       "name": "R3",
-      "amplitude": 0.004395680030724065,
-      "phase": 141.08363339935136
+      "amplitude": 0.004,
+      "phase": 141.08
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005574146945228462,
-      "phase": 241.05323900013065
+      "amplitude": 0.006,
+      "phase": 241.05
     },
     {
       "name": "SGM",
-      "amplitude": 0.003808029139822825,
-      "phase": 72.33347372926767
+      "amplitude": 0.004,
+      "phase": 72.33
     },
     {
       "name": "3L2",
-      "amplitude": 0.0030019848846889606,
-      "phase": 333.5931976317246
+      "amplitude": 0.003,
+      "phase": 333.59
     },
     {
       "name": "3N2",
-      "amplitude": 0.015418720269252322,
-      "phase": 222.19823038702486
+      "amplitude": 0.015,
+      "phase": 222.2
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03436540892602197,
-      "phase": 14.182793150665304
+      "amplitude": 0.034,
+      "phase": 14.18
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06823910355289507,
-      "phase": 323.376482930229
+      "amplitude": 0.068,
+      "phase": 323.38
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005767072632946872,
-      "phase": 255.04546905959793
+      "amplitude": 0.006,
+      "phase": 255.05
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004690210260773774,
-      "phase": 118.37787642264692
+      "amplitude": 0.005,
+      "phase": 118.38
     }
   ],
   "epoch": {

--- a/data/ticon/lichteiland_goeree-lichtelgre-nld-rws.json
+++ b/data/ticon/lichteiland_goeree-lichtelgre-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.83218845,
-      "phase": 55.153121999999996
+      "amplitude": 0.859,
+      "phase": 38.77
     },
     {
       "name": "N2",
-      "amplitude": 0.12956174,
-      "phase": 27.25901399999998
+      "amplitude": 0.133,
+      "phase": 11.18
     },
     {
       "name": "S2",
-      "amplitude": 0.20937892000000002,
-      "phase": 112.46799799999997
+      "amplitude": 0.215,
+      "phase": 95.7
     },
     {
       "name": "K2",
-      "amplitude": 0.05899688,
-      "phase": 116.70779700000003
+      "amplitude": 0.064,
+      "phase": 95.74
     },
     {
       "name": "2N2",
-      "amplitude": 0.01533062,
-      "phase": 358.333554
+      "amplitude": 0.016,
+      "phase": 343.44
     },
     {
       "name": "S1",
-      "amplitude": 0.00706161,
-      "phase": 0.9608789999999772
+      "amplitude": 0.009,
+      "phase": 287.55
     },
     {
       "name": "K1",
-      "amplitude": 0.07798735,
-      "phase": 352.681078
+      "amplitude": 0.078,
+      "phase": 344.08
     },
     {
       "name": "P1",
-      "amplitude": 0.0326491,
-      "phase": 337.642884
+      "amplitude": 0.033,
+      "phase": 330.89
     },
     {
       "name": "O1",
-      "amplitude": 0.11064993,
-      "phase": 182.325483
+      "amplitude": 0.111,
+      "phase": 174.34
     },
     {
       "name": "Q1",
-      "amplitude": 0.03689137,
-      "phase": 126.898863
+      "amplitude": 0.037,
+      "phase": 119.06
     },
     {
       "name": "M1",
-      "amplitude": 0.00060616,
-      "phase": 317.07939799999997
+      "amplitude": 0.002,
+      "phase": 15.75
     },
     {
       "name": "M4",
-      "amplitude": 0.13092847000000002,
-      "phase": 116.26583900000003
+      "amplitude": 0.153,
+      "phase": 82.64
     },
     {
       "name": "MM",
-      "amplitude": 0.0024016199999999997,
-      "phase": 97.77441699999997
+      "amplitude": 0.003,
+      "phase": 99
     },
     {
       "name": "MF",
-      "amplitude": 0.004687,
-      "phase": 137.18062299999997
+      "amplitude": 0.005,
+      "phase": 136.34
     },
     {
       "name": "SA",
-      "amplitude": 0.07850133,
-      "phase": 215.364964
+      "amplitude": 0.079,
+      "phase": 215.18
     },
     {
       "name": "SSA",
-      "amplitude": 0.009473510000000001,
-      "phase": 156.403502
+      "amplitude": 0.01,
+      "phase": 156.07
     },
     {
       "name": "T2",
-      "amplitude": 0.03894944,
-      "phase": 35.97721999999999
+      "amplitude": 0.014,
+      "phase": 88.49
     },
     {
       "name": "J1",
-      "amplitude": 0.00400364,
-      "phase": 90.54962799999998
+      "amplitude": 0.004,
+      "phase": 80.96
     },
     {
       "name": "L2",
-      "amplitude": 0.06574334999999999,
-      "phase": 79.27896599999997
+      "amplitude": 0.068,
+      "phase": 62.64
     },
     {
       "name": "R2",
-      "amplitude": 0.02582832,
-      "phase": 213.844673
+      "amplitude": 0.002,
+      "phase": 82.1
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00606111,
-      "phase": 90.81935499999997
+      "amplitude": 0.006,
+      "phase": 84.28
     },
     {
       "name": "MSF",
-      "amplitude": 0.02208879,
-      "phase": 32.71283
+      "amplitude": 0.022,
+      "phase": 32.08
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00210735,
-      "phase": 140.361361
+      "amplitude": 0.002,
+      "phase": 144.45
     },
     {
       "name": "EP2",
-      "amplitude": 0.01612755,
-      "phase": 153.58526299999994
+      "amplitude": 0.016,
+      "phase": 139.54
     },
     {
       "name": "M3",
-      "amplitude": 0.0005528600000000001,
-      "phase": 155.25569399999995
+      "amplitude": 0.001,
+      "phase": 315.92
     },
     {
       "name": "MU2",
-      "amplitude": 0.07479007,
-      "phase": 176.33970799999997
+      "amplitude": 0.078,
+      "phase": 160.22
     },
     {
       "name": "MTM",
-      "amplitude": 0.0021617200000000002,
-      "phase": 222.243295
+      "amplitude": 0.002,
+      "phase": 221.25
     },
     {
       "name": "NU2",
-      "amplitude": 0.0497741,
-      "phase": 24.63089500000001
+      "amplitude": 0.051,
+      "phase": 8.62
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02980438,
-      "phase": 77.85332
+      "amplitude": 0.031,
+      "phase": 60.9
     },
     {
       "name": "MN4",
-      "amplitude": 0.047005420000000006,
-      "phase": 92.04512399999999
+      "amplitude": 0.055,
+      "phase": 59.09
     },
     {
       "name": "MS4",
-      "amplitude": 0.0858142,
-      "phase": 170.91433299999994
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03040276,
-      "phase": 199.195404
+      "amplitude": 0.099,
+      "phase": 137.59
     },
     {
       "name": "N4",
-      "amplitude": 0.00978534,
-      "phase": 67.45732900000002
+      "amplitude": 0.011,
+      "phase": 34.17
     },
     {
       "name": "M6",
-      "amplitude": 0.04238247999999999,
-      "phase": 70.51200599999999
+      "amplitude": 0.059,
+      "phase": 18.18
     },
     {
       "name": "M8",
-      "amplitude": 0.00956878,
-      "phase": 136.533366
+      "amplitude": 0.018,
+      "phase": 61.93
     },
     {
       "name": "S4",
-      "amplitude": 0.0083321,
-      "phase": 253.845349
+      "amplitude": 0.009,
+      "phase": 219.85
     },
     {
       "name": "OO1",
-      "amplitude": 0.00462571,
-      "phase": 134.924955
+      "amplitude": 0.004,
+      "phase": 125.19
     },
     {
       "name": "S3",
-      "amplitude": 0.00219744,
-      "phase": 41.93426699999998
+      "amplitude": 0,
+      "phase": 230.44
     },
     {
       "name": "MA2",
-      "amplitude": 0.14523688999999998,
-      "phase": 37.550208
+      "amplitude": 0.013,
+      "phase": 26.76
     },
     {
       "name": "MB2",
-      "amplitude": 0.12937421000000002,
-      "phase": 245.627858
+      "amplitude": 0.01,
+      "phase": 116.59
     },
     {
       "name": "T3",
-      "amplitude": 0.00091783,
-      "phase": 12.646865999999989
+      "amplitude": 0.001,
+      "phase": 199.87
     },
     {
       "name": "R3",
-      "amplitude": 0.00635197,
-      "phase": 238.109081
+      "amplitude": 0.007,
+      "phase": 301.18
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00774184,
-      "phase": 128.87278500000002
+      "amplitude": 0.008,
+      "phase": 121.54
     },
     {
       "name": "SGM",
-      "amplitude": 0.0022006,
-      "phase": 136.5523
+      "amplitude": 0.002,
+      "phase": 306.4
     },
     {
       "name": "3L2",
-      "amplitude": 0.0005984300000000001,
-      "phase": 178.99457800000005
+      "amplitude": 0.001,
+      "phase": 341.26
     },
     {
       "name": "3N2",
-      "amplitude": 0.00231037,
-      "phase": 80.475372
+      "amplitude": 0.009,
+      "phase": 218.18
     },
     {
       "name": "2SM2",
-      "amplitude": 0.022807909999999997,
-      "phase": 352.282606
+      "amplitude": 0.023,
+      "phase": 335.33
     },
     {
       "name": "2MS6",
-      "amplitude": 0.03863215,
-      "phase": 123.60863999999998
+      "amplitude": 0.053,
+      "phase": 71.76
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00745198,
-      "phase": 241.37892399999998
+      "amplitude": 0.01,
+      "phase": 288.64
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0086672,
-      "phase": 254.191318
+      "amplitude": 0.011,
+      "phase": 122.26
     }
   ],
   "epoch": {

--- a/data/ticon/listaufsylt-9570070-deu-wsv.json
+++ b/data/ticon/listaufsylt-9570070-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.8061528776263769,
-      "phase": 22.949950844927514
+      "amplitude": 0.806,
+      "phase": 22.95
     },
     {
       "name": "N2",
-      "amplitude": 0.12999605575856946,
-      "phase": 356.912501532635
+      "amplitude": 0.13,
+      "phase": 356.91
     },
     {
       "name": "S2",
-      "amplitude": 0.1971563076624991,
-      "phase": 91.82172697850143
+      "amplitude": 0.197,
+      "phase": 91.82
     },
     {
       "name": "K2",
-      "amplitude": 0.058503463692130796,
-      "phase": 89.76839069998823
+      "amplitude": 0.059,
+      "phase": 89.77
     },
     {
       "name": "2N2",
-      "amplitude": 0.014665285479278471,
-      "phase": 335.8064341530457
+      "amplitude": 0.015,
+      "phase": 335.81
     },
     {
       "name": "S1",
-      "amplitude": 0.00880352586800631,
-      "phase": 46.7496573087941
+      "amplitude": 0.009,
+      "phase": 46.75
     },
     {
       "name": "K1",
-      "amplitude": 0.055877676675033204,
-      "phase": 58.61958045056008
+      "amplitude": 0.056,
+      "phase": 58.62
     },
     {
       "name": "P1",
-      "amplitude": 0.025548724728259406,
-      "phase": 65.12706514236254
+      "amplitude": 0.026,
+      "phase": 65.13
     },
     {
       "name": "O1",
-      "amplitude": 0.08247405955256179,
-      "phase": 267.33719420439854
+      "amplitude": 0.082,
+      "phase": 267.34
     },
     {
       "name": "Q1",
-      "amplitude": 0.026897244512760467,
-      "phase": 208.01085976282727
+      "amplitude": 0.027,
+      "phase": 208.01
     },
     {
       "name": "M1",
-      "amplitude": 0.0016804236327228946,
-      "phase": 131.71212851177268
+      "amplitude": 0.002,
+      "phase": 131.71
     },
     {
       "name": "M4",
-      "amplitude": 0.05529819081115551,
-      "phase": 215.59064206328569
+      "amplitude": 0.055,
+      "phase": 215.59
     },
     {
       "name": "MM",
-      "amplitude": 0.02636741678471183,
-      "phase": 175.67427657531096
+      "amplitude": 0.026,
+      "phase": 175.67
     },
     {
       "name": "MF",
-      "amplitude": 0.010433930909084869,
-      "phase": 177.30677274213508
+      "amplitude": 0.01,
+      "phase": 177.31
     },
     {
       "name": "SA",
-      "amplitude": 0.12803600405292104,
-      "phase": 230.12859211074593
+      "amplitude": 0.128,
+      "phase": 230.13
     },
     {
       "name": "SSA",
-      "amplitude": 0.044689059184441236,
-      "phase": 208.35008024709057
+      "amplitude": 0.045,
+      "phase": 208.35
     },
     {
       "name": "T2",
-      "amplitude": 0.011540886524214434,
-      "phase": 71.12152065635246
+      "amplitude": 0.012,
+      "phase": 71.12
     },
     {
       "name": "J1",
-      "amplitude": 0.0018422002984571926,
-      "phase": 215.6891709918335
+      "amplitude": 0.002,
+      "phase": 215.69
     },
     {
       "name": "L2",
-      "amplitude": 0.06428547535791186,
-      "phase": 43.11615755941
+      "amplitude": 0.064,
+      "phase": 43.12
     },
     {
       "name": "R2",
-      "amplitude": 0.0010343198634979026,
-      "phase": 43.42042170718514
+      "amplitude": 0.001,
+      "phase": 43.42
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005393203314702379,
-      "phase": 145.67516710454686
+      "amplitude": 0.005,
+      "phase": 145.68
     },
     {
       "name": "MSF",
-      "amplitude": 0.012186766183313045,
-      "phase": 27.663795307545797
+      "amplitude": 0.012,
+      "phase": 27.66
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007853244827724544,
-      "phase": 65.53242636732028
+      "amplitude": 0.008,
+      "phase": 65.53
     },
     {
       "name": "EP2",
-      "amplitude": 0.020664551511825197,
-      "phase": 94.24187959765015
+      "amplitude": 0.021,
+      "phase": 94.24
     },
     {
       "name": "M3",
-      "amplitude": 0.0002808460487349421,
-      "phase": 319.3500582686536
+      "amplitude": 0,
+      "phase": 319.35
     },
     {
       "name": "MU2",
-      "amplitude": 0.08879011253558752,
-      "phase": 116.03809292417304
+      "amplitude": 0.089,
+      "phase": 116.04
     },
     {
       "name": "MTM",
-      "amplitude": 0.006479978753619625,
-      "phase": 234.89526115502852
+      "amplitude": 0.006,
+      "phase": 234.9
     },
     {
       "name": "NU2",
-      "amplitude": 0.04874348737476525,
-      "phase": 343.641571185047
+      "amplitude": 0.049,
+      "phase": 343.64
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.029303559441903347,
-      "phase": 36.22898787528851
+      "amplitude": 0.029,
+      "phase": 36.23
     },
     {
       "name": "MN4",
-      "amplitude": 0.02014499760174675,
-      "phase": 182.6289236646394
+      "amplitude": 0.02,
+      "phase": 182.63
     },
     {
       "name": "MS4",
-      "amplitude": 0.023878726205185403,
-      "phase": 288.27310074971103
+      "amplitude": 0.024,
+      "phase": 288.27
     },
     {
       "name": "N4",
-      "amplitude": 0.0038950929239291244,
-      "phase": 158.49026449570863
+      "amplitude": 0.004,
+      "phase": 158.49
     },
     {
       "name": "M6",
-      "amplitude": 0.015958644036721363,
-      "phase": 91.16084872705159
+      "amplitude": 0.016,
+      "phase": 91.16
     },
     {
       "name": "M8",
-      "amplitude": 0.004412378438070827,
-      "phase": 284.34734245258744
+      "amplitude": 0.004,
+      "phase": 284.35
     },
     {
       "name": "S4",
-      "amplitude": 0.0008059472140320078,
-      "phase": 253.40503902509158
+      "amplitude": 0.001,
+      "phase": 253.41
     },
     {
       "name": "OO1",
-      "amplitude": 0.0023357599252850415,
-      "phase": 244.64768859192299
+      "amplitude": 0.002,
+      "phase": 244.65
     },
     {
       "name": "S3",
-      "amplitude": 0.00007821870727593712,
-      "phase": 92.41042570871184
+      "amplitude": 0,
+      "phase": 92.41
     },
     {
       "name": "MA2",
-      "amplitude": 0.02363897782594534,
-      "phase": 347.6516470454073
+      "amplitude": 0.024,
+      "phase": 347.65
     },
     {
       "name": "MB2",
-      "amplitude": 0.008788665941830101,
-      "phase": 89.1144978862049
+      "amplitude": 0.009,
+      "phase": 89.11
     },
     {
       "name": "T3",
-      "amplitude": 0.0004921026865325715,
-      "phase": 248.78513929691587
+      "amplitude": 0,
+      "phase": 248.79
     },
     {
       "name": "R3",
-      "amplitude": 0.0013122235233550385,
-      "phase": 25.232895085688142
+      "amplitude": 0.001,
+      "phase": 25.23
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0058958095152916185,
-      "phase": 210.9546574392223
+      "amplitude": 0.006,
+      "phase": 210.95
     },
     {
       "name": "SGM",
-      "amplitude": 0.001955524768799785,
-      "phase": 76.74988886235036
+      "amplitude": 0.002,
+      "phase": 76.75
     },
     {
       "name": "3L2",
-      "amplitude": 0.00297897429359596,
-      "phase": 296.27228584573
+      "amplitude": 0.003,
+      "phase": 296.27
     },
     {
       "name": "3N2",
-      "amplitude": 0.008460985551518958,
-      "phase": 188.17931628908215
+      "amplitude": 0.008,
+      "phase": 188.18
     },
     {
       "name": "2SM2",
-      "amplitude": 0.018316952205866058,
-      "phase": 315.5174655165588
+      "amplitude": 0.018,
+      "phase": 315.52
     },
     {
       "name": "2MS6",
-      "amplitude": 0.014294729998958441,
-      "phase": 163.67642091016205
+      "amplitude": 0.014,
+      "phase": 163.68
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004016144633067185,
-      "phase": 133.30347826717036
+      "amplitude": 0.004,
+      "phase": 133.3
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005128575954367057,
-      "phase": 345.8552533089445
+      "amplitude": 0.005,
+      "phase": 345.86
     }
   ],
   "epoch": {

--- a/data/ticon/ltkiel-9610050-deu-wsv.json
+++ b/data/ticon/ltkiel-9610050-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.044916033537111086,
-      "phase": 113.2064797611983
+      "amplitude": 0.045,
+      "phase": 113.21
     },
     {
       "name": "N2",
-      "amplitude": 0.013044616383806142,
-      "phase": 59.70659630940128
+      "amplitude": 0.013,
+      "phase": 59.71
     },
     {
       "name": "S2",
-      "amplitude": 0.011458807478090333,
-      "phase": 50.450659438096864
+      "amplitude": 0.011,
+      "phase": 50.45
     },
     {
       "name": "K2",
-      "amplitude": 0.0027594327113929147,
-      "phase": 28.427279623935135
+      "amplitude": 0.003,
+      "phase": 28.43
     },
     {
       "name": "2N2",
-      "amplitude": 0.001889940577062353,
-      "phase": 27.71114375276869
+      "amplitude": 0.002,
+      "phase": 27.71
     },
     {
       "name": "S1",
-      "amplitude": 0.007693279435006233,
-      "phase": 187.51797049975588
+      "amplitude": 0.008,
+      "phase": 187.52
     },
     {
       "name": "K1",
-      "amplitude": 0.020197521368178296,
-      "phase": 212.03127407168918
+      "amplitude": 0.02,
+      "phase": 212.03
     },
     {
       "name": "P1",
-      "amplitude": 0.007763970614282381,
-      "phase": 244.27359507076977
+      "amplitude": 0.008,
+      "phase": 244.27
     },
     {
       "name": "O1",
-      "amplitude": 0.016693972805393077,
-      "phase": 107.03484218658014
+      "amplitude": 0.017,
+      "phase": 107.03
     },
     {
       "name": "Q1",
-      "amplitude": 0.005080399146846209,
-      "phase": 309.30122608610327
+      "amplitude": 0.005,
+      "phase": 309.3
     },
     {
       "name": "M1",
-      "amplitude": 0.00013323537752214857,
-      "phase": 121.25671776669651
+      "amplitude": 0,
+      "phase": 121.26
     },
     {
       "name": "M4",
-      "amplitude": 0.0020609420610970372,
-      "phase": 200.59649668320185
+      "amplitude": 0.002,
+      "phase": 200.6
     },
     {
       "name": "MM",
-      "amplitude": 0.011023572004232873,
-      "phase": 290.36579793672047
+      "amplitude": 0.011,
+      "phase": 290.37
     },
     {
       "name": "MF",
-      "amplitude": 0.01044015355610409,
-      "phase": 248.89725662632816
+      "amplitude": 0.01,
+      "phase": 248.9
     },
     {
       "name": "SA",
-      "amplitude": 0.03701174178014938,
-      "phase": 174.30784736883265
+      "amplitude": 0.037,
+      "phase": 174.31
     },
     {
       "name": "SSA",
-      "amplitude": 0.01436063490367846,
-      "phase": 274.76225780873574
+      "amplitude": 0.014,
+      "phase": 274.76
     },
     {
       "name": "T2",
-      "amplitude": 0.0011113500129843652,
-      "phase": 55.28951923827759
+      "amplitude": 0.001,
+      "phase": 55.29
     },
     {
       "name": "J1",
-      "amplitude": 0.0009908303201156344,
-      "phase": 142.13847144911733
+      "amplitude": 0.001,
+      "phase": 142.14
     },
     {
       "name": "L2",
-      "amplitude": 0.004545967946919282,
-      "phase": 211.94983472461865
+      "amplitude": 0.005,
+      "phase": 211.95
     },
     {
       "name": "R2",
-      "amplitude": 0.0009575165883553556,
-      "phase": 136.79138901702242
+      "amplitude": 0.001,
+      "phase": 136.79
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0013477417389901128,
-      "phase": 275.34436015011244
+      "amplitude": 0.001,
+      "phase": 275.34
     },
     {
       "name": "MSF",
-      "amplitude": 0.002781769483589187,
-      "phase": 232.87878971089063
+      "amplitude": 0.003,
+      "phase": 232.88
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004581633775631411,
-      "phase": 215.2093275605153
+      "amplitude": 0.005,
+      "phase": 215.21
     },
     {
       "name": "EP2",
-      "amplitude": 0.002676723197057561,
-      "phase": 240.1179409639047
+      "amplitude": 0.003,
+      "phase": 240.12
     },
     {
       "name": "M3",
-      "amplitude": 0.0005667193579261035,
-      "phase": 325.67805286136604
+      "amplitude": 0.001,
+      "phase": 325.68
     },
     {
       "name": "MU2",
-      "amplitude": 0.011289416678475805,
-      "phase": 280.28622841062895
+      "amplitude": 0.011,
+      "phase": 280.29
     },
     {
       "name": "MTM",
-      "amplitude": 0.0035140706803703133,
-      "phase": 345.0176563618277
+      "amplitude": 0.004,
+      "phase": 345.02
     },
     {
       "name": "NU2",
-      "amplitude": 0.0046613805481821105,
-      "phase": 97.92491745141376
+      "amplitude": 0.005,
+      "phase": 97.92
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00251271374458185,
-      "phase": 205.0099655288599
+      "amplitude": 0.003,
+      "phase": 205.01
     },
     {
       "name": "MN4",
-      "amplitude": 0.0006084035582422085,
-      "phase": 142.05512046916147
+      "amplitude": 0.001,
+      "phase": 142.06
     },
     {
       "name": "MS4",
-      "amplitude": 0.000403488210570554,
-      "phase": 341.673635374739
+      "amplitude": 0,
+      "phase": 341.67
     },
     {
       "name": "N4",
-      "amplitude": 0.00014119675259984812,
-      "phase": 101.88054614065527
+      "amplitude": 0,
+      "phase": 101.88
     },
     {
       "name": "M6",
-      "amplitude": 0.0002714809630043555,
-      "phase": 293.07826026081483
+      "amplitude": 0,
+      "phase": 293.08
     },
     {
       "name": "M8",
-      "amplitude": 0.000010016785863812549,
-      "phase": 307.15025098243007
+      "amplitude": 0,
+      "phase": 307.15
     },
     {
       "name": "S4",
-      "amplitude": 0.0002831293425186818,
-      "phase": 254.44867176227228
+      "amplitude": 0,
+      "phase": 254.45
     },
     {
       "name": "OO1",
-      "amplitude": 0.0016547774463682805,
-      "phase": 126.80209051434201
+      "amplitude": 0.002,
+      "phase": 126.8
     },
     {
       "name": "S3",
-      "amplitude": 0.00015585173359506375,
-      "phase": 180.56597291035933
+      "amplitude": 0,
+      "phase": 180.57
     },
     {
       "name": "MA2",
-      "amplitude": 0.0062838555680450525,
-      "phase": 101.7563300248002
+      "amplitude": 0.006,
+      "phase": 101.76
     },
     {
       "name": "MB2",
-      "amplitude": 0.0068262727661992165,
-      "phase": 262.7044655989071
+      "amplitude": 0.007,
+      "phase": 262.7
     },
     {
       "name": "T3",
-      "amplitude": 0.0002440685470731129,
-      "phase": 147.93418348516605
+      "amplitude": 0,
+      "phase": 147.93
     },
     {
       "name": "R3",
-      "amplitude": 0.0002830332958962681,
-      "phase": 251.08935501551719
+      "amplitude": 0,
+      "phase": 251.09
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0008745741836969047,
-      "phase": 267.40013163754713
+      "amplitude": 0.001,
+      "phase": 267.4
     },
     {
       "name": "SGM",
-      "amplitude": 0.0030285577206912604,
-      "phase": 217.27244577196112
+      "amplitude": 0.003,
+      "phase": 217.27
     },
     {
       "name": "3L2",
-      "amplitude": 0.0004399332189283987,
-      "phase": 359.575507334288
+      "amplitude": 0,
+      "phase": 359.58
     },
     {
       "name": "3N2",
-      "amplitude": 0.0013960397920602032,
-      "phase": 10.123223511543472
+      "amplitude": 0.001,
+      "phase": 10.12
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0016154954402028097,
-      "phase": 168.8146538693543
+      "amplitude": 0.002,
+      "phase": 168.81
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00036528893583318955,
-      "phase": 12.212841224526642
+      "amplitude": 0,
+      "phase": 12.21
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000177244765116193,
-      "phase": 132.2766280516828
+      "amplitude": 0,
+      "phase": 132.28
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00014083888600109054,
-      "phase": 241.50714692973273
+      "amplitude": 0,
+      "phase": 241.51
     }
   ],
   "epoch": {

--- a/data/ticon/maasmond_stroommeetpaal-maasmsmpl-nld-rws.json
+++ b/data/ticon/maasmond_stroommeetpaal-maasmsmpl-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.78830027,
-      "phase": 70.31147599999997
+      "amplitude": 0.814,
+      "phase": 53.32
     },
     {
       "name": "N2",
-      "amplitude": 0.11888903,
-      "phase": 43.426064999999994
+      "amplitude": 0.122,
+      "phase": 26.73
     },
     {
       "name": "S2",
-      "amplitude": 0.19687256,
-      "phase": 130.94113300000004
+      "amplitude": 0.201,
+      "phase": 113.63
     },
     {
       "name": "K2",
-      "amplitude": 0.05276276,
-      "phase": 134.710176
+      "amplitude": 0.059,
+      "phase": 112.91
     },
     {
       "name": "2N2",
-      "amplitude": 0.01616857,
-      "phase": 7.760338999999988
+      "amplitude": 0.015,
+      "phase": 353.07
     },
     {
       "name": "S1",
-      "amplitude": 0.00747661,
-      "phase": 0.7297379999999976
+      "amplitude": 0.009,
+      "phase": 284.87
     },
     {
       "name": "K1",
-      "amplitude": 0.0781038,
-      "phase": 352.047713
+      "amplitude": 0.078,
+      "phase": 343.16
     },
     {
       "name": "P1",
-      "amplitude": 0.033039679999999995,
-      "phase": 336.085845
+      "amplitude": 0.034,
+      "phase": 329.8
     },
     {
       "name": "O1",
-      "amplitude": 0.11026107,
-      "phase": 183.042391
+      "amplitude": 0.11,
+      "phase": 174.77
     },
     {
       "name": "Q1",
-      "amplitude": 0.03635552,
-      "phase": 125.96829500000001
+      "amplitude": 0.037,
+      "phase": 117.65
     },
     {
       "name": "M1",
-      "amplitude": 0.00561596,
-      "phase": 184.476925
+      "amplitude": 0.002,
+      "phase": 332.53
     },
     {
       "name": "M4",
-      "amplitude": 0.15738959,
-      "phase": 125.79945700000002
+      "amplitude": 0.182,
+      "phase": 95.97
     },
     {
       "name": "MM",
-      "amplitude": 0.01667467,
-      "phase": 131.00478099999998
+      "amplitude": 0.017,
+      "phase": 132.05
     },
     {
       "name": "MF",
-      "amplitude": 0.00511119,
-      "phase": 143.71408199999996
+      "amplitude": 0.005,
+      "phase": 138.76
     },
     {
       "name": "SA",
-      "amplitude": 0.08682767999999999,
-      "phase": 208.320041
+      "amplitude": 0.087,
+      "phase": 208.68
     },
     {
       "name": "SSA",
-      "amplitude": 0.01588327,
-      "phase": 171.92665599999998
+      "amplitude": 0.015,
+      "phase": 174.05
     },
     {
       "name": "T2",
-      "amplitude": 0.0353485,
-      "phase": 49.806084
+      "amplitude": 0.014,
+      "phase": 102.1
     },
     {
       "name": "J1",
-      "amplitude": 0.003915989999999999,
-      "phase": 90.12649899999997
+      "amplitude": 0.004,
+      "phase": 80.15
     },
     {
       "name": "L2",
-      "amplitude": 0.0645419,
-      "phase": 90.09841499999999
+      "amplitude": 0.066,
+      "phase": 76.52
     },
     {
       "name": "R2",
-      "amplitude": 0.026002610000000002,
-      "phase": 240.636815
+      "amplitude": 0.002,
+      "phase": 115.78
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00618042,
-      "phase": 93.385854
+      "amplitude": 0.006,
+      "phase": 85.36
     },
     {
       "name": "MSF",
-      "amplitude": 0.015687120000000002,
-      "phase": 38.736559
+      "amplitude": 0.016,
+      "phase": 37.18
     },
     {
       "name": "MSQM",
-      "amplitude": 0.013561700000000001,
-      "phase": 68.69549899999998
+      "amplitude": 0.013,
+      "phase": 66.59
     },
     {
       "name": "EP2",
-      "amplitude": 0.01723119,
-      "phase": 161.625319
+      "amplitude": 0.018,
+      "phase": 149.72
     },
     {
       "name": "M3",
-      "amplitude": 0.00216562,
-      "phase": 235.129808
+      "amplitude": 0.002,
+      "phase": 25.08
     },
     {
       "name": "MU2",
-      "amplitude": 0.08440384999999999,
-      "phase": 186.885655
+      "amplitude": 0.088,
+      "phase": 170.5
     },
     {
       "name": "MTM",
-      "amplitude": 0.00701406,
-      "phase": 263.422531
+      "amplitude": 0.008,
+      "phase": 262.55
     },
     {
       "name": "NU2",
-      "amplitude": 0.04726219,
-      "phase": 36.836366999999996
+      "amplitude": 0.049,
+      "phase": 21.03
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03330076,
-      "phase": 85.20087799999999
+      "amplitude": 0.034,
+      "phase": 72.54
     },
     {
       "name": "MN4",
-      "amplitude": 0.056166150000000005,
-      "phase": 100.904335
+      "amplitude": 0.065,
+      "phase": 71.04
     },
     {
       "name": "MS4",
-      "amplitude": 0.10198729999999999,
-      "phase": 185.776815
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.040940019999999994,
-      "phase": 213.532536
+      "amplitude": 0.115,
+      "phase": 152.36
     },
     {
       "name": "N4",
-      "amplitude": 0.01206953,
-      "phase": 79.77422200000001
+      "amplitude": 0.014,
+      "phase": 50.26
     },
     {
       "name": "M6",
-      "amplitude": 0.032177449999999996,
-      "phase": 84.56956500000001
+      "amplitude": 0.047,
+      "phase": 35.27
     },
     {
       "name": "M8",
-      "amplitude": 0.01296197,
-      "phase": 167.69351800000004
+      "amplitude": 0.023,
+      "phase": 102.34
     },
     {
       "name": "S4",
-      "amplitude": 0.008830029999999999,
-      "phase": 261.522041
+      "amplitude": 0.01,
+      "phase": 227.34
     },
     {
       "name": "OO1",
-      "amplitude": 0.005136269999999999,
-      "phase": 121.72736399999997
+      "amplitude": 0.004,
+      "phase": 120.52
     },
     {
       "name": "S3",
-      "amplitude": 0.00155565,
-      "phase": 33.46587599999998
+      "amplitude": 0,
+      "phase": 260.61
     },
     {
       "name": "MA2",
-      "amplitude": 0.13909395,
-      "phase": 49.338532999999984
+      "amplitude": 0.014,
+      "phase": 46.6
     },
     {
       "name": "MB2",
-      "amplitude": 0.11543719,
-      "phase": 262.733529
+      "amplitude": 0.014,
+      "phase": 119.63
     },
     {
       "name": "T3",
-      "amplitude": 0.00023144000000000002,
-      "phase": 320.553517
+      "amplitude": 0.001,
+      "phase": 220.39
     },
     {
       "name": "R3",
-      "amplitude": 0.005812040000000001,
-      "phase": 243.658883
+      "amplitude": 0.006,
+      "phase": 306.29
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00921874,
-      "phase": 145.19514500000002
+      "amplitude": 0.008,
+      "phase": 133.1
     },
     {
       "name": "SGM",
-      "amplitude": 0.0030500300000000004,
-      "phase": 135.18734
+      "amplitude": 0.003,
+      "phase": 307.17
     },
     {
       "name": "3L2",
-      "amplitude": 0.0032995600000000004,
-      "phase": 207.376322
+      "amplitude": 0.004,
+      "phase": 6.22
     },
     {
       "name": "3N2",
-      "amplitude": 0.00684602,
-      "phase": 89.434053
+      "amplitude": 0.012,
+      "phase": 227.91
     },
     {
       "name": "2SM2",
-      "amplitude": 0.026979899999999998,
-      "phase": 7.182325999999989
+      "amplitude": 0.027,
+      "phase": 348.88
     },
     {
       "name": "2MS6",
-      "amplitude": 0.03104784,
-      "phase": 143.69016499999998
+      "amplitude": 0.042,
+      "phase": 93.08
     },
     {
       "name": "2MK5",
-      "amplitude": 0.01289369,
-      "phase": 247.304646
+      "amplitude": 0.016,
+      "phase": 302.41
     },
     {
       "name": "2MO5",
-      "amplitude": 0.01306056,
-      "phase": 271.522226
+      "amplitude": 0.016,
+      "phase": 136.19
     }
   ],
   "epoch": {

--- a/data/ticon/maeslantkering_zeezijde-maeslkrzzde-nld-rws.json
+++ b/data/ticon/maeslantkering_zeezijde-maeslkrzzde-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.73753051,
-      "phase": 76.333035
+      "amplitude": 0.762,
+      "phase": 59.34
     },
     {
       "name": "N2",
-      "amplitude": 0.10917567,
-      "phase": 48.78679999999997
+      "amplitude": 0.113,
+      "phase": 32.38
     },
     {
       "name": "S2",
-      "amplitude": 0.17810862,
-      "phase": 137.610543
+      "amplitude": 0.183,
+      "phase": 120.06
     },
     {
       "name": "K2",
-      "amplitude": 0.04991623,
-      "phase": 143.890581
+      "amplitude": 0.056,
+      "phase": 120.69
     },
     {
       "name": "2N2",
-      "amplitude": 0.011744639999999999,
-      "phase": 13.630224999999996
+      "amplitude": 0.012,
+      "phase": 359.52
     },
     {
       "name": "S1",
-      "amplitude": 0.00825219,
-      "phase": 14.438416000000018
+      "amplitude": 0.008,
+      "phase": 303.25
     },
     {
       "name": "K1",
-      "amplitude": 0.07422558,
-      "phase": 356.745656
+      "amplitude": 0.075,
+      "phase": 347.85
     },
     {
       "name": "P1",
-      "amplitude": 0.0322228,
-      "phase": 340.47927
+      "amplitude": 0.033,
+      "phase": 334.01
     },
     {
       "name": "O1",
-      "amplitude": 0.10248968,
-      "phase": 187.232666
+      "amplitude": 0.103,
+      "phase": 178.87
     },
     {
       "name": "Q1",
-      "amplitude": 0.03345741,
-      "phase": 131.117685
+      "amplitude": 0.034,
+      "phase": 122.77
     },
     {
       "name": "M1",
-      "amplitude": 0.00106152,
-      "phase": 343.072649
+      "amplitude": 0.003,
+      "phase": 5.27
     },
     {
       "name": "M4",
-      "amplitude": 0.15006629999999999,
-      "phase": 148.574144
+      "amplitude": 0.175,
+      "phase": 113.57
     },
     {
       "name": "MM",
-      "amplitude": 0.00858366,
-      "phase": 164.806554
+      "amplitude": 0.009,
+      "phase": 163.97
     },
     {
       "name": "MF",
-      "amplitude": 0.01105232,
-      "phase": 138.16306599999996
+      "amplitude": 0.011,
+      "phase": 137.56
     },
     {
       "name": "SA",
-      "amplitude": 0.08442921,
-      "phase": 225.283044
+      "amplitude": 0.085,
+      "phase": 224.95
     },
     {
       "name": "SSA",
-      "amplitude": 0.02324023,
-      "phase": 182.253815
+      "amplitude": 0.023,
+      "phase": 182.23
     },
     {
       "name": "T2",
-      "amplitude": 0.03296055,
-      "phase": 55.613613999999984
+      "amplitude": 0.013,
+      "phase": 107.15
     },
     {
       "name": "J1",
-      "amplitude": 0.00354337,
-      "phase": 91.38055800000001
+      "amplitude": 0.003,
+      "phase": 81.27
     },
     {
       "name": "L2",
-      "amplitude": 0.06519111,
-      "phase": 98.75609300000002
+      "amplitude": 0.068,
+      "phase": 80.98
     },
     {
       "name": "R2",
-      "amplitude": 0.022586460000000003,
-      "phase": 248.021346
+      "amplitude": 0.001,
+      "phase": 37.9
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00603592,
-      "phase": 81.78848700000003
+      "amplitude": 0.006,
+      "phase": 77.98
     },
     {
       "name": "MSF",
-      "amplitude": 0.016364939999999998,
-      "phase": 36.680926
+      "amplitude": 0.016,
+      "phase": 36.19
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00531895,
-      "phase": 76.74176499999999
+      "amplitude": 0.005,
+      "phase": 74.61
     },
     {
       "name": "EP2",
-      "amplitude": 0.01691614,
-      "phase": 175.75275799999997
+      "amplitude": 0.017,
+      "phase": 160
     },
     {
       "name": "M3",
-      "amplitude": 0.00179226,
-      "phase": 277.517087
+      "amplitude": 0.002,
+      "phase": 68.58
     },
     {
       "name": "MU2",
-      "amplitude": 0.08043634000000001,
-      "phase": 194.431565
+      "amplitude": 0.084,
+      "phase": 177.47
     },
     {
       "name": "MTM",
-      "amplitude": 0.00295902,
-      "phase": 265.185807
+      "amplitude": 0.003,
+      "phase": 266.99
     },
     {
       "name": "NU2",
-      "amplitude": 0.04626831,
-      "phase": 44.00192099999998
+      "amplitude": 0.048,
+      "phase": 27.02
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03060451,
-      "phase": 99.56131199999999
+      "amplitude": 0.031,
+      "phase": 80.39
     },
     {
       "name": "MN4",
-      "amplitude": 0.05327315,
-      "phase": 123.98962499999999
+      "amplitude": 0.062,
+      "phase": 90.01
     },
     {
       "name": "MS4",
-      "amplitude": 0.09474192000000001,
-      "phase": 204.544142
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03750505,
-      "phase": 216.151772
+      "amplitude": 0.109,
+      "phase": 169.73
     },
     {
       "name": "N4",
-      "amplitude": 0.01194774,
-      "phase": 97.72244699999999
+      "amplitude": 0.014,
+      "phase": 64.84
     },
     {
       "name": "M6",
-      "amplitude": 0.0293002,
-      "phase": 100.35601600000001
+      "amplitude": 0.04,
+      "phase": 46.98
     },
     {
       "name": "M8",
-      "amplitude": 0.011429370000000001,
-      "phase": 197.077736
+      "amplitude": 0.021,
+      "phase": 118.84
     },
     {
       "name": "S4",
-      "amplitude": 0.00867128,
-      "phase": 281.90637
+      "amplitude": 0.01,
+      "phase": 247.39
     },
     {
       "name": "OO1",
-      "amplitude": 0.00415693,
-      "phase": 144.586206
+      "amplitude": 0.004,
+      "phase": 130.6
     },
     {
       "name": "S3",
-      "amplitude": 0.00166218,
-      "phase": 49.402292999999986
+      "amplitude": 0,
+      "phase": 278.61
     },
     {
       "name": "MA2",
-      "amplitude": 0.13136802,
-      "phase": 55.490508999999975
+      "amplitude": 0.015,
+      "phase": 54.82
     },
     {
       "name": "MB2",
-      "amplitude": 0.11296995000000001,
-      "phase": 271.255319
+      "amplitude": 0.008,
+      "phase": 120.26
     },
     {
       "name": "T3",
-      "amplitude": 0.00119593,
-      "phase": 5.719723999999985
+      "amplitude": 0.001,
+      "phase": 189.92
     },
     {
       "name": "R3",
-      "amplitude": 0.0048506,
-      "phase": 243.05212899999998
+      "amplitude": 0.005,
+      "phase": 307.05
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0080782,
-      "phase": 133.306403
+      "amplitude": 0.008,
+      "phase": 126.29
     },
     {
       "name": "SGM",
-      "amplitude": 0.00176927,
-      "phase": 138.15678200000002
+      "amplitude": 0.002,
+      "phase": 305.1
     },
     {
       "name": "3L2",
-      "amplitude": 0.00059322,
-      "phase": 320.565077
+      "amplitude": 0.001,
+      "phase": 66.95
     },
     {
       "name": "3N2",
-      "amplitude": 0.00295929,
-      "phase": 73.24540100000002
+      "amplitude": 0.01,
+      "phase": 233.51
     },
     {
       "name": "2SM2",
-      "amplitude": 0.023662950000000002,
-      "phase": 12.944637999999998
+      "amplitude": 0.024,
+      "phase": 354.73
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02577686,
-      "phase": 158.244375
+      "amplitude": 0.034,
+      "phase": 104.15
     },
     {
       "name": "2MK5",
-      "amplitude": 0.010095920000000001,
-      "phase": 267.37444800000003
+      "amplitude": 0.013,
+      "phase": 313.52
     },
     {
       "name": "2MO5",
-      "amplitude": 0.01032279,
-      "phase": 280.914692
+      "amplitude": 0.013,
+      "phase": 147.38
     }
   ],
   "epoch": {

--- a/data/ticon/marienleuchte-9610075-deu-wsv.json
+++ b/data/ticon/marienleuchte-9610075-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.04395565522393181,
-      "phase": 142.998553741582
+      "amplitude": 0.044,
+      "phase": 143
     },
     {
       "name": "N2",
-      "amplitude": 0.010626224858582337,
-      "phase": 81.28684602933515
+      "amplitude": 0.011,
+      "phase": 81.29
     },
     {
       "name": "S2",
-      "amplitude": 0.0060942075654776915,
-      "phase": 111.33455459868003
+      "amplitude": 0.006,
+      "phase": 111.33
     },
     {
       "name": "K2",
-      "amplitude": 0.0014922324041870246,
-      "phase": 94.84054754019166
+      "amplitude": 0.001,
+      "phase": 94.84
     },
     {
       "name": "2N2",
-      "amplitude": 0.00142551716182641,
-      "phase": 41.02766328945171
+      "amplitude": 0.001,
+      "phase": 41.03
     },
     {
       "name": "S1",
-      "amplitude": 0.004660164401263479,
-      "phase": 177.47179892310464
+      "amplitude": 0.005,
+      "phase": 177.47
     },
     {
       "name": "K1",
-      "amplitude": 0.01690200322747699,
-      "phase": 199.19957257791674
+      "amplitude": 0.017,
+      "phase": 199.2
     },
     {
       "name": "P1",
-      "amplitude": 0.005949436854230412,
-      "phase": 234.69011670645142
+      "amplitude": 0.006,
+      "phase": 234.69
     },
     {
       "name": "O1",
-      "amplitude": 0.016362538002612895,
-      "phase": 114.64748356770559
+      "amplitude": 0.016,
+      "phase": 114.65
     },
     {
       "name": "Q1",
-      "amplitude": 0.0030334837333808916,
-      "phase": 319.1409071129723
+      "amplitude": 0.003,
+      "phase": 319.14
     },
     {
       "name": "M1",
-      "amplitude": 0.000368755613767797,
-      "phase": 74.04191008003318
+      "amplitude": 0,
+      "phase": 74.04
     },
     {
       "name": "M4",
-      "amplitude": 0.0008842462862642404,
-      "phase": 258.0503223358217
+      "amplitude": 0.001,
+      "phase": 258.05
     },
     {
       "name": "MM",
-      "amplitude": 0.010557801333671336,
-      "phase": 290.6862759706906
+      "amplitude": 0.011,
+      "phase": 290.69
     },
     {
       "name": "MF",
-      "amplitude": 0.008277865209784949,
-      "phase": 254.08204473167174
+      "amplitude": 0.008,
+      "phase": 254.08
     },
     {
       "name": "SA",
-      "amplitude": 0.03465236746221305,
-      "phase": 168.97820309945837
+      "amplitude": 0.035,
+      "phase": 168.98
     },
     {
       "name": "SSA",
-      "amplitude": 0.02206972136325799,
-      "phase": 248.57038060629685
+      "amplitude": 0.022,
+      "phase": 248.57
     },
     {
       "name": "T2",
-      "amplitude": 0.0006843517807696127,
-      "phase": 81.90779224996481
+      "amplitude": 0.001,
+      "phase": 81.91
     },
     {
       "name": "J1",
-      "amplitude": 0.001133255727369209,
-      "phase": 155.67622878366853
+      "amplitude": 0.001,
+      "phase": 155.68
     },
     {
       "name": "L2",
-      "amplitude": 0.00430659303289514,
-      "phase": 234.17895974737826
+      "amplitude": 0.004,
+      "phase": 234.18
     },
     {
       "name": "R2",
-      "amplitude": 0.0007474386506807557,
-      "phase": 165.8274739640549
+      "amplitude": 0.001,
+      "phase": 165.83
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0006052753790999484,
-      "phase": 259.87263298426546
+      "amplitude": 0.001,
+      "phase": 259.87
     },
     {
       "name": "MSF",
-      "amplitude": 0.0025939782221550494,
-      "phase": 256.05939617362225
+      "amplitude": 0.003,
+      "phase": 256.06
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004338159054779538,
-      "phase": 205.1900007074965
+      "amplitude": 0.004,
+      "phase": 205.19
     },
     {
       "name": "EP2",
-      "amplitude": 0.002562737567817331,
-      "phase": 249.29173031530357
+      "amplitude": 0.003,
+      "phase": 249.29
     },
     {
       "name": "M3",
-      "amplitude": 0.0004207533955233096,
-      "phase": 330.34713596417845
+      "amplitude": 0,
+      "phase": 330.35
     },
     {
       "name": "MU2",
-      "amplitude": 0.009614314888006664,
-      "phase": 290.9685211494773
+      "amplitude": 0.01,
+      "phase": 290.97
     },
     {
       "name": "MTM",
-      "amplitude": 0.0036194569685151054,
-      "phase": 358.36080487497003
+      "amplitude": 0.004,
+      "phase": 358.36
     },
     {
       "name": "NU2",
-      "amplitude": 0.003723348534899417,
-      "phase": 119.54957003463278
+      "amplitude": 0.004,
+      "phase": 119.55
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.002321695141642946,
-      "phase": 228.12072087950784
+      "amplitude": 0.002,
+      "phase": 228.12
     },
     {
       "name": "MN4",
-      "amplitude": 0.0002572238283348678,
-      "phase": 208.77008983612538
+      "amplitude": 0,
+      "phase": 208.77
     },
     {
       "name": "MS4",
-      "amplitude": 0.00028253328039901267,
-      "phase": 35.37412773107633
+      "amplitude": 0,
+      "phase": 35.37
     },
     {
       "name": "N4",
-      "amplitude": 0.000045911859515359664,
-      "phase": 176.48285233369347
+      "amplitude": 0,
+      "phase": 176.48
     },
     {
       "name": "M6",
-      "amplitude": 0.0001790573657419749,
-      "phase": 302.2470317911128
+      "amplitude": 0,
+      "phase": 302.25
     },
     {
       "name": "M8",
-      "amplitude": 0.00003334114924362985,
-      "phase": 358.455037795461
+      "amplitude": 0,
+      "phase": 358.46
     },
     {
       "name": "S4",
-      "amplitude": 0.0001029709038245634,
-      "phase": 341.3453862182343
+      "amplitude": 0,
+      "phase": 341.35
     },
     {
       "name": "OO1",
-      "amplitude": 0.0013184586348849925,
-      "phase": 120.97692890241848
+      "amplitude": 0.001,
+      "phase": 120.98
     },
     {
       "name": "S3",
-      "amplitude": 0.00009117355434694618,
-      "phase": 51.129889300821105
+      "amplitude": 0,
+      "phase": 51.13
     },
     {
       "name": "MA2",
-      "amplitude": 0.0048119792644399015,
-      "phase": 108.99467066109668
+      "amplitude": 0.005,
+      "phase": 108.99
     },
     {
       "name": "MB2",
-      "amplitude": 0.005449785999540368,
-      "phase": 272.9029395900167
+      "amplitude": 0.005,
+      "phase": 272.9
     },
     {
       "name": "T3",
-      "amplitude": 0.00036544369999367394,
-      "phase": 250.2363987853926
+      "amplitude": 0,
+      "phase": 250.24
     },
     {
       "name": "R3",
-      "amplitude": 0.00036339631212317967,
-      "phase": 13.003600388130394
+      "amplitude": 0,
+      "phase": 13
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00040363544414823187,
-      "phase": 268.8629587989162
+      "amplitude": 0,
+      "phase": 268.86
     },
     {
       "name": "SGM",
-      "amplitude": 0.0025838230628385077,
-      "phase": 218.35480260128338
+      "amplitude": 0.003,
+      "phase": 218.35
     },
     {
       "name": "3L2",
-      "amplitude": 0.0002251350016738243,
-      "phase": 27.607980205715023
+      "amplitude": 0,
+      "phase": 27.61
     },
     {
       "name": "3N2",
-      "amplitude": 0.0012674400082922145,
-      "phase": 26.53445999753643
+      "amplitude": 0.001,
+      "phase": 26.53
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0011354281708387283,
-      "phase": 215.2283008821037
+      "amplitude": 0.001,
+      "phase": 215.23
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0001489132842611774,
-      "phase": 43.25119924187936
+      "amplitude": 0,
+      "phase": 43.25
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00008359585988587288,
-      "phase": 118.2861372666431
+      "amplitude": 0,
+      "phase": 118.29
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00004812689658840562,
-      "phase": 311.3189712644553
+      "amplitude": 0,
+      "phase": 311.32
     }
   ],
   "epoch": {

--- a/data/ticon/marollegat-marlgt-nld-rws.json
+++ b/data/ticon/marollegat-marlgt-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.46903294,
-      "phase": 79.86044500000003
+      "amplitude": 1.52,
+      "phase": 64.96
     },
     {
       "name": "N2",
-      "amplitude": 0.23070272,
-      "phase": 56.105102999999986
+      "amplitude": 0.237,
+      "phase": 41.79
     },
     {
       "name": "S2",
-      "amplitude": 0.36446807999999997,
-      "phase": 143.94814199999996
+      "amplitude": 0.378,
+      "phase": 128.78
     },
     {
       "name": "K2",
-      "amplitude": 0.10633373,
-      "phase": 144.445066
+      "amplitude": 0.108,
+      "phase": 128.89
     },
     {
       "name": "2N2",
-      "amplitude": 0.03669294,
-      "phase": 42.39471600000002
+      "amplitude": 0.036,
+      "phase": 28.05
     },
     {
       "name": "S1",
-      "amplitude": 0.011953430000000001,
-      "phase": 54.36873400000002
+      "amplitude": 0.01,
+      "phase": 356.29
     },
     {
       "name": "K1",
-      "amplitude": 0.07064291,
-      "phase": 23.284538999999995
+      "amplitude": 0.072,
+      "phase": 15.2
     },
     {
       "name": "P1",
-      "amplitude": 0.03767712,
-      "phase": 10.304479000000015
+      "amplitude": 0.038,
+      "phase": 1.44
     },
     {
       "name": "O1",
-      "amplitude": 0.10402537,
-      "phase": 202.921786
+      "amplitude": 0.104,
+      "phase": 195.38
     },
     {
       "name": "Q1",
-      "amplitude": 0.03314188,
-      "phase": 149.91263600000002
+      "amplitude": 0.033,
+      "phase": 143.35
     },
     {
       "name": "M1",
-      "amplitude": 0.00648443,
-      "phase": 52.64989700000001
+      "amplitude": 0.001,
+      "phase": 83.78
     },
     {
       "name": "M4",
-      "amplitude": 0.08668169,
-      "phase": 191.670693
+      "amplitude": 0.101,
+      "phase": 162.28
     },
     {
       "name": "MM",
-      "amplitude": 0.00840352,
-      "phase": 155.15322000000003
+      "amplitude": 0.009,
+      "phase": 153.49
     },
     {
       "name": "MF",
-      "amplitude": 0.00588331,
-      "phase": 125.82486900000004
+      "amplitude": 0.006,
+      "phase": 124.35
     },
     {
       "name": "SA",
-      "amplitude": 0.06388867000000001,
-      "phase": 211.258292
+      "amplitude": 0.064,
+      "phase": 211.16
     },
     {
       "name": "SSA",
-      "amplitude": 0.01189721,
-      "phase": 202.029536
+      "amplitude": 0.012,
+      "phase": 201.59
     },
     {
       "name": "T2",
-      "amplitude": 0.06983148,
-      "phase": 73.38194799999997
+      "amplitude": 0.016,
+      "phase": 133.5
     },
     {
       "name": "J1",
-      "amplitude": 0.00513848,
-      "phase": 148.22983399999998
+      "amplitude": 0.006,
+      "phase": 138.85
     },
     {
       "name": "L2",
-      "amplitude": 0.11392258999999999,
-      "phase": 97.17065100000002
+      "amplitude": 0.118,
+      "phase": 81.39
     },
     {
       "name": "R2",
-      "amplitude": 0.0468191,
-      "phase": 225.68864
+      "amplitude": 0.007,
+      "phase": 182.05
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00768567,
-      "phase": 143.016166
+      "amplitude": 0.007,
+      "phase": 136.24
     },
     {
       "name": "MSF",
-      "amplitude": 0.05681313,
-      "phase": 25.672237999999993
+      "amplitude": 0.058,
+      "phase": 25.32
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0017616499999999998,
-      "phase": 247.492101
+      "amplitude": 0.002,
+      "phase": 252.15
     },
     {
       "name": "EP2",
-      "amplitude": 0.03254873,
-      "phase": 158.09020899999996
+      "amplitude": 0.033,
+      "phase": 147.12
     },
     {
       "name": "M3",
-      "amplitude": 0.00348781,
-      "phase": 210.720097
+      "amplitude": 0.004,
+      "phase": 6.73
     },
     {
       "name": "MU2",
-      "amplitude": 0.15926956,
-      "phase": 179.45572100000004
+      "amplitude": 0.164,
+      "phase": 165.59
     },
     {
       "name": "MTM",
-      "amplitude": 0.00419335,
-      "phase": 115.04855199999997
+      "amplitude": 0.005,
+      "phase": 123.54
     },
     {
       "name": "NU2",
-      "amplitude": 0.08825068999999999,
-      "phase": 43.12524100000002
+      "amplitude": 0.09,
+      "phase": 25.39
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05407005,
-      "phase": 92.48019799999997
+      "amplitude": 0.058,
+      "phase": 81.22
     },
     {
       "name": "MN4",
-      "amplitude": 0.02839172,
-      "phase": 168.62388599999997
+      "amplitude": 0.034,
+      "phase": 140.9
     },
     {
       "name": "MS4",
-      "amplitude": 0.05322722,
-      "phase": 247.456356
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.02631256,
-      "phase": 245.564256
+      "amplitude": 0.063,
+      "phase": 216.1
     },
     {
       "name": "N4",
-      "amplitude": 0.006248470000000001,
-      "phase": 160.82028200000002
+      "amplitude": 0.008,
+      "phase": 127.41
     },
     {
       "name": "M6",
-      "amplitude": 0.06086271,
-      "phase": 216.301022
+      "amplitude": 0.092,
+      "phase": 166.75
     },
     {
       "name": "M8",
-      "amplitude": 0.0030497600000000003,
-      "phase": 207.009071
+      "amplitude": 0.007,
+      "phase": 150.27
     },
     {
       "name": "S4",
-      "amplitude": 0.00302547,
-      "phase": 348.195457
+      "amplitude": 0.003,
+      "phase": 314.08
     },
     {
       "name": "OO1",
-      "amplitude": 0.0071503700000000005,
-      "phase": 178.77159600000005
+      "amplitude": 0.005,
+      "phase": 176.9
     },
     {
       "name": "S3",
-      "amplitude": 0.0023945900000000003,
-      "phase": 105.81097299999999
+      "amplitude": 0.001,
+      "phase": 206.25
     },
     {
       "name": "MA2",
-      "amplitude": 0.25882971,
-      "phase": 69.42179699999997
+      "amplitude": 0.025,
+      "phase": 3.2
     },
     {
       "name": "MB2",
-      "amplitude": 0.25059178,
-      "phase": 259.830872
+      "amplitude": 0.022,
+      "phase": 177.91
     },
     {
       "name": "T3",
-      "amplitude": 0.00188538,
-      "phase": 96.940812
+      "amplitude": 0.002,
+      "phase": 259.93
     },
     {
       "name": "R3",
-      "amplitude": 0.00521205,
-      "phase": 326.894604
+      "amplitude": 0.005,
+      "phase": 26.35
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00805837,
-      "phase": 142.620537
+      "amplitude": 0.007,
+      "phase": 139.83
     },
     {
       "name": "SGM",
-      "amplitude": 0.010181389999999998,
-      "phase": 85.63559199999997
+      "amplitude": 0.009,
+      "phase": 260.11
     },
     {
       "name": "3L2",
-      "amplitude": 0.0066010800000000005,
-      "phase": 141.808448
+      "amplitude": 0.004,
+      "phase": 205.52
     },
     {
       "name": "3N2",
-      "amplitude": 0.02266575,
-      "phase": 9.223850000000027
+      "amplitude": 0.026,
+      "phase": 235.05
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04562847,
-      "phase": 9.212613999999974
+      "amplitude": 0.048,
+      "phase": 356.01
     },
     {
       "name": "2MS6",
-      "amplitude": 0.051790909999999996,
-      "phase": 266.591317
+      "amplitude": 0.08,
+      "phase": 218.68
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00253552,
-      "phase": 155.16487200000006
+      "amplitude": 0.003,
+      "phase": 206.49
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00324214,
-      "phase": 15.513824
+      "amplitude": 0.003,
+      "phase": 250.05
     }
   ],
   "epoch": {

--- a/data/ticon/mellumplate-9420010-deu-wsv.json
+++ b/data/ticon/mellumplate-9420010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3885319980497641,
-      "phase": 314.6134657051537
+      "amplitude": 1.389,
+      "phase": 314.61
     },
     {
       "name": "N2",
-      "amplitude": 0.22148960400350842,
-      "phase": 289.5888744702934
+      "amplitude": 0.221,
+      "phase": 289.59
     },
     {
       "name": "S2",
-      "amplitude": 0.36480178914344774,
-      "phase": 24.39593190336683
+      "amplitude": 0.365,
+      "phase": 24.4
     },
     {
       "name": "K2",
-      "amplitude": 0.10862998775051788,
-      "phase": 22.337745604405313
+      "amplitude": 0.109,
+      "phase": 22.34
     },
     {
       "name": "2N2",
-      "amplitude": 0.02458619996329096,
-      "phase": 270.18926690334416
+      "amplitude": 0.025,
+      "phase": 270.19
     },
     {
       "name": "S1",
-      "amplitude": 0.010497287052979105,
-      "phase": 22.327071113979628
+      "amplitude": 0.01,
+      "phase": 22.33
     },
     {
       "name": "K1",
-      "amplitude": 0.07200271905321867,
-      "phase": 23.47374462869419
+      "amplitude": 0.072,
+      "phase": 23.47
     },
     {
       "name": "P1",
-      "amplitude": 0.029652299951342116,
-      "phase": 29.07727648249721
+      "amplitude": 0.03,
+      "phase": 29.08
     },
     {
       "name": "O1",
-      "amplitude": 0.09323434335657567,
-      "phase": 233.68113662027977
+      "amplitude": 0.093,
+      "phase": 233.68
     },
     {
       "name": "Q1",
-      "amplitude": 0.029412769597027447,
-      "phase": 175.60099833681784
+      "amplitude": 0.029,
+      "phase": 175.6
     },
     {
       "name": "M1",
-      "amplitude": 0.0016676014530803245,
-      "phase": 85.77006603948502
+      "amplitude": 0.002,
+      "phase": 85.77
     },
     {
       "name": "M4",
-      "amplitude": 0.07777324233235973,
-      "phase": 132.9107231599304
+      "amplitude": 0.078,
+      "phase": 132.91
     },
     {
       "name": "MM",
-      "amplitude": 0.022969737659361198,
-      "phase": 176.8763845209669
+      "amplitude": 0.023,
+      "phase": 176.88
     },
     {
       "name": "MF",
-      "amplitude": 0.010061974110680365,
-      "phase": 175.12825999609663
+      "amplitude": 0.01,
+      "phase": 175.13
     },
     {
       "name": "SA",
-      "amplitude": 0.10444872746873955,
-      "phase": 222.5346549965166
+      "amplitude": 0.104,
+      "phase": 222.53
     },
     {
       "name": "SSA",
-      "amplitude": 0.03478040610678308,
-      "phase": 205.21795804925804
+      "amplitude": 0.035,
+      "phase": 205.22
     },
     {
       "name": "T2",
-      "amplitude": 0.02040278811178827,
-      "phase": 2.6815183819641106
+      "amplitude": 0.02,
+      "phase": 2.68
     },
     {
       "name": "J1",
-      "amplitude": 0.001851790771657293,
-      "phase": 138.7945385767839
+      "amplitude": 0.002,
+      "phase": 138.79
     },
     {
       "name": "L2",
-      "amplitude": 0.11015491787729811,
-      "phase": 331.4877656546065
+      "amplitude": 0.11,
+      "phase": 331.49
     },
     {
       "name": "R2",
-      "amplitude": 0.003014561766833486,
-      "phase": 5.466825455585536
+      "amplitude": 0.003,
+      "phase": 5.47
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005902837738731523,
-      "phase": 120.62834584895347
+      "amplitude": 0.006,
+      "phase": 120.63
     },
     {
       "name": "MSF",
-      "amplitude": 0.005510247842034822,
-      "phase": 22.19747750985556
+      "amplitude": 0.006,
+      "phase": 22.2
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007844586935400364,
-      "phase": 65.3613865841429
+      "amplitude": 0.008,
+      "phase": 65.36
     },
     {
       "name": "EP2",
-      "amplitude": 0.031157620724222037,
-      "phase": 18.42613162217981
+      "amplitude": 0.031,
+      "phase": 18.43
     },
     {
       "name": "M3",
-      "amplitude": 0.003696931126959806,
-      "phase": 329.41950893692257
+      "amplitude": 0.004,
+      "phase": 329.42
     },
     {
       "name": "MU2",
-      "amplitude": 0.13816886637725717,
-      "phase": 41.316391155370695
+      "amplitude": 0.138,
+      "phase": 41.32
     },
     {
       "name": "MTM",
-      "amplitude": 0.004801197402281695,
-      "phase": 244.13433275501137
+      "amplitude": 0.005,
+      "phase": 244.13
     },
     {
       "name": "NU2",
-      "amplitude": 0.07960038608102549,
-      "phase": 273.4068932937846
+      "amplitude": 0.08,
+      "phase": 273.41
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05254778437504642,
-      "phase": 325.44461644698566
+      "amplitude": 0.053,
+      "phase": 325.44
     },
     {
       "name": "MN4",
-      "amplitude": 0.025832225262314736,
-      "phase": 113.50053520647344
+      "amplitude": 0.026,
+      "phase": 113.5
     },
     {
       "name": "MS4",
-      "amplitude": 0.05387680048300978,
-      "phase": 200.00673982879843
+      "amplitude": 0.054,
+      "phase": 200.01
     },
     {
       "name": "N4",
-      "amplitude": 0.005679943034631758,
-      "phase": 94.89738525065269
+      "amplitude": 0.006,
+      "phase": 94.9
     },
     {
       "name": "M6",
-      "amplitude": 0.049961804897122875,
-      "phase": 304.4397707882613
+      "amplitude": 0.05,
+      "phase": 304.44
     },
     {
       "name": "M8",
-      "amplitude": 0.008537063934045342,
-      "phase": 132.36403272254557
+      "amplitude": 0.009,
+      "phase": 132.36
     },
     {
       "name": "S4",
-      "amplitude": 0.006681342322648401,
-      "phase": 320.62763188621466
+      "amplitude": 0.007,
+      "phase": 320.63
     },
     {
       "name": "OO1",
-      "amplitude": 0.0025266501274511495,
-      "phase": 190.06873057850248
+      "amplitude": 0.003,
+      "phase": 190.07
     },
     {
       "name": "S3",
-      "amplitude": 0.00044368169340237016,
-      "phase": 131.6748517874346
+      "amplitude": 0,
+      "phase": 131.67
     },
     {
       "name": "MA2",
-      "amplitude": 0.04528184772688797,
-      "phase": 266.37163957402896
+      "amplitude": 0.045,
+      "phase": 266.37
     },
     {
       "name": "MB2",
-      "amplitude": 0.0249426125272611,
-      "phase": 40.65026852260945
+      "amplitude": 0.025,
+      "phase": 40.65
     },
     {
       "name": "T3",
-      "amplitude": 0.0002450047674646618,
-      "phase": 330.5827702488404
+      "amplitude": 0,
+      "phase": 330.58
     },
     {
       "name": "R3",
-      "amplitude": 0.002396521981912789,
-      "phase": 10.169191629631484
+      "amplitude": 0.002,
+      "phase": 10.17
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0058206710901663895,
-      "phase": 180.4819300968005
+      "amplitude": 0.006,
+      "phase": 180.48
     },
     {
       "name": "SGM",
-      "amplitude": 0.0023385067189146337,
-      "phase": 44.44280271743264
+      "amplitude": 0.002,
+      "phase": 44.44
     },
     {
       "name": "3L2",
-      "amplitude": 0.003954591098221062,
-      "phase": 226.3466314937977
+      "amplitude": 0.004,
+      "phase": 226.35
     },
     {
       "name": "3N2",
-      "amplitude": 0.0179850659064427,
-      "phase": 114.76408368616762
+      "amplitude": 0.018,
+      "phase": 114.76
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03528788719202053,
-      "phase": 245.103811734867
+      "amplitude": 0.035,
+      "phase": 245.1
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05062529817913909,
-      "phase": 6.509873946946129
+      "amplitude": 0.051,
+      "phase": 6.51
     },
     {
       "name": "2MK5",
-      "amplitude": 0.002677463072894201,
-      "phase": 356.0214631770831
+      "amplitude": 0.003,
+      "phase": 356.02
     },
     {
       "name": "2MO5",
-      "amplitude": 0.002585156799864243,
-      "phase": 245.22523835657063
+      "amplitude": 0.003,
+      "phase": 245.23
     }
   ],
   "epoch": {

--- a/data/ticon/mittelgrund-9510132-deu-wsv.json
+++ b/data/ticon/mittelgrund-9510132-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4141920053225956,
-      "phase": 329.976897519107
+      "amplitude": 1.414,
+      "phase": 329.98
     },
     {
       "name": "N2",
-      "amplitude": 0.2242830016327055,
-      "phase": 304.7752933189622
+      "amplitude": 0.224,
+      "phase": 304.78
     },
     {
       "name": "S2",
-      "amplitude": 0.3719286831253084,
-      "phase": 39.6796872207928
+      "amplitude": 0.372,
+      "phase": 39.68
     },
     {
       "name": "K2",
-      "amplitude": 0.11109948423178094,
-      "phase": 37.72400940178915
+      "amplitude": 0.111,
+      "phase": 37.72
     },
     {
       "name": "2N2",
-      "amplitude": 0.024778022361030043,
-      "phase": 283.93320583659875
+      "amplitude": 0.025,
+      "phase": 283.93
     },
     {
       "name": "S1",
-      "amplitude": 0.011847758626660236,
-      "phase": 29.652016385532306
+      "amplitude": 0.012,
+      "phase": 29.65
     },
     {
       "name": "K1",
-      "amplitude": 0.0714630957251089,
-      "phase": 32.931069456564046
+      "amplitude": 0.071,
+      "phase": 32.93
     },
     {
       "name": "P1",
-      "amplitude": 0.03034388425382239,
-      "phase": 38.277226826961964
+      "amplitude": 0.03,
+      "phase": 38.28
     },
     {
       "name": "O1",
-      "amplitude": 0.09397852999378345,
-      "phase": 242.80246441064878
+      "amplitude": 0.094,
+      "phase": 242.8
     },
     {
       "name": "Q1",
-      "amplitude": 0.0294100860435125,
-      "phase": 185.3341709063608
+      "amplitude": 0.029,
+      "phase": 185.33
     },
     {
       "name": "M1",
-      "amplitude": 0.0017124106834749602,
-      "phase": 100.80728459204215
+      "amplitude": 0.002,
+      "phase": 100.81
     },
     {
       "name": "M4",
-      "amplitude": 0.0710282529459322,
-      "phase": 180.50937049640808
+      "amplitude": 0.071,
+      "phase": 180.51
     },
     {
       "name": "MM",
-      "amplitude": 0.025052801457630957,
-      "phase": 164.37805177080418
+      "amplitude": 0.025,
+      "phase": 164.38
     },
     {
       "name": "MF",
-      "amplitude": 0.010705055812887141,
-      "phase": 161.84472723989325
+      "amplitude": 0.011,
+      "phase": 161.84
     },
     {
       "name": "SA",
-      "amplitude": 0.10143930406312068,
-      "phase": 222.0486563846562
+      "amplitude": 0.101,
+      "phase": 222.05
     },
     {
       "name": "SSA",
-      "amplitude": 0.041818356063769116,
-      "phase": 209.52728422842773
+      "amplitude": 0.042,
+      "phase": 209.53
     },
     {
       "name": "T2",
-      "amplitude": 0.019329818641383452,
-      "phase": 22.581843391562415
+      "amplitude": 0.019,
+      "phase": 22.58
     },
     {
       "name": "J1",
-      "amplitude": 0.0021978817362168826,
-      "phase": 163.93058960854546
+      "amplitude": 0.002,
+      "phase": 163.93
     },
     {
       "name": "L2",
-      "amplitude": 0.11281026886889328,
-      "phase": 347.5943460258776
+      "amplitude": 0.113,
+      "phase": 347.59
     },
     {
       "name": "R2",
-      "amplitude": 0.003599538852639531,
-      "phase": 17.580310439534287
+      "amplitude": 0.004,
+      "phase": 17.58
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006573587420258442,
-      "phase": 125.27229216760571
+      "amplitude": 0.007,
+      "phase": 125.27
     },
     {
       "name": "MSF",
-      "amplitude": 0.011599768573008516,
-      "phase": 45.12059007713833
+      "amplitude": 0.012,
+      "phase": 45.12
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007734817630410552,
-      "phase": 62.220018166805914
+      "amplitude": 0.008,
+      "phase": 62.22
     },
     {
       "name": "EP2",
-      "amplitude": 0.03222994859935816,
-      "phase": 34.40430421021426
+      "amplitude": 0.032,
+      "phase": 34.4
     },
     {
       "name": "M3",
-      "amplitude": 0.004357319478200369,
-      "phase": 354.4137112500984
+      "amplitude": 0.004,
+      "phase": 354.41
     },
     {
       "name": "MU2",
-      "amplitude": 0.1432380736474414,
-      "phase": 58.36411398608533
+      "amplitude": 0.143,
+      "phase": 58.36
     },
     {
       "name": "MTM",
-      "amplitude": 0.004427535861290724,
-      "phase": 267.4182331001816
+      "amplitude": 0.004,
+      "phase": 267.42
     },
     {
       "name": "NU2",
-      "amplitude": 0.08174791049833291,
-      "phase": 289.61597338427464
+      "amplitude": 0.082,
+      "phase": 289.62
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05393236582700997,
-      "phase": 341.58515105695204
+      "amplitude": 0.054,
+      "phase": 341.59
     },
     {
       "name": "MN4",
-      "amplitude": 0.025449127488882513,
-      "phase": 163.1389710904591
+      "amplitude": 0.025,
+      "phase": 163.14
     },
     {
       "name": "MS4",
-      "amplitude": 0.05113345547596814,
-      "phase": 244.33388937093017
+      "amplitude": 0.051,
+      "phase": 244.33
     },
     {
       "name": "N4",
-      "amplitude": 0.0058726118361725485,
-      "phase": 145.01770107261717
+      "amplitude": 0.006,
+      "phase": 145.02
     },
     {
       "name": "M6",
-      "amplitude": 0.05892247783289331,
-      "phase": 26.191158648407395
+      "amplitude": 0.059,
+      "phase": 26.19
     },
     {
       "name": "M8",
-      "amplitude": 0.008850454788847656,
-      "phase": 238.67084837080768
+      "amplitude": 0.009,
+      "phase": 238.67
     },
     {
       "name": "S4",
-      "amplitude": 0.0073758241673541405,
-      "phase": 359.98523129931476
+      "amplitude": 0.007,
+      "phase": 359.99
     },
     {
       "name": "OO1",
-      "amplitude": 0.002577069601410619,
-      "phase": 198.88652949902078
+      "amplitude": 0.003,
+      "phase": 198.89
     },
     {
       "name": "S3",
-      "amplitude": 0.000692271513031003,
-      "phase": 214.16905219321205
+      "amplitude": 0.001,
+      "phase": 214.17
     },
     {
       "name": "MA2",
-      "amplitude": 0.04273585499714057,
-      "phase": 273.5682132569491
+      "amplitude": 0.043,
+      "phase": 273.57
     },
     {
       "name": "MB2",
-      "amplitude": 0.027410866295856814,
-      "phase": 45.256108707152066
+      "amplitude": 0.027,
+      "phase": 45.26
     },
     {
       "name": "T3",
-      "amplitude": 0.0001325864187255891,
-      "phase": 54.27656985746944
+      "amplitude": 0,
+      "phase": 54.28
     },
     {
       "name": "R3",
-      "amplitude": 0.0022486804391234705,
-      "phase": 21.542756101857094
+      "amplitude": 0.002,
+      "phase": 21.54
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0060554262627839864,
-      "phase": 187.48614425394808
+      "amplitude": 0.006,
+      "phase": 187.49
     },
     {
       "name": "SGM",
-      "amplitude": 0.002212740548784145,
-      "phase": 45.06560245366791
+      "amplitude": 0.002,
+      "phase": 45.07
     },
     {
       "name": "3L2",
-      "amplitude": 0.0042360233754134185,
-      "phase": 244.47234342393398
+      "amplitude": 0.004,
+      "phase": 244.47
     },
     {
       "name": "3N2",
-      "amplitude": 0.01689711049113569,
-      "phase": 135.6004218474527
+      "amplitude": 0.017,
+      "phase": 135.6
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03646300249075635,
-      "phase": 261.0140089032747
+      "amplitude": 0.036,
+      "phase": 261.01
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0565840370792547,
-      "phase": 87.16823180296637
+      "amplitude": 0.057,
+      "phase": 87.17
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0036694571245297716,
-      "phase": 51.49793936192191
+      "amplitude": 0.004,
+      "phase": 51.5
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0035729807961786477,
-      "phase": 307.9260192135301
+      "amplitude": 0.004,
+      "phase": 307.93
     }
   ],
   "epoch": {

--- a/data/ticon/moerdijk-moerdk-nld-rws.json
+++ b/data/ticon/moerdijk-moerdk-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.11297995999999999,
-      "phase": 195.053101
+      "amplitude": 0.118,
+      "phase": 182.61
     },
     {
       "name": "N2",
-      "amplitude": 0.015645279999999998,
-      "phase": 166.46167100000002
+      "amplitude": 0.017,
+      "phase": 154.87
     },
     {
       "name": "S2",
-      "amplitude": 0.024064139999999998,
-      "phase": 258.883764
+      "amplitude": 0.024,
+      "phase": 246.87
     },
     {
       "name": "K2",
-      "amplitude": 0.00729962,
-      "phase": 271.076754
+      "amplitude": 0.007,
+      "phase": 253.54
     },
     {
       "name": "2N2",
-      "amplitude": 0.0018360299999999998,
-      "phase": 143.39254900000003
+      "amplitude": 0.002,
+      "phase": 139.64
     },
     {
       "name": "S1",
-      "amplitude": 0.00160008,
-      "phase": 99.36530199999999
+      "amplitude": 0.002,
+      "phase": 40.09
     },
     {
       "name": "K1",
-      "amplitude": 0.01442992,
-      "phase": 69.60665899999998
+      "amplitude": 0.014,
+      "phase": 62.76
     },
     {
       "name": "P1",
-      "amplitude": 0.006684,
-      "phase": 94.54483800000003
+      "amplitude": 0.007,
+      "phase": 87.7
     },
     {
       "name": "O1",
-      "amplitude": 0.023276810000000002,
-      "phase": 264.047491
+      "amplitude": 0.023,
+      "phase": 258.22
     },
     {
       "name": "Q1",
-      "amplitude": 0.007681759999999999,
-      "phase": 212.313422
+      "amplitude": 0.008,
+      "phase": 206.92
     },
     {
       "name": "M1",
-      "amplitude": 0.00153006,
-      "phase": 199.261908
+      "amplitude": 0,
+      "phase": 89.91
     },
     {
       "name": "M4",
-      "amplitude": 0.011474819999999998,
-      "phase": 283.25867
+      "amplitude": 0.013,
+      "phase": 260.26
     },
     {
       "name": "MM",
-      "amplitude": 0.00509204,
-      "phase": 8.447497999999996
+      "amplitude": 0.005,
+      "phase": 2.92
     },
     {
       "name": "MF",
-      "amplitude": 0.0025906600000000003,
-      "phase": 174.10754499999996
+      "amplitude": 0.003,
+      "phase": 170.83
     },
     {
       "name": "SA",
-      "amplitude": 0.060796979999999994,
-      "phase": 250.539332
+      "amplitude": 0.06,
+      "phase": 251.04
     },
     {
       "name": "SSA",
-      "amplitude": 0.03142689,
-      "phase": 171.53947300000004
+      "amplitude": 0.031,
+      "phase": 173.08
     },
     {
       "name": "T2",
-      "amplitude": 0.005446609999999999,
-      "phase": 190.328576
+      "amplitude": 0.002,
+      "phase": 214.5
     },
     {
       "name": "J1",
-      "amplitude": 0.00042069000000000004,
-      "phase": 136.55260299999998
+      "amplitude": 0,
+      "phase": 138.05
     },
     {
       "name": "L2",
-      "amplitude": 0.009616360000000001,
-      "phase": 226.457356
+      "amplitude": 0.01,
+      "phase": 212.02
     },
     {
       "name": "R2",
-      "amplitude": 0.0034747299999999997,
-      "phase": 45.781993
+      "amplitude": 0.003,
+      "phase": 67.64
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00197117,
-      "phase": 179.08770500000003
+      "amplitude": 0.002,
+      "phase": 176.38
     },
     {
       "name": "MSF",
-      "amplitude": 0.03329176,
-      "phase": 59.590979000000004
+      "amplitude": 0.034,
+      "phase": 59.57
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00864121,
-      "phase": 290.634184
+      "amplitude": 0.009,
+      "phase": 288.65
     },
     {
       "name": "EP2",
-      "amplitude": 0.00305357,
-      "phase": 296.681337
+      "amplitude": 0.003,
+      "phase": 282.24
     },
     {
       "name": "M3",
-      "amplitude": 0.00023255000000000001,
-      "phase": 355.408162
+      "amplitude": 0,
+      "phase": 145.97
     },
     {
       "name": "MU2",
-      "amplitude": 0.01602819,
-      "phase": 307.931874
+      "amplitude": 0.016,
+      "phase": 296.13
     },
     {
       "name": "MTM",
-      "amplitude": 0.00996591,
-      "phase": 224.748302
+      "amplitude": 0.01,
+      "phase": 220.57
     },
     {
       "name": "NU2",
-      "amplitude": 0.0065400400000000004,
-      "phase": 156.52108199999998
+      "amplitude": 0.007,
+      "phase": 142.46
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0031107400000000003,
-      "phase": 223.11055
+      "amplitude": 0.003,
+      "phase": 199.89
     },
     {
       "name": "MN4",
-      "amplitude": 0.00354825,
-      "phase": 256.335739
+      "amplitude": 0.004,
+      "phase": 233.46
     },
     {
       "name": "MS4",
-      "amplitude": 0.00652141,
-      "phase": 344.227954
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.0074624999999999995,
-      "phase": 334.455755
+      "amplitude": 0.007,
+      "phase": 320.99
     },
     {
       "name": "N4",
-      "amplitude": 0.00088949,
-      "phase": 235.540525
+      "amplitude": 0.001,
+      "phase": 222.23
     },
     {
       "name": "M6",
-      "amplitude": 0.00071942,
-      "phase": 276.71999800000003
+      "amplitude": 0.001,
+      "phase": 229.89
     },
     {
       "name": "M8",
-      "amplitude": 0.00058419,
-      "phase": 44.35361399999999
+      "amplitude": 0.001,
+      "phase": 333.04
     },
     {
       "name": "S4",
-      "amplitude": 0.00011986000000000001,
-      "phase": 93.149881
+      "amplitude": 0,
+      "phase": 87.3
     },
     {
       "name": "OO1",
-      "amplitude": 0.0007491100000000001,
-      "phase": 251.30164000000002
+      "amplitude": 0.001,
+      "phase": 245.77
     },
     {
       "name": "S3",
-      "amplitude": 0.00034681999999999996,
-      "phase": 22.928886999999975
+      "amplitude": 0,
+      "phase": 179.45
     },
     {
       "name": "MA2",
-      "amplitude": 0.02888965,
-      "phase": 185.094632
+      "amplitude": 0.013,
+      "phase": 172.98
     },
     {
       "name": "MB2",
-      "amplitude": 0.02120923,
-      "phase": 54.037779
+      "amplitude": 0.011,
+      "phase": 87.44
     },
     {
       "name": "T3",
-      "amplitude": 0.00020768999999999999,
-      "phase": 174.611943
+      "amplitude": 0,
+      "phase": 318.1
     },
     {
       "name": "R3",
-      "amplitude": 0.00010263,
-      "phase": 297.542021
+      "amplitude": 0,
+      "phase": 27.23
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00194118,
-      "phase": 218.424482
+      "amplitude": 0.002,
+      "phase": 212.57
     },
     {
       "name": "SGM",
-      "amplitude": 0.00242558,
-      "phase": 205.674736
+      "amplitude": 0.002,
+      "phase": 15.52
     },
     {
       "name": "3L2",
-      "amplitude": 0.0005054899999999999,
-      "phase": 299.068728
+      "amplitude": 0.001,
+      "phase": 152.93
     },
     {
       "name": "3N2",
-      "amplitude": 0.00071185,
-      "phase": 224.150444
+      "amplitude": 0.006,
+      "phase": 337.11
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0032094,
-      "phase": 130.06809899999996
+      "amplitude": 0.003,
+      "phase": 118.29
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00057639,
-      "phase": 337.992979
+      "amplitude": 0.001,
+      "phase": 296.46
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00097515,
-      "phase": 12.856543999999985
+      "amplitude": 0.001,
+      "phase": 58.13
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0009307699999999999,
-      "phase": 17.591473000000008
+      "amplitude": 0.001,
+      "phase": 253.43
     }
   ],
   "epoch": {

--- a/data/ticon/neuendorfhafen-9670046-deu-wsv.json
+++ b/data/ticon/neuendorfhafen-9670046-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.0034980759150921763,
-      "phase": 352.45045585288494
+      "amplitude": 0.003,
+      "phase": 352.45
     },
     {
       "name": "N2",
-      "amplitude": 0.0011357523880376123,
-      "phase": 336.67903779081877
+      "amplitude": 0.001,
+      "phase": 336.68
     },
     {
       "name": "S2",
-      "amplitude": 0.0027452261294908195,
-      "phase": 318.63004074566004
+      "amplitude": 0.003,
+      "phase": 318.63
     },
     {
       "name": "K2",
-      "amplitude": 0.00071906128924965,
-      "phase": 329.96590569200356
+      "amplitude": 0.001,
+      "phase": 329.97
     },
     {
       "name": "2N2",
-      "amplitude": 0.00004631389015071583,
-      "phase": 52.65428655470055
+      "amplitude": 0,
+      "phase": 52.65
     },
     {
       "name": "S1",
-      "amplitude": 0.002196896567972377,
-      "phase": 123.58992267011826
+      "amplitude": 0.002,
+      "phase": 123.59
     },
     {
       "name": "K1",
-      "amplitude": 0.008374756537672747,
-      "phase": 211.2881177259267
+      "amplitude": 0.008,
+      "phase": 211.29
     },
     {
       "name": "P1",
-      "amplitude": 0.002279033062807259,
-      "phase": 212.7413092835569
+      "amplitude": 0.002,
+      "phase": 212.74
     },
     {
       "name": "O1",
-      "amplitude": 0.01243290662874538,
-      "phase": 189.24542757147805
+      "amplitude": 0.012,
+      "phase": 189.25
     },
     {
       "name": "Q1",
-      "amplitude": 0.0015252742986414116,
-      "phase": 133.92325412905802
+      "amplitude": 0.002,
+      "phase": 133.92
     },
     {
       "name": "M1",
-      "amplitude": 0.00046338574414942087,
-      "phase": 85.19618870742119
+      "amplitude": 0,
+      "phase": 85.2
     },
     {
       "name": "M4",
-      "amplitude": 0.0004156681202121894,
-      "phase": 236.413018576545
+      "amplitude": 0,
+      "phase": 236.41
     },
     {
       "name": "MM",
-      "amplitude": 0.011594374055822343,
-      "phase": 284.5464776755771
+      "amplitude": 0.012,
+      "phase": 284.55
     },
     {
       "name": "MF",
-      "amplitude": 0.00874348713281492,
-      "phase": 272.60002037462505
+      "amplitude": 0.009,
+      "phase": 272.6
     },
     {
       "name": "SA",
-      "amplitude": 0.04550622772256322,
-      "phase": 206.705053249641
+      "amplitude": 0.046,
+      "phase": 206.71
     },
     {
       "name": "SSA",
-      "amplitude": 0.03161262826112637,
-      "phase": 244.6118422423476
+      "amplitude": 0.032,
+      "phase": 244.61
     },
     {
       "name": "T2",
-      "amplitude": 0.00032941247002253983,
-      "phase": 325.8355187394706
+      "amplitude": 0,
+      "phase": 325.84
     },
     {
       "name": "J1",
-      "amplitude": 0.0005904135779597017,
-      "phase": 244.12468229054014
+      "amplitude": 0.001,
+      "phase": 244.12
     },
     {
       "name": "L2",
-      "amplitude": 0.0003310757080400598,
-      "phase": 176.1724689878621
+      "amplitude": 0,
+      "phase": 176.17
     },
     {
       "name": "R2",
-      "amplitude": 0.00027643810907484204,
-      "phase": 150.17510901833703
+      "amplitude": 0,
+      "phase": 150.18
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0001629741541309559,
-      "phase": 234.10769939324172
+      "amplitude": 0,
+      "phase": 234.11
     },
     {
       "name": "MSF",
-      "amplitude": 0.0011895880953708181,
-      "phase": 265.83096690933763
+      "amplitude": 0.001,
+      "phase": 265.83
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003878705623655862,
-      "phase": 214.5816617452336
+      "amplitude": 0.004,
+      "phase": 214.58
     },
     {
       "name": "EP2",
-      "amplitude": 0.00013867876343237425,
-      "phase": 150.31282621789626
+      "amplitude": 0,
+      "phase": 150.31
     },
     {
       "name": "M3",
-      "amplitude": 0.00016173627675316818,
-      "phase": 168.36361653448375
+      "amplitude": 0,
+      "phase": 168.36
     },
     {
       "name": "MU2",
-      "amplitude": 0.0006818161435059732,
-      "phase": 229.22614652449613
+      "amplitude": 0.001,
+      "phase": 229.23
     },
     {
       "name": "MTM",
-      "amplitude": 0.0029232222673993714,
-      "phase": 339.26058333126025
+      "amplitude": 0.003,
+      "phase": 339.26
     },
     {
       "name": "NU2",
-      "amplitude": 0.00022107551508017748,
-      "phase": 15.370891597891898
+      "amplitude": 0,
+      "phase": 15.37
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00012454119580106187,
-      "phase": 125.3013673636093
+      "amplitude": 0,
+      "phase": 125.3
     },
     {
       "name": "MN4",
-      "amplitude": 0.0001943946220598123,
-      "phase": 174.22764024940784
+      "amplitude": 0,
+      "phase": 174.23
     },
     {
       "name": "MS4",
-      "amplitude": 0.00012050692834602371,
-      "phase": 81.7909865587568
+      "amplitude": 0,
+      "phase": 81.79
     },
     {
       "name": "N4",
-      "amplitude": 0.00004213062497439353,
-      "phase": 88.28089072761094
+      "amplitude": 0,
+      "phase": 88.28
     },
     {
       "name": "M6",
-      "amplitude": 0.00005026659873268253,
-      "phase": 130.36913125337082
+      "amplitude": 0,
+      "phase": 130.37
     },
     {
       "name": "M8",
-      "amplitude": 0.00002546124908587412,
-      "phase": 137.6886950008602
+      "amplitude": 0,
+      "phase": 137.69
     },
     {
       "name": "S4",
-      "amplitude": 0.000060799081329612436,
-      "phase": 346.85002767754304
+      "amplitude": 0,
+      "phase": 346.85
     },
     {
       "name": "OO1",
-      "amplitude": 0.00045867140736762456,
-      "phase": 159.12790120520413
+      "amplitude": 0,
+      "phase": 159.13
     },
     {
       "name": "S3",
-      "amplitude": 0.00018039436211253574,
-      "phase": 193.78563014502993
+      "amplitude": 0,
+      "phase": 193.79
     },
     {
       "name": "MA2",
-      "amplitude": 0.00011880759208029442,
-      "phase": 317.76328241878923
+      "amplitude": 0,
+      "phase": 317.76
     },
     {
       "name": "MB2",
-      "amplitude": 0.0005974806509917895,
-      "phase": 134.00200232893815
+      "amplitude": 0.001,
+      "phase": 134
     },
     {
       "name": "T3",
-      "amplitude": 0.00011920391084461556,
-      "phase": 148.30759440700126
+      "amplitude": 0,
+      "phase": 148.31
     },
     {
       "name": "R3",
-      "amplitude": 0.00016969481117668444,
-      "phase": 244.01450400507878
+      "amplitude": 0,
+      "phase": 244.01
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00008576234066833744,
-      "phase": 342.59052226241045
+      "amplitude": 0,
+      "phase": 342.59
     },
     {
       "name": "SGM",
-      "amplitude": 0.0008926818746919381,
-      "phase": 280.081921943106
+      "amplitude": 0.001,
+      "phase": 280.08
     },
     {
       "name": "3L2",
-      "amplitude": 0.00007151800338650833,
-      "phase": 251.61875389137577
+      "amplitude": 0,
+      "phase": 251.62
     },
     {
       "name": "3N2",
-      "amplitude": 0.00013206217602281027,
-      "phase": 332.1232550284188
+      "amplitude": 0,
+      "phase": 332.12
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00028063583000155186,
-      "phase": 115.47346081185765
+      "amplitude": 0,
+      "phase": 115.47
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000006716753508686954,
-      "phase": 43.65761207768037
+      "amplitude": 0,
+      "phase": 43.66
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00003055580226666213,
-      "phase": 356.8216418208701
+      "amplitude": 0,
+      "phase": 356.82
     },
     {
       "name": "2MO5",
-      "amplitude": 0.000021327426460189927,
-      "phase": 295.91912416467164
+      "amplitude": 0,
+      "phase": 295.92
     }
   ],
   "epoch": {

--- a/data/ticon/neustadt-9610080-deu-wsv.json
+++ b/data/ticon/neustadt-9610080-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.05947044150966504,
-      "phase": 160.95670381716923
+      "amplitude": 0.059,
+      "phase": 160.96
     },
     {
       "name": "N2",
-      "amplitude": 0.013332553508302406,
-      "phase": 100.03470009369323
+      "amplitude": 0.013,
+      "phase": 100.03
     },
     {
       "name": "S2",
-      "amplitude": 0.010934632128977885,
-      "phase": 141.8019014096759
+      "amplitude": 0.011,
+      "phase": 141.8
     },
     {
       "name": "K2",
-      "amplitude": 0.0026230944744224305,
-      "phase": 130.27547263782492
+      "amplitude": 0.003,
+      "phase": 130.28
     },
     {
       "name": "2N2",
-      "amplitude": 0.0013345090990637054,
-      "phase": 57.68215427240824
+      "amplitude": 0.001,
+      "phase": 57.68
     },
     {
       "name": "S1",
-      "amplitude": 0.0034365386520344224,
-      "phase": 116.62867854357614
+      "amplitude": 0.003,
+      "phase": 116.63
     },
     {
       "name": "K1",
-      "amplitude": 0.014401897942527015,
-      "phase": 191.22813612641377
+      "amplitude": 0.014,
+      "phase": 191.23
     },
     {
       "name": "P1",
-      "amplitude": 0.0033636093425120066,
-      "phase": 230.24805070974062
+      "amplitude": 0.003,
+      "phase": 230.25
     },
     {
       "name": "O1",
-      "amplitude": 0.01865401690012642,
-      "phase": 118.14067310085011
+      "amplitude": 0.019,
+      "phase": 118.14
     },
     {
       "name": "Q1",
-      "amplitude": 0.0023836817139643407,
-      "phase": 334.39779488511715
+      "amplitude": 0.002,
+      "phase": 334.4
     },
     {
       "name": "M1",
-      "amplitude": 0.00038602844241876754,
-      "phase": 31.313823657985665
+      "amplitude": 0,
+      "phase": 31.31
     },
     {
       "name": "M4",
-      "amplitude": 0.0014436669212803694,
-      "phase": 322.5572311385467
+      "amplitude": 0.001,
+      "phase": 322.56
     },
     {
       "name": "MM",
-      "amplitude": 0.012218276045917508,
-      "phase": 299.09550345114616
+      "amplitude": 0.012,
+      "phase": 299.1
     },
     {
       "name": "MF",
-      "amplitude": 0.010096833012310295,
-      "phase": 256.9187116747343
+      "amplitude": 0.01,
+      "phase": 256.92
     },
     {
       "name": "SA",
-      "amplitude": 0.034326033997684725,
-      "phase": 159.49096687074098
+      "amplitude": 0.034,
+      "phase": 159.49
     },
     {
       "name": "SSA",
-      "amplitude": 0.019210058946596442,
-      "phase": 265.81512303189936
+      "amplitude": 0.019,
+      "phase": 265.82
     },
     {
       "name": "T2",
-      "amplitude": 0.0010688412688802619,
-      "phase": 130.7371087052802
+      "amplitude": 0.001,
+      "phase": 130.74
     },
     {
       "name": "J1",
-      "amplitude": 0.000965033269870345,
-      "phase": 145.55694698625945
+      "amplitude": 0.001,
+      "phase": 145.56
     },
     {
       "name": "L2",
-      "amplitude": 0.005697750500324452,
-      "phase": 254.18579629879684
+      "amplitude": 0.006,
+      "phase": 254.19
     },
     {
       "name": "R2",
-      "amplitude": 0.0010298376632660526,
-      "phase": 203.47199139399004
+      "amplitude": 0.001,
+      "phase": 203.47
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0008541531878767886,
-      "phase": 264.3707582968774
+      "amplitude": 0.001,
+      "phase": 264.37
     },
     {
       "name": "MSF",
-      "amplitude": 0.0028217327037296375,
-      "phase": 239.57797034306816
+      "amplitude": 0.003,
+      "phase": 239.58
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004391922352515293,
-      "phase": 205.1299200095831
+      "amplitude": 0.004,
+      "phase": 205.13
     },
     {
       "name": "EP2",
-      "amplitude": 0.0027942728603864582,
-      "phase": 263.59528318787955
+      "amplitude": 0.003,
+      "phase": 263.6
     },
     {
       "name": "M3",
-      "amplitude": 0.0005741141846330364,
-      "phase": 345.05675110974346
+      "amplitude": 0.001,
+      "phase": 345.06
     },
     {
       "name": "MU2",
-      "amplitude": 0.011013711480262737,
-      "phase": 306.7397947003377
+      "amplitude": 0.011,
+      "phase": 306.74
     },
     {
       "name": "MTM",
-      "amplitude": 0.004153905361011019,
-      "phase": 346.97376769535214
+      "amplitude": 0.004,
+      "phase": 346.97
     },
     {
       "name": "NU2",
-      "amplitude": 0.004553149989389059,
-      "phase": 137.81766630504274
+      "amplitude": 0.005,
+      "phase": 137.82
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0028615026431335474,
-      "phase": 249.61809293200855
+      "amplitude": 0.003,
+      "phase": 249.62
     },
     {
       "name": "MN4",
-      "amplitude": 0.0005078388453864127,
-      "phase": 252.1483535309738
+      "amplitude": 0.001,
+      "phase": 252.15
     },
     {
       "name": "MS4",
-      "amplitude": 0.00041523274729509475,
-      "phase": 119.3074569302633
+      "amplitude": 0,
+      "phase": 119.31
     },
     {
       "name": "N4",
-      "amplitude": 0.00003841686788124895,
-      "phase": 171.2433812077594
+      "amplitude": 0,
+      "phase": 171.24
     },
     {
       "name": "M6",
-      "amplitude": 0.0007416367971736249,
-      "phase": 213.23025183080398
+      "amplitude": 0.001,
+      "phase": 213.23
     },
     {
       "name": "M8",
-      "amplitude": 0.000026081386625197172,
-      "phase": 83.05865845240487
+      "amplitude": 0,
+      "phase": 83.06
     },
     {
       "name": "S4",
-      "amplitude": 0.000124970377725539,
-      "phase": 47.786291476311874
+      "amplitude": 0,
+      "phase": 47.79
     },
     {
       "name": "OO1",
-      "amplitude": 0.001409189559482764,
-      "phase": 136.50752540627002
+      "amplitude": 0.001,
+      "phase": 136.51
     },
     {
       "name": "S3",
-      "amplitude": 0.0005692017424481287,
-      "phase": 24.559189707758264
+      "amplitude": 0.001,
+      "phase": 24.56
     },
     {
       "name": "MA2",
-      "amplitude": 0.004390835766515812,
-      "phase": 133.3198657376313
+      "amplitude": 0.004,
+      "phase": 133.32
     },
     {
       "name": "MB2",
-      "amplitude": 0.00828166570611799,
-      "phase": 291.65974074483023
+      "amplitude": 0.008,
+      "phase": 291.66
     },
     {
       "name": "T3",
-      "amplitude": 0.001003749150541998,
-      "phase": 283.1031545636347
+      "amplitude": 0.001,
+      "phase": 283.1
     },
     {
       "name": "R3",
-      "amplitude": 0.0010140610339612961,
-      "phase": 24.69987857755541
+      "amplitude": 0.001,
+      "phase": 24.7
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00034473694538866926,
-      "phase": 287.71690372938235
+      "amplitude": 0,
+      "phase": 287.72
     },
     {
       "name": "SGM",
-      "amplitude": 0.002597620883801334,
-      "phase": 220.22461741662244
+      "amplitude": 0.003,
+      "phase": 220.22
     },
     {
       "name": "3L2",
-      "amplitude": 0.0003118735099092973,
-      "phase": 55.271142832843395
+      "amplitude": 0,
+      "phase": 55.27
     },
     {
       "name": "3N2",
-      "amplitude": 0.0020328536527192747,
-      "phase": 20.376002659883852
+      "amplitude": 0.002,
+      "phase": 20.38
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0017027015499673213,
-      "phase": 255.81164376981866
+      "amplitude": 0.002,
+      "phase": 255.81
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0005347110425572868,
-      "phase": 278.8835641488538
+      "amplitude": 0.001,
+      "phase": 278.88
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0001297055640646878,
-      "phase": 317.509158968336
+      "amplitude": 0,
+      "phase": 317.51
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00024189227362828998,
-      "phase": 152.32049901149549
+      "amplitude": 0,
+      "phase": 152.32
     }
   ],
   "epoch": {

--- a/data/ticon/niederblockland-4940020-deu-wsv.json
+++ b/data/ticon/niederblockland-4940020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.8688971042300294,
-      "phase": 89.92455234716647
+      "amplitude": 0.869,
+      "phase": 89.92
     },
     {
       "name": "N2",
-      "amplitude": 0.1243899791776202,
-      "phase": 67.59376188178135
+      "amplitude": 0.124,
+      "phase": 67.59
     },
     {
       "name": "S2",
-      "amplitude": 0.19544941273765992,
-      "phase": 176.01123122871365
+      "amplitude": 0.195,
+      "phase": 176.01
     },
     {
       "name": "K2",
-      "amplitude": 0.0591510296437401,
-      "phase": 177.27221874421957
+      "amplitude": 0.059,
+      "phase": 177.27
     },
     {
       "name": "2N2",
-      "amplitude": 0.012753184185421595,
-      "phase": 52.183200248682795
+      "amplitude": 0.013,
+      "phase": 52.18
     },
     {
       "name": "S1",
-      "amplitude": 0.010248173686580207,
-      "phase": 111.25299101195179
+      "amplitude": 0.01,
+      "phase": 111.25
     },
     {
       "name": "K1",
-      "amplitude": 0.0357680192855161,
-      "phase": 117.94114808361655
+      "amplitude": 0.036,
+      "phase": 117.94
     },
     {
       "name": "P1",
-      "amplitude": 0.015102023479390022,
-      "phase": 144.52414996401865
+      "amplitude": 0.015,
+      "phase": 144.52
     },
     {
       "name": "O1",
-      "amplitude": 0.04668712444567751,
-      "phase": 322.84414539736457
+      "amplitude": 0.047,
+      "phase": 322.84
     },
     {
       "name": "Q1",
-      "amplitude": 0.011067246788543154,
-      "phase": 251.44181640681558
+      "amplitude": 0.011,
+      "phase": 251.44
     },
     {
       "name": "M1",
-      "amplitude": 0.0014764108386121297,
-      "phase": 180.95066087141097
+      "amplitude": 0.001,
+      "phase": 180.95
     },
     {
       "name": "M4",
-      "amplitude": 0.14898863923603306,
-      "phase": 94.49331351798924
+      "amplitude": 0.149,
+      "phase": 94.49
     },
     {
       "name": "MM",
-      "amplitude": 0.012533585871993408,
-      "phase": 51.157062568434355
+      "amplitude": 0.013,
+      "phase": 51.16
     },
     {
       "name": "MF",
-      "amplitude": 0.019146772750439033,
-      "phase": 105.13005029870527
+      "amplitude": 0.019,
+      "phase": 105.13
     },
     {
       "name": "SA",
-      "amplitude": 0.17330548921129946,
-      "phase": 306.5347297373177
+      "amplitude": 0.173,
+      "phase": 306.53
     },
     {
       "name": "SSA",
-      "amplitude": 0.06274332144036804,
-      "phase": 244.1590980422383
+      "amplitude": 0.063,
+      "phase": 244.16
     },
     {
       "name": "T2",
-      "amplitude": 0.0037460225829848903,
-      "phase": 91.96591780602802
+      "amplitude": 0.004,
+      "phase": 91.97
     },
     {
       "name": "J1",
-      "amplitude": 0.0020472733480242098,
-      "phase": 296.7091156596078
+      "amplitude": 0.002,
+      "phase": 296.71
     },
     {
       "name": "L2",
-      "amplitude": 0.08961693433751043,
-      "phase": 104.88889124682873
+      "amplitude": 0.09,
+      "phase": 104.89
     },
     {
       "name": "R2",
-      "amplitude": 0.011945920196973015,
-      "phase": 238.75413268086848
+      "amplitude": 0.012,
+      "phase": 238.75
     },
     {
       "name": "2Q1",
-      "amplitude": 0.001650175024804932,
-      "phase": 158.71465971241673
+      "amplitude": 0.002,
+      "phase": 158.71
     },
     {
       "name": "MSF",
-      "amplitude": 0.07094507972718651,
-      "phase": 70.8350706574023
+      "amplitude": 0.071,
+      "phase": 70.84
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007602182507457005,
-      "phase": 347.94239879580215
+      "amplitude": 0.008,
+      "phase": 347.94
     },
     {
       "name": "EP2",
-      "amplitude": 0.030051249209537115,
-      "phase": 150.39807837061142
+      "amplitude": 0.03,
+      "phase": 150.4
     },
     {
       "name": "M3",
-      "amplitude": 0.0021607167430664027,
-      "phase": 186.68793193187335
+      "amplitude": 0.002,
+      "phase": 186.69
     },
     {
       "name": "MU2",
-      "amplitude": 0.14885351476528746,
-      "phase": 172.38684915073713
+      "amplitude": 0.149,
+      "phase": 172.39
     },
     {
       "name": "MTM",
-      "amplitude": 0.0024338401002009943,
-      "phase": 149.5750564637948
+      "amplitude": 0.002,
+      "phase": 149.58
     },
     {
       "name": "NU2",
-      "amplitude": 0.06424099876371515,
-      "phase": 39.576852675717305
+      "amplitude": 0.064,
+      "phase": 39.58
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04197049496932749,
-      "phase": 108.43878155077783
+      "amplitude": 0.042,
+      "phase": 108.44
     },
     {
       "name": "MN4",
-      "amplitude": 0.04514016775161112,
-      "phase": 69.08630578900846
+      "amplitude": 0.045,
+      "phase": 69.09
     },
     {
       "name": "MS4",
-      "amplitude": 0.07745681110186066,
-      "phase": 174.5343051572006
+      "amplitude": 0.077,
+      "phase": 174.53
     },
     {
       "name": "N4",
-      "amplitude": 0.008846358353752951,
-      "phase": 53.312338804741046
+      "amplitude": 0.009,
+      "phase": 53.31
     },
     {
       "name": "M6",
-      "amplitude": 0.016238752399004335,
-      "phase": 39.00714980670085
+      "amplitude": 0.016,
+      "phase": 39.01
     },
     {
       "name": "M8",
-      "amplitude": 0.010501982580755635,
-      "phase": 343.37206625319686
+      "amplitude": 0.011,
+      "phase": 343.37
     },
     {
       "name": "S4",
-      "amplitude": 0.006812356341427325,
-      "phase": 343.11281017365854
+      "amplitude": 0.007,
+      "phase": 343.11
     },
     {
       "name": "OO1",
-      "amplitude": 0.0016447102989736128,
-      "phase": 336.8591697705656
+      "amplitude": 0.002,
+      "phase": 336.86
     },
     {
       "name": "S3",
-      "amplitude": 0.00015750993635141246,
-      "phase": 215.56990434020855
+      "amplitude": 0,
+      "phase": 215.57
     },
     {
       "name": "MA2",
-      "amplitude": 0.06476912249217592,
-      "phase": 15.125836995082864
+      "amplitude": 0.065,
+      "phase": 15.13
     },
     {
       "name": "MB2",
-      "amplitude": 0.0542571486543968,
-      "phase": 246.0900702531834
+      "amplitude": 0.054,
+      "phase": 246.09
     },
     {
       "name": "T3",
-      "amplitude": 0.0006799475942394246,
-      "phase": 185.58987602906797
+      "amplitude": 0.001,
+      "phase": 185.59
     },
     {
       "name": "R3",
-      "amplitude": 0.004843905546561206,
-      "phase": 146.40536107565373
+      "amplitude": 0.005,
+      "phase": 146.41
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004441704077282679,
-      "phase": 272.5506761928991
+      "amplitude": 0.004,
+      "phase": 272.55
     },
     {
       "name": "SGM",
-      "amplitude": 0.008960886376904988,
-      "phase": 96.20646691523092
+      "amplitude": 0.009,
+      "phase": 96.21
     },
     {
       "name": "3L2",
-      "amplitude": 0.003109357006672586,
-      "phase": 7.651805367569523
+      "amplitude": 0.003,
+      "phase": 7.65
     },
     {
       "name": "3N2",
-      "amplitude": 0.01905257457507683,
-      "phase": 213.3105145136445
+      "amplitude": 0.019,
+      "phase": 213.31
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02516711562957905,
-      "phase": 38.710561125604045
+      "amplitude": 0.025,
+      "phase": 38.71
     },
     {
       "name": "2MS6",
-      "amplitude": 0.018073734144576095,
-      "phase": 110.91213484362663
+      "amplitude": 0.018,
+      "phase": 110.91
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005323196353433863,
-      "phase": 65.20638159435453
+      "amplitude": 0.005,
+      "phase": 65.21
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006313775395892544,
-      "phase": 284.6608122695858
+      "amplitude": 0.006,
+      "phase": 284.66
     }
   ],
   "epoch": {

--- a/data/ticon/nokbrunsbttel-5970091-deu-wsv.json
+++ b/data/ticon/nokbrunsbttel-5970091-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.011816892350144393,
-      "phase": 10.685197562524479
+      "amplitude": 0.012,
+      "phase": 10.69
     },
     {
       "name": "N2",
-      "amplitude": 0.0015777383279167406,
-      "phase": 1.2541251358767909
+      "amplitude": 0.002,
+      "phase": 1.25
     },
     {
       "name": "S2",
-      "amplitude": 0.0033488383006781744,
-      "phase": 95.97298644005878
+      "amplitude": 0.003,
+      "phase": 95.97
     },
     {
       "name": "K2",
-      "amplitude": 0.0008847779500239687,
-      "phase": 73.99049202033905
+      "amplitude": 0.001,
+      "phase": 73.99
     },
     {
       "name": "2N2",
-      "amplitude": 0.00009532897792090859,
-      "phase": 337.27855393872045
+      "amplitude": 0,
+      "phase": 337.28
     },
     {
       "name": "S1",
-      "amplitude": 0.0030893278812523196,
-      "phase": 87.76802767566392
+      "amplitude": 0.003,
+      "phase": 87.77
     },
     {
       "name": "K1",
-      "amplitude": 0.001191509177037334,
-      "phase": 94.36284866886393
+      "amplitude": 0.001,
+      "phase": 94.36
     },
     {
       "name": "P1",
-      "amplitude": 0.0014423594460108262,
-      "phase": 106.572012903874
+      "amplitude": 0.001,
+      "phase": 106.57
     },
     {
       "name": "O1",
-      "amplitude": 0.001381602617479573,
-      "phase": 302.38694548878834
+      "amplitude": 0.001,
+      "phase": 302.39
     },
     {
       "name": "Q1",
-      "amplitude": 0.00046923739468141435,
-      "phase": 0.5260215895930287
+      "amplitude": 0,
+      "phase": 0.53
     },
     {
       "name": "M1",
-      "amplitude": 0.00030046526221604237,
-      "phase": 298.3258843214981
+      "amplitude": 0,
+      "phase": 298.33
     },
     {
       "name": "M4",
-      "amplitude": 0.036854800537332554,
-      "phase": 228.01277242198148
+      "amplitude": 0.037,
+      "phase": 228.01
     },
     {
       "name": "MM",
-      "amplitude": 0.006276025586072193,
-      "phase": 334.1216519411885
+      "amplitude": 0.006,
+      "phase": 334.12
     },
     {
       "name": "MF",
-      "amplitude": 0.0015934509835341694,
-      "phase": 232.45324423382363
+      "amplitude": 0.002,
+      "phase": 232.45
     },
     {
       "name": "SA",
-      "amplitude": 0.005870074377380262,
-      "phase": 119.52910640225639
+      "amplitude": 0.006,
+      "phase": 119.53
     },
     {
       "name": "SSA",
-      "amplitude": 0.004718624015469052,
-      "phase": 339.8146898543444
+      "amplitude": 0.005,
+      "phase": 339.81
     },
     {
       "name": "T2",
-      "amplitude": 0.0005885975259184823,
-      "phase": 74.25542053327382
+      "amplitude": 0.001,
+      "phase": 74.26
     },
     {
       "name": "J1",
-      "amplitude": 0.000007873098436088869,
-      "phase": 72.98427721671516
+      "amplitude": 0,
+      "phase": 72.98
     },
     {
       "name": "L2",
-      "amplitude": 0.0011258738269332594,
-      "phase": 20.18496135941183
+      "amplitude": 0.001,
+      "phase": 20.18
     },
     {
       "name": "R2",
-      "amplitude": 0.00045478880286112434,
-      "phase": 256.9932657575674
+      "amplitude": 0,
+      "phase": 256.99
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0003829562158338564,
-      "phase": 93.50823821356494
+      "amplitude": 0,
+      "phase": 93.51
     },
     {
       "name": "MSF",
-      "amplitude": 0.002628236942968147,
-      "phase": 319.28729166831613
+      "amplitude": 0.003,
+      "phase": 319.29
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0016090180019505086,
-      "phase": 132.93138083314955
+      "amplitude": 0.002,
+      "phase": 132.93
     },
     {
       "name": "EP2",
-      "amplitude": 0.0002680870933810102,
-      "phase": 80.17213821684629
+      "amplitude": 0,
+      "phase": 80.17
     },
     {
       "name": "M3",
-      "amplitude": 0.00008586291762605072,
-      "phase": 63.166573454748516
+      "amplitude": 0,
+      "phase": 63.17
     },
     {
       "name": "MU2",
-      "amplitude": 0.0015355200416675714,
-      "phase": 100.72982082142454
+      "amplitude": 0.002,
+      "phase": 100.73
     },
     {
       "name": "MTM",
-      "amplitude": 0.0019154004372466565,
-      "phase": 69.36589545969497
+      "amplitude": 0.002,
+      "phase": 69.37
     },
     {
       "name": "NU2",
-      "amplitude": 0.00081502817902879,
-      "phase": 318.5817300310124
+      "amplitude": 0.001,
+      "phase": 318.58
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00041887265738758386,
-      "phase": 34.619759144488
+      "amplitude": 0,
+      "phase": 34.62
     },
     {
       "name": "MN4",
-      "amplitude": 0.011001843431820592,
-      "phase": 201.4194969060072
+      "amplitude": 0.011,
+      "phase": 201.42
     },
     {
       "name": "MS4",
-      "amplitude": 0.018081581325815624,
-      "phase": 313.01995152358285
+      "amplitude": 0.018,
+      "phase": 313.02
     },
     {
       "name": "N4",
-      "amplitude": 0.0016926238695490002,
-      "phase": 145.27208176553177
+      "amplitude": 0.002,
+      "phase": 145.27
     },
     {
       "name": "M6",
-      "amplitude": 0.0007146629935026848,
-      "phase": 80.79665996644627
+      "amplitude": 0.001,
+      "phase": 80.8
     },
     {
       "name": "M8",
-      "amplitude": 0.0014978453203619822,
-      "phase": 60.52336109303536
+      "amplitude": 0.001,
+      "phase": 60.52
     },
     {
       "name": "S4",
-      "amplitude": 0.0026018038630938756,
-      "phase": 103.30361972702792
+      "amplitude": 0.003,
+      "phase": 103.3
     },
     {
       "name": "OO1",
-      "amplitude": 0.00022111756861542333,
-      "phase": 299.80531611586173
+      "amplitude": 0,
+      "phase": 299.81
     },
     {
       "name": "S3",
-      "amplitude": 0.00214395996804835,
-      "phase": 43.50547381490094
+      "amplitude": 0.002,
+      "phase": 43.51
     },
     {
       "name": "MA2",
-      "amplitude": 0.0013234590108886421,
-      "phase": 111.10761250557636
+      "amplitude": 0.001,
+      "phase": 111.11
     },
     {
       "name": "MB2",
-      "amplitude": 0.0015453036991436634,
-      "phase": 308.5294608090924
+      "amplitude": 0.002,
+      "phase": 308.53
     },
     {
       "name": "T3",
-      "amplitude": 0.0005514379071975882,
-      "phase": 349.9064594753661
+      "amplitude": 0.001,
+      "phase": 349.91
     },
     {
       "name": "R3",
-      "amplitude": 0.0004830141808564858,
-      "phase": 19.35944557297097
+      "amplitude": 0,
+      "phase": 19.36
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00021711104695410733,
-      "phase": 181.71987743895215
+      "amplitude": 0,
+      "phase": 181.72
     },
     {
       "name": "SGM",
-      "amplitude": 0.0007333790927970963,
-      "phase": 338.38119727922566
+      "amplitude": 0.001,
+      "phase": 338.38
     },
     {
       "name": "3L2",
-      "amplitude": 0.00011103097676188489,
-      "phase": 329.71683170961427
+      "amplitude": 0,
+      "phase": 329.72
     },
     {
       "name": "3N2",
-      "amplitude": 0.0006253242584842409,
-      "phase": 254.80990160443883
+      "amplitude": 0.001,
+      "phase": 254.81
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0005809983070788674,
-      "phase": 277.6811055852734
+      "amplitude": 0.001,
+      "phase": 277.68
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000674549043831235,
-      "phase": 150.12476092302313
+      "amplitude": 0.001,
+      "phase": 150.12
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00041605554278937624,
-      "phase": 143.81182375469882
+      "amplitude": 0,
+      "phase": 143.81
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00007983886609450062,
-      "phase": 53.69219623691248
+      "amplitude": 0,
+      "phase": 53.69
     }
   ],
   "epoch": {

--- a/data/ticon/nokkielaussen-5650068-deu-wsv.json
+++ b/data/ticon/nokkielaussen-5650068-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.04656774308468575,
-      "phase": 108.31262623878843
+      "amplitude": 0.047,
+      "phase": 108.31
     },
     {
       "name": "N2",
-      "amplitude": 0.013096558661957922,
-      "phase": 55.76713725717502
+      "amplitude": 0.013,
+      "phase": 55.77
     },
     {
       "name": "S2",
-      "amplitude": 0.012364024702040947,
-      "phase": 49.05080042438493
+      "amplitude": 0.012,
+      "phase": 49.05
     },
     {
       "name": "K2",
-      "amplitude": 0.003162228986803072,
-      "phase": 21.12078149309565
+      "amplitude": 0.003,
+      "phase": 21.12
     },
     {
       "name": "2N2",
-      "amplitude": 0.0019410992841250258,
-      "phase": 348.868332819971
+      "amplitude": 0.002,
+      "phase": 348.87
     },
     {
       "name": "S1",
-      "amplitude": 0.00687969064101689,
-      "phase": 170.77377762284698
+      "amplitude": 0.007,
+      "phase": 170.77
     },
     {
       "name": "K1",
-      "amplitude": 0.018881740404414465,
-      "phase": 210.73418329428796
+      "amplitude": 0.019,
+      "phase": 210.73
     },
     {
       "name": "P1",
-      "amplitude": 0.008026811323084256,
-      "phase": 242.47850789630343
+      "amplitude": 0.008,
+      "phase": 242.48
     },
     {
       "name": "O1",
-      "amplitude": 0.015799315080521795,
-      "phase": 106.0164818904733
+      "amplitude": 0.016,
+      "phase": 106.02
     },
     {
       "name": "Q1",
-      "amplitude": 0.004380416783663057,
-      "phase": 315.0140194065909
+      "amplitude": 0.004,
+      "phase": 315.01
     },
     {
       "name": "M1",
-      "amplitude": 0.00025711963872647545,
-      "phase": 233.4562417767744
+      "amplitude": 0,
+      "phase": 233.46
     },
     {
       "name": "M4",
-      "amplitude": 0.0021622496395215266,
-      "phase": 196.65734354268884
+      "amplitude": 0.002,
+      "phase": 196.66
     },
     {
       "name": "MM",
-      "amplitude": 0.016118042375333565,
-      "phase": 274.37904000330445
+      "amplitude": 0.016,
+      "phase": 274.38
     },
     {
       "name": "MF",
-      "amplitude": 0.016355060435415347,
-      "phase": 265.1846863310325
+      "amplitude": 0.016,
+      "phase": 265.18
     },
     {
       "name": "SA",
-      "amplitude": 0.03169882745785483,
-      "phase": 167.4484992392055
+      "amplitude": 0.032,
+      "phase": 167.45
     },
     {
       "name": "SSA",
-      "amplitude": 0.014250616068328842,
-      "phase": 280.30301101261796
+      "amplitude": 0.014,
+      "phase": 280.3
     },
     {
       "name": "T2",
-      "amplitude": 0.001484050081354159,
-      "phase": 47.341681591425015
+      "amplitude": 0.001,
+      "phase": 47.34
     },
     {
       "name": "J1",
-      "amplitude": 0.0014905880093601938,
-      "phase": 147.30442436809858
+      "amplitude": 0.001,
+      "phase": 147.3
     },
     {
       "name": "L2",
-      "amplitude": 0.005283567549040038,
-      "phase": 206.1866038284336
+      "amplitude": 0.005,
+      "phase": 206.19
     },
     {
       "name": "R2",
-      "amplitude": 0.0011602139966199374,
-      "phase": 136.80276325621094
+      "amplitude": 0.001,
+      "phase": 136.8
     },
     {
       "name": "2Q1",
-      "amplitude": 0.003416418233554876,
-      "phase": 268.298095321632
+      "amplitude": 0.003,
+      "phase": 268.3
     },
     {
       "name": "MSF",
-      "amplitude": 0.002746166500700283,
-      "phase": 251.76604454989962
+      "amplitude": 0.003,
+      "phase": 251.77
     },
     {
       "name": "MSQM",
-      "amplitude": 0.005377755191069893,
-      "phase": 17.906290710774044
+      "amplitude": 0.005,
+      "phase": 17.91
     },
     {
       "name": "EP2",
-      "amplitude": 0.0024110640576095813,
-      "phase": 247.05304690693214
+      "amplitude": 0.002,
+      "phase": 247.05
     },
     {
       "name": "M3",
-      "amplitude": 0.00039073436623835546,
-      "phase": 295.48769681445015
+      "amplitude": 0,
+      "phase": 295.49
     },
     {
       "name": "MU2",
-      "amplitude": 0.011691574580363734,
-      "phase": 278.11229417133006
+      "amplitude": 0.012,
+      "phase": 278.11
     },
     {
       "name": "MTM",
-      "amplitude": 0.005067709560860962,
-      "phase": 25.49778147201215
+      "amplitude": 0.005,
+      "phase": 25.5
     },
     {
       "name": "NU2",
-      "amplitude": 0.005062149464864788,
-      "phase": 89.05749888715161
+      "amplitude": 0.005,
+      "phase": 89.06
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0028236703022184767,
-      "phase": 194.7434917268792
+      "amplitude": 0.003,
+      "phase": 194.74
     },
     {
       "name": "MN4",
-      "amplitude": 0.0004183174390853056,
-      "phase": 146.33731539025797
+      "amplitude": 0,
+      "phase": 146.34
     },
     {
       "name": "MS4",
-      "amplitude": 0.0006522262731984996,
-      "phase": 347.38586400894735
+      "amplitude": 0.001,
+      "phase": 347.39
     },
     {
       "name": "N4",
-      "amplitude": 0.00018744557701349862,
-      "phase": 226.08709241979963
+      "amplitude": 0,
+      "phase": 226.09
     },
     {
       "name": "M6",
-      "amplitude": 0.0005679661261239023,
-      "phase": 289.9452531628871
+      "amplitude": 0.001,
+      "phase": 289.95
     },
     {
       "name": "M8",
-      "amplitude": 0.00024156366326276297,
-      "phase": 300.14959889460613
+      "amplitude": 0,
+      "phase": 300.15
     },
     {
       "name": "S4",
-      "amplitude": 0.0003828324162285486,
-      "phase": 348.36818550569075
+      "amplitude": 0,
+      "phase": 348.37
     },
     {
       "name": "OO1",
-      "amplitude": 0.0018377210931502669,
-      "phase": 166.31954383476125
+      "amplitude": 0.002,
+      "phase": 166.32
     },
     {
       "name": "S3",
-      "amplitude": 0.0004892049836534765,
-      "phase": 215.56733090650857
+      "amplitude": 0,
+      "phase": 215.57
     },
     {
       "name": "MA2",
-      "amplitude": 0.006244712418383547,
-      "phase": 95.60045269581241
+      "amplitude": 0.006,
+      "phase": 95.6
     },
     {
       "name": "MB2",
-      "amplitude": 0.007125553404719864,
-      "phase": 261.8986801922787
+      "amplitude": 0.007,
+      "phase": 261.9
     },
     {
       "name": "T3",
-      "amplitude": 0.0004973423862223859,
-      "phase": 123.94099460320194
+      "amplitude": 0,
+      "phase": 123.94
     },
     {
       "name": "R3",
-      "amplitude": 0.0006193159120988264,
-      "phase": 252.98582328169232
+      "amplitude": 0.001,
+      "phase": 252.99
     },
     {
       "name": "RHO1",
-      "amplitude": 0.001091612713878415,
-      "phase": 256.2820275983232
+      "amplitude": 0.001,
+      "phase": 256.28
     },
     {
       "name": "SGM",
-      "amplitude": 0.002774483268540368,
-      "phase": 236.87668773672243
+      "amplitude": 0.003,
+      "phase": 236.88
     },
     {
       "name": "3L2",
-      "amplitude": 0.0008411565310425757,
-      "phase": 22.73520182258153
+      "amplitude": 0.001,
+      "phase": 22.74
     },
     {
       "name": "3N2",
-      "amplitude": 0.0015139874065695693,
-      "phase": 358.28527517872436
+      "amplitude": 0.002,
+      "phase": 358.29
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0012596111546583015,
-      "phase": 159.3935697042334
+      "amplitude": 0.001,
+      "phase": 159.39
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000748224542897796,
-      "phase": 346.59334497175075
+      "amplitude": 0.001,
+      "phase": 346.59
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0002459477406693733,
-      "phase": 140.65509680092202
+      "amplitude": 0,
+      "phase": 140.66
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00008130394562244143,
-      "phase": 100.78559966691307
+      "amplitude": 0,
+      "phase": 100.79
     }
   ],
   "epoch": {

--- a/data/ticon/nokkielbinnen-5979020-deu-wsv.json
+++ b/data/ticon/nokkielbinnen-5979020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.03291172583296418,
-      "phase": 113.70832088216264
+      "amplitude": 0.033,
+      "phase": 113.71
     },
     {
       "name": "N2",
-      "amplitude": 0.004707948048881059,
-      "phase": 92.85586777307941
+      "amplitude": 0.005,
+      "phase": 92.86
     },
     {
       "name": "S2",
-      "amplitude": 0.006795573637397436,
-      "phase": 192.9917500105469
+      "amplitude": 0.007,
+      "phase": 192.99
     },
     {
       "name": "K2",
-      "amplitude": 0.0017820598583774703,
-      "phase": 186.11758399106947
+      "amplitude": 0.002,
+      "phase": 186.12
     },
     {
       "name": "2N2",
-      "amplitude": 0.00032676637306792067,
-      "phase": 49.99081953308831
+      "amplitude": 0,
+      "phase": 49.99
     },
     {
       "name": "S1",
-      "amplitude": 0.005688063430042411,
-      "phase": 61.960865514729505
+      "amplitude": 0.006,
+      "phase": 61.96
     },
     {
       "name": "K1",
-      "amplitude": 0.0014405361123491142,
-      "phase": 87.43004351585068
+      "amplitude": 0.001,
+      "phase": 87.43
     },
     {
       "name": "P1",
-      "amplitude": 0.0004161121026012939,
-      "phase": 6.750211767014491
+      "amplitude": 0,
+      "phase": 6.75
     },
     {
       "name": "O1",
-      "amplitude": 0.002817672995461733,
-      "phase": 312.9831258004006
+      "amplitude": 0.003,
+      "phase": 312.98
     },
     {
       "name": "Q1",
-      "amplitude": 0.0010946130496456545,
-      "phase": 266.3022366105108
+      "amplitude": 0.001,
+      "phase": 266.3
     },
     {
       "name": "M1",
-      "amplitude": 0.00033300723227429395,
-      "phase": 332.8680265919355
+      "amplitude": 0,
+      "phase": 332.87
     },
     {
       "name": "M4",
-      "amplitude": 0.035173527347713694,
-      "phase": 47.11229165320208
+      "amplitude": 0.035,
+      "phase": 47.11
     },
     {
       "name": "MM",
-      "amplitude": 0.003964072902866484,
-      "phase": 338.60512746279596
+      "amplitude": 0.004,
+      "phase": 338.61
     },
     {
       "name": "MF",
-      "amplitude": 0.004329088150254311,
-      "phase": 125.93312069407438
+      "amplitude": 0.004,
+      "phase": 125.93
     },
     {
       "name": "SA",
-      "amplitude": 0.008030218048297037,
-      "phase": 146.2051426412379
+      "amplitude": 0.008,
+      "phase": 146.21
     },
     {
       "name": "SSA",
-      "amplitude": 0.00984754651865228,
-      "phase": 265.32067197701656
+      "amplitude": 0.01,
+      "phase": 265.32
     },
     {
       "name": "T2",
-      "amplitude": 0.0017839015574003816,
-      "phase": 176.10835343810265
+      "amplitude": 0.002,
+      "phase": 176.11
     },
     {
       "name": "J1",
-      "amplitude": 0.00007397783706838654,
-      "phase": 54.16458074375174
+      "amplitude": 0,
+      "phase": 54.16
     },
     {
       "name": "L2",
-      "amplitude": 0.003412625398379481,
-      "phase": 132.68042882661263
+      "amplitude": 0.003,
+      "phase": 132.68
     },
     {
       "name": "R2",
-      "amplitude": 0.0011049577107087984,
-      "phase": 45.146302358571916
+      "amplitude": 0.001,
+      "phase": 45.15
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0003100469239729191,
-      "phase": 28.0085497591038
+      "amplitude": 0,
+      "phase": 28.01
     },
     {
       "name": "MSF",
-      "amplitude": 0.002284891375878016,
-      "phase": 37.283622188473885
+      "amplitude": 0.002,
+      "phase": 37.28
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0021807098022704426,
-      "phase": 190.2234557684375
+      "amplitude": 0.002,
+      "phase": 190.22
     },
     {
       "name": "EP2",
-      "amplitude": 0.001179318847467887,
-      "phase": 169.45995476364624
+      "amplitude": 0.001,
+      "phase": 169.46
     },
     {
       "name": "M3",
-      "amplitude": 0.0000623846004860554,
-      "phase": 296.9332834484891
+      "amplitude": 0,
+      "phase": 296.93
     },
     {
       "name": "MU2",
-      "amplitude": 0.004431874588841168,
-      "phase": 202.72488070784428
+      "amplitude": 0.004,
+      "phase": 202.72
     },
     {
       "name": "MTM",
-      "amplitude": 0.0014481731447337567,
-      "phase": 263.3266888471993
+      "amplitude": 0.001,
+      "phase": 263.33
     },
     {
       "name": "NU2",
-      "amplitude": 0.0025920407313132,
-      "phase": 78.29317714334775
+      "amplitude": 0.003,
+      "phase": 78.29
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0008198719089730596,
-      "phase": 126.7357976376901
+      "amplitude": 0.001,
+      "phase": 126.74
     },
     {
       "name": "MN4",
-      "amplitude": 0.010004665653507811,
-      "phase": 19.445851665026453
+      "amplitude": 0.01,
+      "phase": 19.45
     },
     {
       "name": "MS4",
-      "amplitude": 0.01632614597566672,
-      "phase": 133.71620702537655
+      "amplitude": 0.016,
+      "phase": 133.72
     },
     {
       "name": "N4",
-      "amplitude": 0.0013513407466117294,
-      "phase": 347.89379438489675
+      "amplitude": 0.001,
+      "phase": 347.89
     },
     {
       "name": "M6",
-      "amplitude": 0.0017158032933259678,
-      "phase": 314.15280803836754
+      "amplitude": 0.002,
+      "phase": 314.15
     },
     {
       "name": "M8",
-      "amplitude": 0.0022592788301229404,
-      "phase": 74.33263703941884
+      "amplitude": 0.002,
+      "phase": 74.33
     },
     {
       "name": "S4",
-      "amplitude": 0.0020985671632281957,
-      "phase": 279.846012422644
+      "amplitude": 0.002,
+      "phase": 279.85
     },
     {
       "name": "OO1",
-      "amplitude": 0.0004897266681271186,
-      "phase": 30.936159991233524
+      "amplitude": 0,
+      "phase": 30.94
     },
     {
       "name": "S3",
-      "amplitude": 0.001972863707618616,
-      "phase": 225.13028534349556
+      "amplitude": 0.002,
+      "phase": 225.13
     },
     {
       "name": "MA2",
-      "amplitude": 0.0035864092001046603,
-      "phase": 167.94127276789754
+      "amplitude": 0.004,
+      "phase": 167.94
     },
     {
       "name": "MB2",
-      "amplitude": 0.004493663778343602,
-      "phase": 54.98886544959748
+      "amplitude": 0.004,
+      "phase": 54.99
     },
     {
       "name": "T3",
-      "amplitude": 0.0006373671463020135,
-      "phase": 181.04508871800067
+      "amplitude": 0.001,
+      "phase": 181.05
     },
     {
       "name": "R3",
-      "amplitude": 0.0005949068518418081,
-      "phase": 206.99509455964764
+      "amplitude": 0.001,
+      "phase": 207
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0006612932903906442,
-      "phase": 299.3335558956136
+      "amplitude": 0.001,
+      "phase": 299.33
     },
     {
       "name": "SGM",
-      "amplitude": 0.0005327205178395334,
-      "phase": 347.92935962262567
+      "amplitude": 0.001,
+      "phase": 347.93
     },
     {
       "name": "3L2",
-      "amplitude": 0.00046953981267723724,
-      "phase": 112.11942317529395
+      "amplitude": 0,
+      "phase": 112.12
     },
     {
       "name": "3N2",
-      "amplitude": 0.0017070495455234673,
-      "phase": 355.95389618201915
+      "amplitude": 0.002,
+      "phase": 355.95
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0008140175567906349,
-      "phase": 23.288833411346843
+      "amplitude": 0.001,
+      "phase": 23.29
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00170722452317834,
-      "phase": 37.34612558701656
+      "amplitude": 0.002,
+      "phase": 37.35
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0003761456819190519,
-      "phase": 315.082873694097
+      "amplitude": 0,
+      "phase": 315.08
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0003027604548067411,
-      "phase": 150.55868044733222
+      "amplitude": 0,
+      "phase": 150.56
     }
   ],
   "epoch": {

--- a/data/ticon/nordenham-4970040-deu-wsv.json
+++ b/data/ticon/nordenham-4970040-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.7753621778085018,
-      "phase": 353.23682095157045
+      "amplitude": 1.775,
+      "phase": 353.24
     },
     {
       "name": "N2",
-      "amplitude": 0.2769702685805762,
-      "phase": 328.96012082029716
+      "amplitude": 0.277,
+      "phase": 328.96
     },
     {
       "name": "S2",
-      "amplitude": 0.4543971895860348,
-      "phase": 69.42750378204505
+      "amplitude": 0.454,
+      "phase": 69.43
     },
     {
       "name": "K2",
-      "amplitude": 0.13444709901901067,
-      "phase": 65.76596605363761
+      "amplitude": 0.134,
+      "phase": 65.77
     },
     {
       "name": "2N2",
-      "amplitude": 0.030464370816425213,
-      "phase": 308.95907709199315
+      "amplitude": 0.03,
+      "phase": 308.96
     },
     {
       "name": "S1",
-      "amplitude": 0.017245875905408263,
-      "phase": 56.5315371808619
+      "amplitude": 0.017,
+      "phase": 56.53
     },
     {
       "name": "K1",
-      "amplitude": 0.07232795200621082,
-      "phase": 46.38305369289617
+      "amplitude": 0.072,
+      "phase": 46.38
     },
     {
       "name": "P1",
-      "amplitude": 0.0333590885554839,
-      "phase": 52.47714208221902
+      "amplitude": 0.033,
+      "phase": 52.48
     },
     {
       "name": "O1",
-      "amplitude": 0.09431586332154816,
-      "phase": 254.17920186994172
+      "amplitude": 0.094,
+      "phase": 254.18
     },
     {
       "name": "Q1",
-      "amplitude": 0.02889604531727118,
-      "phase": 195.65980681257332
+      "amplitude": 0.029,
+      "phase": 195.66
     },
     {
       "name": "M1",
-      "amplitude": 0.0022564854520904735,
-      "phase": 115.07998784181433
+      "amplitude": 0.002,
+      "phase": 115.08
     },
     {
       "name": "M4",
-      "amplitude": 0.1567533534429925,
-      "phase": 162.85430326195842
+      "amplitude": 0.157,
+      "phase": 162.85
     },
     {
       "name": "MM",
-      "amplitude": 0.01631321229984243,
-      "phase": 158.50593944590378
+      "amplitude": 0.016,
+      "phase": 158.51
     },
     {
       "name": "MF",
-      "amplitude": 0.011437413888072224,
-      "phase": 150.86178471091296
+      "amplitude": 0.011,
+      "phase": 150.86
     },
     {
       "name": "SA",
-      "amplitude": 0.07566416904774576,
-      "phase": 229.85318003140793
+      "amplitude": 0.076,
+      "phase": 229.85
     },
     {
       "name": "SSA",
-      "amplitude": 0.039503204491844024,
-      "phase": 210.5181762305564
+      "amplitude": 0.04,
+      "phase": 210.52
     },
     {
       "name": "T2",
-      "amplitude": 0.024239204981832664,
-      "phase": 39.55236368744352
+      "amplitude": 0.024,
+      "phase": 39.55
     },
     {
       "name": "J1",
-      "amplitude": 0.002621340045394262,
-      "phase": 181.7031361659342
+      "amplitude": 0.003,
+      "phase": 181.7
     },
     {
       "name": "L2",
-      "amplitude": 0.15385478825086638,
-      "phase": 8.688428668458073
+      "amplitude": 0.154,
+      "phase": 8.69
     },
     {
       "name": "R2",
-      "amplitude": 0.003194940222993062,
-      "phase": 309.25577277270736
+      "amplitude": 0.003,
+      "phase": 309.26
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006259707553961141,
-      "phase": 140.6135301190207
+      "amplitude": 0.006,
+      "phase": 140.61
     },
     {
       "name": "MSF",
-      "amplitude": 0.02222548610087495,
-      "phase": 66.17207904883037
+      "amplitude": 0.022,
+      "phase": 66.17
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00955217659020353,
-      "phase": 45.16516501480385
+      "amplitude": 0.01,
+      "phase": 45.17
     },
     {
       "name": "EP2",
-      "amplitude": 0.045895911886793844,
-      "phase": 51.458623093873655
+      "amplitude": 0.046,
+      "phase": 51.46
     },
     {
       "name": "M3",
-      "amplitude": 0.004392572587271084,
-      "phase": 61.06953515090703
+      "amplitude": 0.004,
+      "phase": 61.07
     },
     {
       "name": "MU2",
-      "amplitude": 0.21304664585914473,
-      "phase": 74.35878953327881
+      "amplitude": 0.213,
+      "phase": 74.36
     },
     {
       "name": "MTM",
-      "amplitude": 0.0050299795013702,
-      "phase": 231.53141109710168
+      "amplitude": 0.005,
+      "phase": 231.53
     },
     {
       "name": "NU2",
-      "amplitude": 0.10984686652295532,
-      "phase": 307.7165452561971
+      "amplitude": 0.11,
+      "phase": 307.72
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07237336098554846,
-      "phase": 6.194814934399631
+      "amplitude": 0.072,
+      "phase": 6.19
     },
     {
       "name": "MN4",
-      "amplitude": 0.04779723421388976,
-      "phase": 138.93354331603064
+      "amplitude": 0.048,
+      "phase": 138.93
     },
     {
       "name": "MS4",
-      "amplitude": 0.10722117059045887,
-      "phase": 246.93145122421998
+      "amplitude": 0.107,
+      "phase": 246.93
     },
     {
       "name": "N4",
-      "amplitude": 0.009871014926583682,
-      "phase": 119.20785294617451
+      "amplitude": 0.01,
+      "phase": 119.21
     },
     {
       "name": "M6",
-      "amplitude": 0.05525535927819775,
-      "phase": 31.577863126177647
+      "amplitude": 0.055,
+      "phase": 31.58
     },
     {
       "name": "M8",
-      "amplitude": 0.01264507397289405,
-      "phase": 318.12782955375604
+      "amplitude": 0.013,
+      "phase": 318.13
     },
     {
       "name": "S4",
-      "amplitude": 0.014423166121435951,
-      "phase": 35.05563469971645
+      "amplitude": 0.014,
+      "phase": 35.06
     },
     {
       "name": "OO1",
-      "amplitude": 0.003003444299894809,
-      "phase": 203.53846126494153
+      "amplitude": 0.003,
+      "phase": 203.54
     },
     {
       "name": "S3",
-      "amplitude": 0.0006256208683736632,
-      "phase": 267.7815218620718
+      "amplitude": 0.001,
+      "phase": 267.78
     },
     {
       "name": "MA2",
-      "amplitude": 0.06562202396128894,
-      "phase": 306.29556358111927
+      "amplitude": 0.066,
+      "phase": 306.3
     },
     {
       "name": "MB2",
-      "amplitude": 0.013665199923567548,
-      "phase": 59.30260699943858
+      "amplitude": 0.014,
+      "phase": 59.3
     },
     {
       "name": "T3",
-      "amplitude": 0.0007444051204892187,
-      "phase": 208.2144804898613
+      "amplitude": 0.001,
+      "phase": 208.21
     },
     {
       "name": "R3",
-      "amplitude": 0.0035188083116509247,
-      "phase": 56.75454613174111
+      "amplitude": 0.004,
+      "phase": 56.75
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0061106590468768965,
-      "phase": 199.3679535242891
+      "amplitude": 0.006,
+      "phase": 199.37
     },
     {
       "name": "SGM",
-      "amplitude": 0.0019227404241719738,
-      "phase": 49.53514675313875
+      "amplitude": 0.002,
+      "phase": 49.54
     },
     {
       "name": "3L2",
-      "amplitude": 0.0048018909949603845,
-      "phase": 258.6038282886049
+      "amplitude": 0.005,
+      "phase": 258.6
     },
     {
       "name": "3N2",
-      "amplitude": 0.023893269058293507,
-      "phase": 163.66671034195224
+      "amplitude": 0.024,
+      "phase": 163.67
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04864007587286365,
-      "phase": 289.9915176433033
+      "amplitude": 0.049,
+      "phase": 289.99
     },
     {
       "name": "2MS6",
-      "amplitude": 0.062289119546735716,
-      "phase": 103.56571115592016
+      "amplitude": 0.062,
+      "phase": 103.57
     },
     {
       "name": "2MK5",
-      "amplitude": 0.010944772768830179,
-      "phase": 33.40482101001595
+      "amplitude": 0.011,
+      "phase": 33.4
     },
     {
       "name": "2MO5",
-      "amplitude": 0.007240603916918478,
-      "phase": 215.22587928699622
+      "amplitude": 0.007,
+      "phase": 215.23
     }
   ],
   "epoch": {

--- a/data/ticon/norderneyriffgat-9360010-deu-wsv.json
+++ b/data/ticon/norderneyriffgat-9360010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.10995694702521,
-      "phase": 285.13027142447385
+      "amplitude": 1.11,
+      "phase": 285.13
     },
     {
       "name": "N2",
-      "amplitude": 0.1784765410111642,
-      "phase": 260.29924077887785
+      "amplitude": 0.178,
+      "phase": 260.3
     },
     {
       "name": "S2",
-      "amplitude": 0.29330609455615064,
-      "phase": 351.5891840070853
+      "amplitude": 0.293,
+      "phase": 351.59
     },
     {
       "name": "K2",
-      "amplitude": 0.08831724439367526,
-      "phase": 349.5208770794254
+      "amplitude": 0.088,
+      "phase": 349.52
     },
     {
       "name": "2N2",
-      "amplitude": 0.020261964796580607,
-      "phase": 241.2210330081378
+      "amplitude": 0.02,
+      "phase": 241.22
     },
     {
       "name": "S1",
-      "amplitude": 0.008266721193336064,
-      "phase": 0.10003507292600489
+      "amplitude": 0.008,
+      "phase": 0.1
     },
     {
       "name": "K1",
-      "amplitude": 0.06888175320437796,
-      "phase": 12.591040062977982
+      "amplitude": 0.069,
+      "phase": 12.59
     },
     {
       "name": "P1",
-      "amplitude": 0.027673809589299353,
-      "phase": 18.46855066481487
+      "amplitude": 0.028,
+      "phase": 18.47
     },
     {
       "name": "O1",
-      "amplitude": 0.088201984478943,
-      "phase": 222.34609045614036
+      "amplitude": 0.088,
+      "phase": 222.35
     },
     {
       "name": "Q1",
-      "amplitude": 0.028473893616848624,
-      "phase": 163.90122920025067
+      "amplitude": 0.028,
+      "phase": 163.9
     },
     {
       "name": "M1",
-      "amplitude": 0.001670455417196592,
-      "phase": 69.49021961904691
+      "amplitude": 0.002,
+      "phase": 69.49
     },
     {
       "name": "M4",
-      "amplitude": 0.027204970364030686,
-      "phase": 51.96864391162774
+      "amplitude": 0.027,
+      "phase": 51.97
     },
     {
       "name": "MM",
-      "amplitude": 0.022759455472354105,
-      "phase": 176.79318738723828
+      "amplitude": 0.023,
+      "phase": 176.79
     },
     {
       "name": "MF",
-      "amplitude": 0.01028875325787581,
-      "phase": 177.51599957462622
+      "amplitude": 0.01,
+      "phase": 177.52
     },
     {
       "name": "SA",
-      "amplitude": 0.10791823239135927,
-      "phase": 226.1651269315188
+      "amplitude": 0.108,
+      "phase": 226.17
     },
     {
       "name": "SSA",
-      "amplitude": 0.03417520128789046,
-      "phase": 201.60195987047183
+      "amplitude": 0.034,
+      "phase": 201.6
     },
     {
       "name": "T2",
-      "amplitude": 0.014700767245527427,
-      "phase": 330.8143346558131
+      "amplitude": 0.015,
+      "phase": 330.81
     },
     {
       "name": "J1",
-      "amplitude": 0.0019346524272410176,
-      "phase": 116.5450920689409
+      "amplitude": 0.002,
+      "phase": 116.55
     },
     {
       "name": "L2",
-      "amplitude": 0.08545737730633712,
-      "phase": 301.57146158967873
+      "amplitude": 0.085,
+      "phase": 301.57
     },
     {
       "name": "R2",
-      "amplitude": 0.0018588001765521343,
-      "phase": 330.2145481197167
+      "amplitude": 0.002,
+      "phase": 330.21
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005901769807855707,
-      "phase": 109.96613100638689
+      "amplitude": 0.006,
+      "phase": 109.97
     },
     {
       "name": "MSF",
-      "amplitude": 0.004029790371949713,
-      "phase": 8.410902916405064
+      "amplitude": 0.004,
+      "phase": 8.41
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008563463429937962,
-      "phase": 65.25474329497808
+      "amplitude": 0.009,
+      "phase": 65.25
     },
     {
       "name": "EP2",
-      "amplitude": 0.023881736027920035,
-      "phase": 354.1376026835463
+      "amplitude": 0.024,
+      "phase": 354.14
     },
     {
       "name": "M3",
-      "amplitude": 0.0036713365839211093,
-      "phase": 269.6652265464283
+      "amplitude": 0.004,
+      "phase": 269.67
     },
     {
       "name": "MU2",
-      "amplitude": 0.10349808176925072,
-      "phase": 16.307537088099878
+      "amplitude": 0.103,
+      "phase": 16.31
     },
     {
       "name": "MTM",
-      "amplitude": 0.006212314751674269,
-      "phase": 251.4471352750503
+      "amplitude": 0.006,
+      "phase": 251.45
     },
     {
       "name": "NU2",
-      "amplitude": 0.062302869427500934,
-      "phase": 246.22659713544664
+      "amplitude": 0.062,
+      "phase": 246.23
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0404604962899719,
-      "phase": 294.95224920631955
+      "amplitude": 0.04,
+      "phase": 294.95
     },
     {
       "name": "MN4",
-      "amplitude": 0.008831387930644086,
-      "phase": 39.99494209552188
+      "amplitude": 0.009,
+      "phase": 39.99
     },
     {
       "name": "MS4",
-      "amplitude": 0.029861736167323776,
-      "phase": 114.6661092801412
+      "amplitude": 0.03,
+      "phase": 114.67
     },
     {
       "name": "N4",
-      "amplitude": 0.002063648254924183,
-      "phase": 24.745514516654566
+      "amplitude": 0.002,
+      "phase": 24.75
     },
     {
       "name": "M6",
-      "amplitude": 0.06016579975599327,
-      "phase": 208.52809140796214
+      "amplitude": 0.06,
+      "phase": 208.53
     },
     {
       "name": "M8",
-      "amplitude": 0.009950396640489554,
-      "phase": 33.2207749700716
+      "amplitude": 0.01,
+      "phase": 33.22
     },
     {
       "name": "S4",
-      "amplitude": 0.00533106631771555,
-      "phase": 233.20921398190254
+      "amplitude": 0.005,
+      "phase": 233.21
     },
     {
       "name": "OO1",
-      "amplitude": 0.0022133691672720822,
-      "phase": 183.94604423689142
+      "amplitude": 0.002,
+      "phase": 183.95
     },
     {
       "name": "S3",
-      "amplitude": 0.0006052003833072076,
-      "phase": 94.02188391838496
+      "amplitude": 0.001,
+      "phase": 94.02
     },
     {
       "name": "MA2",
-      "amplitude": 0.03498973334144552,
-      "phase": 234.8674427515217
+      "amplitude": 0.035,
+      "phase": 234.87
     },
     {
       "name": "MB2",
-      "amplitude": 0.01556352267096376,
-      "phase": 17.843978042033882
+      "amplitude": 0.016,
+      "phase": 17.84
     },
     {
       "name": "T3",
-      "amplitude": 0.0009349987149102974,
-      "phase": 323.5532413096225
+      "amplitude": 0.001,
+      "phase": 323.55
     },
     {
       "name": "R3",
-      "amplitude": 0.0024417501848771114,
-      "phase": 323.99597124104486
+      "amplitude": 0.002,
+      "phase": 324
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005585837564838356,
-      "phase": 171.4640076045015
+      "amplitude": 0.006,
+      "phase": 171.46
     },
     {
       "name": "SGM",
-      "amplitude": 0.002600260614658277,
-      "phase": 43.70353398118141
+      "amplitude": 0.003,
+      "phase": 43.7
     },
     {
       "name": "3L2",
-      "amplitude": 0.0034709327598143954,
-      "phase": 190.95941986927153
+      "amplitude": 0.003,
+      "phase": 190.96
     },
     {
       "name": "3N2",
-      "amplitude": 0.011712635113656349,
-      "phase": 84.9315367265225
+      "amplitude": 0.012,
+      "phase": 84.93
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02683752204676645,
-      "phase": 210.16480398275894
+      "amplitude": 0.027,
+      "phase": 210.16
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05930552451780058,
-      "phase": 271.1238851265432
+      "amplitude": 0.059,
+      "phase": 271.12
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004465170221262361,
-      "phase": 209.7022987040744
+      "amplitude": 0.004,
+      "phase": 209.7
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0010979897081695431,
-      "phase": 72.02846483948804
+      "amplitude": 0.001,
+      "phase": 72.03
     }
   ],
   "epoch": {

--- a/data/ticon/nordfeldoberwasser-9520040-deu-wsv.json
+++ b/data/ticon/nordfeldoberwasser-9520040-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.033827818256086134,
-      "phase": 104.96204067128258
+      "amplitude": 0.034,
+      "phase": 104.96
     },
     {
       "name": "N2",
-      "amplitude": 0.005887252954005227,
-      "phase": 82.57641958965752
+      "amplitude": 0.006,
+      "phase": 82.58
     },
     {
       "name": "S2",
-      "amplitude": 0.007671330686813303,
-      "phase": 182.3660839504788
+      "amplitude": 0.008,
+      "phase": 182.37
     },
     {
       "name": "K2",
-      "amplitude": 0.002532694528689352,
-      "phase": 187.34991846045008
+      "amplitude": 0.003,
+      "phase": 187.35
     },
     {
       "name": "2N2",
-      "amplitude": 0.0005823891569755873,
-      "phase": 78.66007467520791
+      "amplitude": 0.001,
+      "phase": 78.66
     },
     {
       "name": "S1",
-      "amplitude": 0.006287419875765765,
-      "phase": 89.82002234251422
+      "amplitude": 0.006,
+      "phase": 89.82
     },
     {
       "name": "K1",
-      "amplitude": 0.008273841402720484,
-      "phase": 143.37898491799984
+      "amplitude": 0.008,
+      "phase": 143.38
     },
     {
       "name": "P1",
-      "amplitude": 0.004819784770856702,
-      "phase": 65.4320244219802
+      "amplitude": 0.005,
+      "phase": 65.43
     },
     {
       "name": "O1",
-      "amplitude": 0.008562606856288053,
-      "phase": 334.60779913905884
+      "amplitude": 0.009,
+      "phase": 334.61
     },
     {
       "name": "Q1",
-      "amplitude": 0.0016349307755046264,
-      "phase": 288.75621055886006
+      "amplitude": 0.002,
+      "phase": 288.76
     },
     {
       "name": "M1",
-      "amplitude": 0.000563685484752436,
-      "phase": 266.9642985082229
+      "amplitude": 0.001,
+      "phase": 266.96
     },
     {
       "name": "M4",
-      "amplitude": 0.016164972652553226,
-      "phase": 273.09768113220315
+      "amplitude": 0.016,
+      "phase": 273.1
     },
     {
       "name": "MM",
-      "amplitude": 0.014491494861753104,
-      "phase": 222.43394223156923
+      "amplitude": 0.014,
+      "phase": 222.43
     },
     {
       "name": "MF",
-      "amplitude": 0.004177258661539439,
-      "phase": 155.94316316460458
+      "amplitude": 0.004,
+      "phase": 155.94
     },
     {
       "name": "SA",
-      "amplitude": 0.011804603132599152,
-      "phase": 139.0423754402923
+      "amplitude": 0.012,
+      "phase": 139.04
     },
     {
       "name": "SSA",
-      "amplitude": 0.007735058917583359,
-      "phase": 121.2912621679227
+      "amplitude": 0.008,
+      "phase": 121.29
     },
     {
       "name": "T2",
-      "amplitude": 0.0018453345181105839,
-      "phase": 355.2322244450095
+      "amplitude": 0.002,
+      "phase": 355.23
     },
     {
       "name": "J1",
-      "amplitude": 0.0002715942976530414,
-      "phase": 68.7313065595373
+      "amplitude": 0,
+      "phase": 68.73
     },
     {
       "name": "L2",
-      "amplitude": 0.0025055242010945224,
-      "phase": 125.24959138054294
+      "amplitude": 0.003,
+      "phase": 125.25
     },
     {
       "name": "R2",
-      "amplitude": 0.002316786955716579,
-      "phase": 193.02897481280635
+      "amplitude": 0.002,
+      "phase": 193.03
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0008535268239522835,
-      "phase": 190.8889114304819
+      "amplitude": 0.001,
+      "phase": 190.89
     },
     {
       "name": "MSF",
-      "amplitude": 0.018267060623198397,
-      "phase": 261.2062361352805
+      "amplitude": 0.018,
+      "phase": 261.21
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0038199109587048895,
-      "phase": 65.42756748629984
+      "amplitude": 0.004,
+      "phase": 65.43
     },
     {
       "name": "EP2",
-      "amplitude": 0.001114215748764673,
-      "phase": 188.9542478893833
+      "amplitude": 0.001,
+      "phase": 188.95
     },
     {
       "name": "M3",
-      "amplitude": 0.00006990581054079605,
-      "phase": 345.4809941613085
+      "amplitude": 0,
+      "phase": 345.48
     },
     {
       "name": "MU2",
-      "amplitude": 0.00500619368464493,
-      "phase": 187.71570139998343
+      "amplitude": 0.005,
+      "phase": 187.72
     },
     {
       "name": "MTM",
-      "amplitude": 0.005482888364650378,
-      "phase": 254.11609774974343
+      "amplitude": 0.005,
+      "phase": 254.12
     },
     {
       "name": "NU2",
-      "amplitude": 0.0025789392955211728,
-      "phase": 63.59628428211727
+      "amplitude": 0.003,
+      "phase": 63.6
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.001307119846009862,
-      "phase": 125.19410066362025
+      "amplitude": 0.001,
+      "phase": 125.19
     },
     {
       "name": "MN4",
-      "amplitude": 0.0050243649016321595,
-      "phase": 249.2379619010701
+      "amplitude": 0.005,
+      "phase": 249.24
     },
     {
       "name": "MS4",
-      "amplitude": 0.009215759412369165,
-      "phase": 357.76096929470833
+      "amplitude": 0.009,
+      "phase": 357.76
     },
     {
       "name": "N4",
-      "amplitude": 0.0008843466020988705,
-      "phase": 247.42115102283043
+      "amplitude": 0.001,
+      "phase": 247.42
     },
     {
       "name": "M6",
-      "amplitude": 0.0022252094653629605,
-      "phase": 249.95321574799817
+      "amplitude": 0.002,
+      "phase": 249.95
     },
     {
       "name": "M8",
-      "amplitude": 0.0013014159920019532,
-      "phase": 150.6242947338318
+      "amplitude": 0.001,
+      "phase": 150.62
     },
     {
       "name": "S4",
-      "amplitude": 0.0009518382682098618,
-      "phase": 145.16952100727337
+      "amplitude": 0.001,
+      "phase": 145.17
     },
     {
       "name": "OO1",
-      "amplitude": 0.0005795758810361492,
-      "phase": 3.9121943816438716
+      "amplitude": 0.001,
+      "phase": 3.91
     },
     {
       "name": "S3",
-      "amplitude": 0.00018000208289495806,
-      "phase": 89.53512855752456
+      "amplitude": 0,
+      "phase": 89.54
     },
     {
       "name": "MA2",
-      "amplitude": 0.011110181578710262,
-      "phase": 350.8735889276148
+      "amplitude": 0.011,
+      "phase": 350.87
     },
     {
       "name": "MB2",
-      "amplitude": 0.011732062399069593,
-      "phase": 193.7561358067073
+      "amplitude": 0.012,
+      "phase": 193.76
     },
     {
       "name": "T3",
-      "amplitude": 0.00008723990156423263,
-      "phase": 352.81058830996477
+      "amplitude": 0,
+      "phase": 352.81
     },
     {
       "name": "R3",
-      "amplitude": 0.0003486920530900819,
-      "phase": 25.664016988913886
+      "amplitude": 0,
+      "phase": 25.66
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0008333718303281458,
-      "phase": 297.6648580229199
+      "amplitude": 0.001,
+      "phase": 297.66
     },
     {
       "name": "SGM",
-      "amplitude": 0.00044661844924523045,
-      "phase": 36.195770938391945
+      "amplitude": 0,
+      "phase": 36.2
     },
     {
       "name": "3L2",
-      "amplitude": 0.00016849062270720476,
-      "phase": 276.4523489591817
+      "amplitude": 0,
+      "phase": 276.45
     },
     {
       "name": "3N2",
-      "amplitude": 0.0022325721860131692,
-      "phase": 174.58788577308064
+      "amplitude": 0.002,
+      "phase": 174.59
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0006254676583711357,
-      "phase": 62.59036249424042
+      "amplitude": 0.001,
+      "phase": 62.59
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0019792817518946106,
-      "phase": 326.5551714116083
+      "amplitude": 0.002,
+      "phase": 326.56
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0014027302223384146,
-      "phase": 213.011254017787
+      "amplitude": 0.001,
+      "phase": 213.01
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0009401511346089257,
-      "phase": 112.2089528252032
+      "amplitude": 0.001,
+      "phase": 112.21
     }
   ],
   "epoch": {

--- a/data/ticon/nordfeldunterwasser-9520050-deu-wsv.json
+++ b/data/ticon/nordfeldunterwasser-9520050-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.8413663417111884,
-      "phase": 41.46596443241839
+      "amplitude": 0.841,
+      "phase": 41.47
     },
     {
       "name": "N2",
-      "amplitude": 0.13037415094251853,
-      "phase": 17.35029161057986
+      "amplitude": 0.13,
+      "phase": 17.35
     },
     {
       "name": "S2",
-      "amplitude": 0.21991781227407659,
-      "phase": 122.3096375603186
+      "amplitude": 0.22,
+      "phase": 122.31
     },
     {
       "name": "K2",
-      "amplitude": 0.06922381768202772,
-      "phase": 121.24975282152462
+      "amplitude": 0.069,
+      "phase": 121.25
     },
     {
       "name": "2N2",
-      "amplitude": 0.01924373288800268,
-      "phase": 12.437549762414676
+      "amplitude": 0.019,
+      "phase": 12.44
     },
     {
       "name": "S1",
-      "amplitude": 0.013725886103414457,
-      "phase": 281.0271167221333
+      "amplitude": 0.014,
+      "phase": 281.03
     },
     {
       "name": "K1",
-      "amplitude": 0.04702175953633582,
-      "phase": 85.58178445660133
+      "amplitude": 0.047,
+      "phase": 85.58
     },
     {
       "name": "P1",
-      "amplitude": 0.02296551207746529,
-      "phase": 71.47832668986439
+      "amplitude": 0.023,
+      "phase": 71.48
     },
     {
       "name": "O1",
-      "amplitude": 0.06082997105381368,
-      "phase": 298.7799835977377
+      "amplitude": 0.061,
+      "phase": 298.78
     },
     {
       "name": "Q1",
-      "amplitude": 0.016215351124915234,
-      "phase": 240.0380894659712
+      "amplitude": 0.016,
+      "phase": 240.04
     },
     {
       "name": "M1",
-      "amplitude": 0.0007072731331868901,
-      "phase": 104.5227661810332
+      "amplitude": 0.001,
+      "phase": 104.52
     },
     {
       "name": "M4",
-      "amplitude": 0.08926005310676652,
-      "phase": 41.337309918643484
+      "amplitude": 0.089,
+      "phase": 41.34
     },
     {
       "name": "MM",
-      "amplitude": 0.017385333514281988,
-      "phase": 111.56067681191269
+      "amplitude": 0.017,
+      "phase": 111.56
     },
     {
       "name": "MF",
-      "amplitude": 0.010540170376267937,
-      "phase": 123.56973034035622
+      "amplitude": 0.011,
+      "phase": 123.57
     },
     {
       "name": "SA",
-      "amplitude": 0.0921596822772462,
-      "phase": 128.6709113329557
+      "amplitude": 0.092,
+      "phase": 128.67
     },
     {
       "name": "SSA",
-      "amplitude": 0.015515845281489657,
-      "phase": 221.4728481614164
+      "amplitude": 0.016,
+      "phase": 221.47
     },
     {
       "name": "T2",
-      "amplitude": 0.008995248273944276,
-      "phase": 125.92631304925885
+      "amplitude": 0.009,
+      "phase": 125.93
     },
     {
       "name": "J1",
-      "amplitude": 0.007109470953158359,
-      "phase": 197.44539159705084
+      "amplitude": 0.007,
+      "phase": 197.45
     },
     {
       "name": "L2",
-      "amplitude": 0.07703716742799473,
-      "phase": 51.29980798817536
+      "amplitude": 0.077,
+      "phase": 51.3
     },
     {
       "name": "R2",
-      "amplitude": 0.004065575607756491,
-      "phase": 100.49399303272628
+      "amplitude": 0.004,
+      "phase": 100.49
     },
     {
       "name": "2Q1",
-      "amplitude": 0.007590248723405903,
-      "phase": 206.70458060585707
+      "amplitude": 0.008,
+      "phase": 206.7
     },
     {
       "name": "MSF",
-      "amplitude": 0.05419308680919823,
-      "phase": 83.00492976282567
+      "amplitude": 0.054,
+      "phase": 83
     },
     {
       "name": "MSQM",
-      "amplitude": 0.001263103120532498,
-      "phase": 200.3905211266659
+      "amplitude": 0.001,
+      "phase": 200.39
     },
     {
       "name": "EP2",
-      "amplitude": 0.031770333146007815,
-      "phase": 103.97260749901466
+      "amplitude": 0.032,
+      "phase": 103.97
     },
     {
       "name": "M3",
-      "amplitude": 0.0023366308416902866,
-      "phase": 145.30460777377027
+      "amplitude": 0.002,
+      "phase": 145.3
     },
     {
       "name": "MU2",
-      "amplitude": 0.10816673934529396,
-      "phase": 122.48904843158869
+      "amplitude": 0.108,
+      "phase": 122.49
     },
     {
       "name": "MTM",
-      "amplitude": 0.014845794659478025,
-      "phase": 90.08411600483612
+      "amplitude": 0.015,
+      "phase": 90.08
     },
     {
       "name": "NU2",
-      "amplitude": 0.051345892783838686,
-      "phase": 2.783431570870846
+      "amplitude": 0.051,
+      "phase": 2.78
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03446966007427113,
-      "phase": 67.33426872959433
+      "amplitude": 0.034,
+      "phase": 67.33
     },
     {
       "name": "MN4",
-      "amplitude": 0.028766095162535678,
-      "phase": 20.16699187365151
+      "amplitude": 0.029,
+      "phase": 20.17
     },
     {
       "name": "MS4",
-      "amplitude": 0.04360134850035698,
-      "phase": 114.83368296994263
+      "amplitude": 0.044,
+      "phase": 114.83
     },
     {
       "name": "N4",
-      "amplitude": 0.005512138486250214,
-      "phase": 9.751649199813869
+      "amplitude": 0.006,
+      "phase": 9.75
     },
     {
       "name": "M6",
-      "amplitude": 0.019643310271029567,
-      "phase": 282.3873048760465
+      "amplitude": 0.02,
+      "phase": 282.39
     },
     {
       "name": "M8",
-      "amplitude": 0.013566871324445739,
-      "phase": 205.8259659058252
+      "amplitude": 0.014,
+      "phase": 205.83
     },
     {
       "name": "S4",
-      "amplitude": 0.005180171473808551,
-      "phase": 250.67218362866402
+      "amplitude": 0.005,
+      "phase": 250.67
     },
     {
       "name": "OO1",
-      "amplitude": 0.002945539286806509,
-      "phase": 22.911660972443542
+      "amplitude": 0.003,
+      "phase": 22.91
     },
     {
       "name": "S3",
-      "amplitude": 0.003957348706003643,
-      "phase": 143.54700072047518
+      "amplitude": 0.004,
+      "phase": 143.55
     },
     {
       "name": "MA2",
-      "amplitude": 0.03378026188120228,
-      "phase": 292.08220109415606
+      "amplitude": 0.034,
+      "phase": 292.08
     },
     {
       "name": "MB2",
-      "amplitude": 0.053110002948784076,
-      "phase": 141.8970989750925
+      "amplitude": 0.053,
+      "phase": 141.9
     },
     {
       "name": "T3",
-      "amplitude": 0.0009375326436302867,
-      "phase": 332.6297645525249
+      "amplitude": 0.001,
+      "phase": 332.63
     },
     {
       "name": "R3",
-      "amplitude": 0.0038943770360166862,
-      "phase": 65.94224377572891
+      "amplitude": 0.004,
+      "phase": 65.94
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004213468734832773,
-      "phase": 229.20870544817217
+      "amplitude": 0.004,
+      "phase": 229.21
     },
     {
       "name": "SGM",
-      "amplitude": 0.013479234013432317,
-      "phase": 91.29634858755276
+      "amplitude": 0.013,
+      "phase": 91.3
     },
     {
       "name": "3L2",
-      "amplitude": 0.006454997716098282,
-      "phase": 331.1734006472487
+      "amplitude": 0.006,
+      "phase": 331.17
     },
     {
       "name": "3N2",
-      "amplitude": 0.003393823071150598,
-      "phase": 341.3619045680908
+      "amplitude": 0.003,
+      "phase": 341.36
     },
     {
       "name": "2SM2",
-      "amplitude": 0.024669315666048373,
-      "phase": 335.41264197915086
+      "amplitude": 0.025,
+      "phase": 335.41
     },
     {
       "name": "2MS6",
-      "amplitude": 0.021063741456689333,
-      "phase": 346.8373604334941
+      "amplitude": 0.021,
+      "phase": 346.84
     },
     {
       "name": "2MK5",
-      "amplitude": 0.006841060941622361,
-      "phase": 333.4884232116056
+      "amplitude": 0.007,
+      "phase": 333.49
     },
     {
       "name": "2MO5",
-      "amplitude": 0.007477546749332905,
-      "phase": 198.23443172542574
+      "amplitude": 0.007,
+      "phase": 198.23
     }
   ],
   "epoch": {

--- a/data/ticon/north_cormorant-northcmrt-nld-rws.json
+++ b/data/ticon/north_cormorant-northcmrt-nld-rws.json
@@ -33,253 +33,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.50066586,
-      "phase": 306.66378199999997
+      "amplitude": 0.516,
+      "phase": 289.81
     },
     {
       "name": "N2",
-      "amplitude": 0.10124693000000001,
-      "phase": 284.890495
+      "amplitude": 0.104,
+      "phase": 267.73
     },
     {
       "name": "S2",
-      "amplitude": 0.17827095,
-      "phase": 343.020652
+      "amplitude": 0.183,
+      "phase": 325.57
     },
     {
       "name": "K2",
-      "amplitude": 0.04687358,
-      "phase": 345.654911
+      "amplitude": 0.052,
+      "phase": 321.21
     },
     {
       "name": "2N2",
-      "amplitude": 0.014471560000000001,
-      "phase": 264.223553
+      "amplitude": 0.014,
+      "phase": 246.36
     },
     {
       "name": "S1",
-      "amplitude": 0.00340171,
-      "phase": 227.596075
+      "amplitude": 0.003,
+      "phase": 83.73
     },
     {
       "name": "K1",
-      "amplitude": 0.06254539,
-      "phase": 177.81025999999997
+      "amplitude": 0.063,
+      "phase": 169.33
     },
     {
       "name": "P1",
-      "amplitude": 0.018644559999999998,
-      "phase": 159.96184199999993
+      "amplitude": 0.019,
+      "phase": 154.74
     },
     {
       "name": "O1",
-      "amplitude": 0.06044123,
-      "phase": 47.37948499999999
+      "amplitude": 0.06,
+      "phase": 38.78
     },
     {
       "name": "Q1",
-      "amplitude": 0.020919379999999998,
-      "phase": 354.204621
+      "amplitude": 0.021,
+      "phase": 345.87
     },
     {
       "name": "M1",
-      "amplitude": 0.00070868,
-      "phase": 74.11685299999999
+      "amplitude": 0.001,
+      "phase": 249.99
     },
     {
       "name": "M4",
-      "amplitude": 0.00302752,
-      "phase": 284.189056
+      "amplitude": 0.003,
+      "phase": 244.31
     },
     {
       "name": "MM",
-      "amplitude": 0.0214111,
-      "phase": 186.507888
+      "amplitude": 0.022,
+      "phase": 180.08
     },
     {
       "name": "MF",
-      "amplitude": 0.02546882,
-      "phase": 194.612644
+      "amplitude": 0.024,
+      "phase": 193.52
     },
     {
       "name": "SA",
-      "amplitude": 0.08545097,
-      "phase": 251.517189
+      "amplitude": 0.091,
+      "phase": 252.62
     },
     {
       "name": "SSA",
-      "amplitude": 0.02359255,
-      "phase": 181.128394
+      "amplitude": 0.025,
+      "phase": 172.01
     },
     {
       "name": "T2",
-      "amplitude": 0.029534639999999997,
-      "phase": 258.025298
+      "amplitude": 0.009,
+      "phase": 325.66
     },
     {
       "name": "J1",
-      "amplitude": 0.00266351,
-      "phase": 239.86847799999998
+      "amplitude": 0.003,
+      "phase": 230.96
     },
     {
       "name": "L2",
-      "amplitude": 0.01331001,
-      "phase": 327.726047
+      "amplitude": 0.014,
+      "phase": 309.27
     },
     {
       "name": "R2",
-      "amplitude": 0.024279600000000002,
-      "phase": 86.15042900000003
+      "amplitude": 0.002,
+      "phase": 348.3
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00418466,
-      "phase": 300.700853
+      "amplitude": 0.004,
+      "phase": 293.94
     },
     {
       "name": "MSF",
-      "amplitude": 0.00424614,
-      "phase": 158.40143
+      "amplitude": 0.005,
+      "phase": 155.32
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0014427499999999998,
-      "phase": 317.89346
+      "amplitude": 0.001,
+      "phase": 321.44
     },
     {
       "name": "EP2",
-      "amplitude": 0.00300428,
-      "phase": 241.665162
+      "amplitude": 0.004,
+      "phase": 220.11
     },
     {
       "name": "M3",
-      "amplitude": 0.0035730099999999997,
-      "phase": 197.789434
+      "amplitude": 0.004,
+      "phase": 350.15
     },
     {
       "name": "MU2",
-      "amplitude": 0.01577251,
-      "phase": 263.842511
+      "amplitude": 0.016,
+      "phase": 247.74
     },
     {
       "name": "MTM",
-      "amplitude": 0.00605483,
-      "phase": 209.46472
+      "amplitude": 0.006,
+      "phase": 213.05
     },
     {
       "name": "NU2",
-      "amplitude": 0.018753699999999998,
-      "phase": 289.916825
+      "amplitude": 0.019,
+      "phase": 272.48
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00419035,
-      "phase": 322.912699
+      "amplitude": 0.004,
+      "phase": 307.3
     },
     {
       "name": "MN4",
-      "amplitude": 0.00021365,
-      "phase": 161.032783
+      "amplitude": 0,
+      "phase": 123.72
     },
     {
       "name": "MS4",
-      "amplitude": 0.00459019,
-      "phase": 27.182732999999985
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.01783924,
-      "phase": 83.02941699999997
+      "amplitude": 0.005,
+      "phase": 351.37
     },
     {
       "name": "N4",
-      "amplitude": 0.00013972,
-      "phase": 26.926648999999998
+      "amplitude": 0,
+      "phase": 1.07
     },
     {
       "name": "M6",
-      "amplitude": 0.00308342,
-      "phase": 311.154559
+      "amplitude": 0.004,
+      "phase": 256.39
     },
     {
       "name": "M8",
-      "amplitude": 0.00023259,
-      "phase": 74.04937699999999
+      "amplitude": 0,
+      "phase": 348.99
     },
     {
       "name": "S4",
-      "amplitude": 0.00119446,
-      "phase": 135.05634099999997
+      "amplitude": 0.001,
+      "phase": 108.71
     },
     {
       "name": "OO1",
-      "amplitude": 0.0016828199999999998,
-      "phase": 331.295649
+      "amplitude": 0.002,
+      "phase": 316.62
     },
     {
       "name": "S3",
-      "amplitude": 0.00034074,
-      "phase": 148.851716
+      "amplitude": 0,
+      "phase": 235.06
     },
     {
       "name": "MA2",
-      "amplitude": 0.07702863,
-      "phase": 282.19377299999996
+      "amplitude": 0.003,
+      "phase": 145.29
     },
     {
       "name": "MB2",
-      "amplitude": 0.07979542,
-      "phase": 144.88475600000004
+      "amplitude": 0,
+      "phase": 86.7
     },
     {
       "name": "T3",
-      "amplitude": 0.0011236899999999999,
-      "phase": 226.081212
+      "amplitude": 0.001,
+      "phase": 21.39
     },
     {
       "name": "R3",
-      "amplitude": 0.0008535,
-      "phase": 12.511488999999983
+      "amplitude": 0.001,
+      "phase": 70.5
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0036883,
-      "phase": 357.233753
+      "amplitude": 0.004,
+      "phase": 350.78
     },
     {
       "name": "SGM",
-      "amplitude": 0.00427982,
-      "phase": 132.64156200000002
+      "amplitude": 0.005,
+      "phase": 307.52
     },
     {
       "name": "3L2",
-      "amplitude": 0.00301263,
-      "phase": 82.44007199999999
+      "amplitude": 0.003,
+      "phase": 172.31
     },
     {
       "name": "3N2",
-      "amplitude": 0.00211443,
-      "phase": 36.35179800000003
+      "amplitude": 0.003,
+      "phase": 221.67
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00071935,
-      "phase": 226.097873
+      "amplitude": 0.001,
+      "phase": 204.36
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0035261,
-      "phase": 9.251891999999998
+      "amplitude": 0.005,
+      "phase": 314.43
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00033417,
-      "phase": 13.054024000000027
+      "amplitude": 0,
+      "phase": 41.54
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0006581099999999999,
-      "phase": 334.137093
+      "amplitude": 0.001,
+      "phase": 188.17
     }
   ],
   "epoch": {

--- a/data/ticon/oldenburgdrielake-4960030-deu-wsv.json
+++ b/data/ticon/oldenburgdrielake-4960030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.1261803899009772,
-      "phase": 70.64919570075506
+      "amplitude": 1.126,
+      "phase": 70.65
     },
     {
       "name": "N2",
-      "amplitude": 0.16692838691551706,
-      "phase": 47.119832044112684
+      "amplitude": 0.167,
+      "phase": 47.12
     },
     {
       "name": "S2",
-      "amplitude": 0.25769577689100626,
-      "phase": 153.3384623456045
+      "amplitude": 0.258,
+      "phase": 153.34
     },
     {
       "name": "K2",
-      "amplitude": 0.07686089994603985,
-      "phase": 151.9079714202665
+      "amplitude": 0.077,
+      "phase": 151.91
     },
     {
       "name": "2N2",
-      "amplitude": 0.015725709682727143,
-      "phase": 28.488970015467316
+      "amplitude": 0.016,
+      "phase": 28.49
     },
     {
       "name": "S1",
-      "amplitude": 0.013532388012405548,
-      "phase": 67.20343083952116
+      "amplitude": 0.014,
+      "phase": 67.2
     },
     {
       "name": "K1",
-      "amplitude": 0.05817353106421566,
-      "phase": 99.40181494532669
+      "amplitude": 0.058,
+      "phase": 99.4
     },
     {
       "name": "P1",
-      "amplitude": 0.019231569498588227,
-      "phase": 98.53451843771222
+      "amplitude": 0.019,
+      "phase": 98.53
     },
     {
       "name": "O1",
-      "amplitude": 0.07141490438211925,
-      "phase": 306.71679629541035
+      "amplitude": 0.071,
+      "phase": 306.72
     },
     {
       "name": "Q1",
-      "amplitude": 0.018218814608593724,
-      "phase": 244.48171855422646
+      "amplitude": 0.018,
+      "phase": 244.48
     },
     {
       "name": "M1",
-      "amplitude": 0.0017493516106050202,
-      "phase": 169.521369344969
+      "amplitude": 0.002,
+      "phase": 169.52
     },
     {
       "name": "M4",
-      "amplitude": 0.13641497966758728,
-      "phase": 70.95897427738396
+      "amplitude": 0.136,
+      "phase": 70.96
     },
     {
       "name": "MM",
-      "amplitude": 0.018585021517973557,
-      "phase": 53.46484379706135
+      "amplitude": 0.019,
+      "phase": 53.46
     },
     {
       "name": "MF",
-      "amplitude": 0.02219358674310917,
-      "phase": 82.02873239087842
+      "amplitude": 0.022,
+      "phase": 82.03
     },
     {
       "name": "SA",
-      "amplitude": 0.14738696896748293,
-      "phase": 300.7091088448901
+      "amplitude": 0.147,
+      "phase": 300.71
     },
     {
       "name": "SSA",
-      "amplitude": 0.062492298042809175,
-      "phase": 240.6964024250326
+      "amplitude": 0.062,
+      "phase": 240.7
     },
     {
       "name": "T2",
-      "amplitude": 0.011207068688610534,
-      "phase": 112.46539479405448
+      "amplitude": 0.011,
+      "phase": 112.47
     },
     {
       "name": "J1",
-      "amplitude": 0.0046368027352678715,
-      "phase": 229.8685757624037
+      "amplitude": 0.005,
+      "phase": 229.87
     },
     {
       "name": "L2",
-      "amplitude": 0.10887191731067727,
-      "phase": 84.27367521382882
+      "amplitude": 0.109,
+      "phase": 84.27
     },
     {
       "name": "R2",
-      "amplitude": 0.00889619856937333,
-      "phase": 222.01156234016744
+      "amplitude": 0.009,
+      "phase": 222.01
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0027631589733387845,
-      "phase": 188.1428792015946
+      "amplitude": 0.003,
+      "phase": 188.14
     },
     {
       "name": "MSF",
-      "amplitude": 0.10119402949942836,
-      "phase": 67.33594844479967
+      "amplitude": 0.101,
+      "phase": 67.34
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007463214713488394,
-      "phase": 351.0752455162389
+      "amplitude": 0.007,
+      "phase": 351.08
     },
     {
       "name": "EP2",
-      "amplitude": 0.034993755507562126,
-      "phase": 129.38931751525968
+      "amplitude": 0.035,
+      "phase": 129.39
     },
     {
       "name": "M3",
-      "amplitude": 0.003508354204167115,
-      "phase": 150.59476983347423
+      "amplitude": 0.004,
+      "phase": 150.59
     },
     {
       "name": "MU2",
-      "amplitude": 0.17276128801252522,
-      "phase": 154.53223855695273
+      "amplitude": 0.173,
+      "phase": 154.53
     },
     {
       "name": "MTM",
-      "amplitude": 0.0031247151943219723,
-      "phase": 130.76778051406149
+      "amplitude": 0.003,
+      "phase": 130.77
     },
     {
       "name": "NU2",
-      "amplitude": 0.08144341175329967,
-      "phase": 19.839212240705535
+      "amplitude": 0.081,
+      "phase": 19.84
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.049422455504880884,
-      "phase": 86.40266720780471
+      "amplitude": 0.049,
+      "phase": 86.4
     },
     {
       "name": "MN4",
-      "amplitude": 0.044106001734159093,
-      "phase": 45.6225367311589
+      "amplitude": 0.044,
+      "phase": 45.62
     },
     {
       "name": "MS4",
-      "amplitude": 0.07049762061644682,
-      "phase": 148.93718999228975
+      "amplitude": 0.07,
+      "phase": 148.94
     },
     {
       "name": "N4",
-      "amplitude": 0.008536273371077497,
-      "phase": 26.670637352651283
+      "amplitude": 0.009,
+      "phase": 26.67
     },
     {
       "name": "M6",
-      "amplitude": 0.026202040711293388,
-      "phase": 209.3758466986626
+      "amplitude": 0.026,
+      "phase": 209.38
     },
     {
       "name": "M8",
-      "amplitude": 0.015941954099633858,
-      "phase": 219.95335437930368
+      "amplitude": 0.016,
+      "phase": 219.95
     },
     {
       "name": "S4",
-      "amplitude": 0.005690678650750576,
-      "phase": 312.12763450160696
+      "amplitude": 0.006,
+      "phase": 312.13
     },
     {
       "name": "OO1",
-      "amplitude": 0.0022546691629615396,
-      "phase": 269.4180404058852
+      "amplitude": 0.002,
+      "phase": 269.42
     },
     {
       "name": "S3",
-      "amplitude": 0.0023702535740347213,
-      "phase": 58.676307919256544
+      "amplitude": 0.002,
+      "phase": 58.68
     },
     {
       "name": "MA2",
-      "amplitude": 0.04171490990267604,
-      "phase": 5.106829927993658
+      "amplitude": 0.042,
+      "phase": 5.11
     },
     {
       "name": "MB2",
-      "amplitude": 0.04369393576581201,
-      "phase": 216.986226242756
+      "amplitude": 0.044,
+      "phase": 216.99
     },
     {
       "name": "T3",
-      "amplitude": 0.0013433790171998813,
-      "phase": 132.85928850648713
+      "amplitude": 0.001,
+      "phase": 132.86
     },
     {
       "name": "R3",
-      "amplitude": 0.004826862630396589,
-      "phase": 147.68016450505365
+      "amplitude": 0.005,
+      "phase": 147.68
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0046395744639472734,
-      "phase": 250.29218509462794
+      "amplitude": 0.005,
+      "phase": 250.29
     },
     {
       "name": "SGM",
-      "amplitude": 0.006391827291987393,
-      "phase": 75.34273269526932
+      "amplitude": 0.006,
+      "phase": 75.34
     },
     {
       "name": "3L2",
-      "amplitude": 0.0029937910490377773,
-      "phase": 347.35917493617734
+      "amplitude": 0.003,
+      "phase": 347.36
     },
     {
       "name": "3N2",
-      "amplitude": 0.021785131841321734,
-      "phase": 212.92266597339594
+      "amplitude": 0.022,
+      "phase": 212.92
     },
     {
       "name": "2SM2",
-      "amplitude": 0.030465869715843533,
-      "phase": 17.1104764586064
+      "amplitude": 0.03,
+      "phase": 17.11
     },
     {
       "name": "2MS6",
-      "amplitude": 0.024579631745935943,
-      "phase": 284.5186334855485
+      "amplitude": 0.025,
+      "phase": 284.52
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00074541493967381,
-      "phase": 126.58229391687763
+      "amplitude": 0.001,
+      "phase": 126.58
     },
     {
       "name": "2MO5",
-      "amplitude": 0.002552382418794664,
-      "phase": 310.18898437575876
+      "amplitude": 0.003,
+      "phase": 310.19
     }
   ],
   "epoch": {

--- a/data/ticon/oosterschelde_11-oostsde11-nld-rws.json
+++ b/data/ticon/oosterschelde_11-oostsde11-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.27680722,
-      "phase": 44.39092900000003
+      "amplitude": 1.32,
+      "phase": 27.45
     },
     {
       "name": "N2",
-      "amplitude": 0.20879213,
-      "phase": 18.600614000000007
+      "amplitude": 0.216,
+      "phase": 1.78
     },
     {
       "name": "S2",
-      "amplitude": 0.34710171,
-      "phase": 99.91200000000003
+      "amplitude": 0.357,
+      "phase": 82.44
     },
     {
       "name": "K2",
-      "amplitude": 0.09514317,
-      "phase": 106.71348599999999
+      "amplitude": 0.105,
+      "phase": 82.51
     },
     {
       "name": "2N2",
-      "amplitude": 0.02589481,
-      "phase": 352.360249
+      "amplitude": 0.027,
+      "phase": 336.27
     },
     {
       "name": "S1",
-      "amplitude": 0.00680821,
-      "phase": 13.528916999999979
+      "amplitude": 0.007,
+      "phase": 295.43
     },
     {
       "name": "K1",
-      "amplitude": 0.07003973000000001,
-      "phase": 355.807527
+      "amplitude": 0.071,
+      "phase": 346.9
     },
     {
       "name": "P1",
-      "amplitude": 0.031436359999999997,
-      "phase": 336.721375
+      "amplitude": 0.032,
+      "phase": 330.32
     },
     {
       "name": "O1",
-      "amplitude": 0.10471355,
-      "phase": 182.035481
+      "amplitude": 0.105,
+      "phase": 173.35
     },
     {
       "name": "Q1",
-      "amplitude": 0.0331523,
-      "phase": 125.71744000000001
+      "amplitude": 0.033,
+      "phase": 117.06
     },
     {
       "name": "M1",
-      "amplitude": 0.00270559,
-      "phase": 11.054085999999984
+      "amplitude": 0.003,
+      "phase": 4.44
     },
     {
       "name": "M4",
-      "amplitude": 0.11438190000000001,
-      "phase": 95.168519
+      "amplitude": 0.132,
+      "phase": 58.17
     },
     {
       "name": "MM",
-      "amplitude": 0.00370315,
-      "phase": 187.549375
+      "amplitude": 0.004,
+      "phase": 186.26
     },
     {
       "name": "MF",
-      "amplitude": 0.00254087,
-      "phase": 144.59053900000004
+      "amplitude": 0.003,
+      "phase": 142.82
     },
     {
       "name": "SA",
-      "amplitude": 0.07724793,
-      "phase": 210.01363
+      "amplitude": 0.077,
+      "phase": 209.9
     },
     {
       "name": "SSA",
-      "amplitude": 0.0142242,
-      "phase": 166.28657399999997
+      "amplitude": 0.014,
+      "phase": 164.73
     },
     {
       "name": "T2",
-      "amplitude": 0.061004949999999995,
-      "phase": 16.83585099999999
+      "amplitude": 0.02,
+      "phase": 73.96
     },
     {
       "name": "J1",
-      "amplitude": 0.00308223,
-      "phase": 110.177371
+      "amplitude": 0.003,
+      "phase": 99.6
     },
     {
       "name": "L2",
-      "amplitude": 0.08976820999999999,
-      "phase": 66.50107400000002
+      "amplitude": 0.093,
+      "phase": 47.64
     },
     {
       "name": "R2",
-      "amplitude": 0.046206050000000005,
-      "phase": 201.727636
+      "amplitude": 0.003,
+      "phase": 106.53
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004395,
-      "phase": 69.767179
+      "amplitude": 0.005,
+      "phase": 64.03
     },
     {
       "name": "MSF",
-      "amplitude": 0.01425738,
-      "phase": 41.73398500000002
+      "amplitude": 0.014,
+      "phase": 41.36
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0044755,
-      "phase": 60.244192
+      "amplitude": 0.004,
+      "phase": 59.58
     },
     {
       "name": "EP2",
-      "amplitude": 0.021066099999999997,
-      "phase": 141.14349300000003
+      "amplitude": 0.021,
+      "phase": 126.02
     },
     {
       "name": "M3",
-      "amplitude": 0.00435357,
-      "phase": 134.777714
+      "amplitude": 0.005,
+      "phase": 287.53
     },
     {
       "name": "MU2",
-      "amplitude": 0.09006366,
-      "phase": 160.915974
+      "amplitude": 0.094,
+      "phase": 143.47
     },
     {
       "name": "MTM",
-      "amplitude": 0.00235368,
-      "phase": 206.70009
+      "amplitude": 0.002,
+      "phase": 213.57
     },
     {
       "name": "NU2",
-      "amplitude": 0.07055883,
-      "phase": 13.041789999999992
+      "amplitude": 0.072,
+      "phase": 357.71
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04116492,
-      "phase": 65.06921499999999
+      "amplitude": 0.042,
+      "phase": 45.07
     },
     {
       "name": "MN4",
-      "amplitude": 0.040205149999999995,
-      "phase": 72.56086199999999
+      "amplitude": 0.046,
+      "phase": 36.41
     },
     {
       "name": "MS4",
-      "amplitude": 0.07829472,
-      "phase": 150.78486799999996
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.05464186,
-      "phase": 180.90723
+      "amplitude": 0.09,
+      "phase": 115.13
     },
     {
       "name": "N4",
-      "amplitude": 0.00860949,
-      "phase": 50.03790300000003
+      "amplitude": 0.01,
+      "phase": 13.61
     },
     {
       "name": "M6",
-      "amplitude": 0.060644460000000004,
-      "phase": 50.33749899999998
+      "amplitude": 0.082,
+      "phase": 353.95
     },
     {
       "name": "M8",
-      "amplitude": 0.01087101,
-      "phase": 76.929709
+      "amplitude": 0.02,
+      "phase": 356.24
     },
     {
       "name": "S4",
-      "amplitude": 0.00760714,
-      "phase": 243.850212
+      "amplitude": 0.008,
+      "phase": 207.11
     },
     {
       "name": "OO1",
-      "amplitude": 0.0036178399999999998,
-      "phase": 149.293408
+      "amplitude": 0.004,
+      "phase": 129.11
     },
     {
       "name": "S3",
-      "amplitude": 0.00226595,
-      "phase": 37.27789899999999
+      "amplitude": 0,
+      "phase": 6.34
     },
     {
       "name": "MA2",
-      "amplitude": 0.22131793,
-      "phase": 20.719559000000004
+      "amplitude": 0.02,
+      "phase": 346.72
     },
     {
       "name": "MB2",
-      "amplitude": 0.20354284,
-      "phase": 237.499082
+      "amplitude": 0.014,
+      "phase": 135.83
     },
     {
       "name": "T3",
-      "amplitude": 0.00099196,
-      "phase": 8.155651999999975
+      "amplitude": 0.001,
+      "phase": 200.16
     },
     {
       "name": "R3",
-      "amplitude": 0.0075836,
-      "phase": 241.756307
+      "amplitude": 0.008,
+      "phase": 300.78
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00812902,
-      "phase": 123.41761400000001
+      "amplitude": 0.008,
+      "phase": 117.33
     },
     {
       "name": "SGM",
-      "amplitude": 0.00319052,
-      "phase": 100.87995799999999
+      "amplitude": 0.003,
+      "phase": 275.73
     },
     {
       "name": "3L2",
-      "amplitude": 0.00314234,
-      "phase": 307.053763
+      "amplitude": 0.002,
+      "phase": 24.36
     },
     {
       "name": "3N2",
-      "amplitude": 0.0006407100000000001,
-      "phase": 13.659501999999975
+      "amplitude": 0.01,
+      "phase": 204.38
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02997848,
-      "phase": 334.677635
+      "amplitude": 0.03,
+      "phase": 317.12
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05929467,
-      "phase": 100.89443699999998
+      "amplitude": 0.08,
+      "phase": 44.6
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00283825,
-      "phase": 166.745627
+      "amplitude": 0.004,
+      "phase": 211.48
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00447845,
-      "phase": 208.234896
+      "amplitude": 0.006,
+      "phase": 72.32
     }
   ],
   "epoch": {

--- a/data/ticon/oosterschelde_13-oostsde13-nld-rws.json
+++ b/data/ticon/oosterschelde_13-oostsde13-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.1125852,
-      "phase": 45.50422600000002
+      "amplitude": 1.153,
+      "phase": 30.74
     },
     {
       "name": "N2",
-      "amplitude": 0.18215631,
-      "phase": 18.576390000000004
+      "amplitude": 0.185,
+      "phase": 5.34
     },
     {
       "name": "S2",
-      "amplitude": 0.2961946,
-      "phase": 100.174014
+      "amplitude": 0.307,
+      "phase": 85.94
     },
     {
       "name": "K2",
-      "amplitude": 0.08632957,
-      "phase": 100.38978400000002
+      "amplitude": 0.092,
+      "phase": 85.75
     },
     {
       "name": "2N2",
-      "amplitude": 0.02309092,
-      "phase": 349.017501
+      "amplitude": 0.022,
+      "phase": 331.41
     },
     {
       "name": "S1",
-      "amplitude": 0.006638509999999999,
-      "phase": 23.689485999999988
+      "amplitude": 0.008,
+      "phase": 309.74
     },
     {
       "name": "K1",
-      "amplitude": 0.07380675,
-      "phase": 353.059125
+      "amplitude": 0.075,
+      "phase": 346.72
     },
     {
       "name": "P1",
-      "amplitude": 0.03218947,
-      "phase": 336.996057
+      "amplitude": 0.034,
+      "phase": 328.44
     },
     {
       "name": "O1",
-      "amplitude": 0.10940166,
-      "phase": 178.77564200000006
+      "amplitude": 0.111,
+      "phase": 171.13
     },
     {
       "name": "Q1",
-      "amplitude": 0.03830026,
-      "phase": 127.79976499999998
+      "amplitude": 0.037,
+      "phase": 123.66
     },
     {
       "name": "M1",
-      "amplitude": 0.00806676,
-      "phase": 45.42703399999999
+      "amplitude": 0,
+      "phase": 275.55
     },
     {
       "name": "M4",
-      "amplitude": 0.12901481,
-      "phase": 90.74619200000001
+      "amplitude": 0.149,
+      "phase": 63
     },
     {
       "name": "MM",
-      "amplitude": 0.017838609999999998,
-      "phase": 186.02339
+      "amplitude": 0.018,
+      "phase": 177.43
     },
     {
       "name": "MF",
-      "amplitude": 0.008184519999999999,
-      "phase": 182.771256
+      "amplitude": 0.008,
+      "phase": 189.96
     },
     {
       "name": "SA",
-      "amplitude": 0.07904714,
-      "phase": 208.470608
+      "amplitude": 0.079,
+      "phase": 210.15
     },
     {
       "name": "SSA",
-      "amplitude": 0.01581092,
-      "phase": 143.794806
+      "amplitude": 0.017,
+      "phase": 136.76
     },
     {
       "name": "T2",
-      "amplitude": 0.0637132,
-      "phase": 30.58934899999997
+      "amplitude": 0.017,
+      "phase": 66.48
     },
     {
       "name": "J1",
-      "amplitude": 0.004576279999999999,
-      "phase": 94.21227399999998
+      "amplitude": 0.004,
+      "phase": 67.41
     },
     {
       "name": "L2",
-      "amplitude": 0.07940806,
-      "phase": 67.422571
+      "amplitude": 0.081,
+      "phase": 54
     },
     {
       "name": "R2",
-      "amplitude": 0.03245447,
-      "phase": 186.210438
+      "amplitude": 0.002,
+      "phase": 220.02
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00662628,
-      "phase": 95.450334
+      "amplitude": 0.005,
+      "phase": 70.43
     },
     {
       "name": "MSF",
-      "amplitude": 0.03069073,
-      "phase": 23.028286999999978
+      "amplitude": 0.034,
+      "phase": 22.13
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0025199,
-      "phase": 203.308444
+      "amplitude": 0.003,
+      "phase": 163.73
     },
     {
       "name": "EP2",
-      "amplitude": 0.01955055,
-      "phase": 144.01786900000002
+      "amplitude": 0.019,
+      "phase": 136.34
     },
     {
       "name": "M3",
-      "amplitude": 0.00243478,
-      "phase": 123.864866
+      "amplitude": 0,
+      "phase": 253.3
     },
     {
       "name": "MU2",
-      "amplitude": 0.08541588000000001,
-      "phase": 163.87259300000005
+      "amplitude": 0.091,
+      "phase": 150.99
     },
     {
       "name": "MTM",
-      "amplitude": 0.0011209,
-      "phase": 85.31568400000003
+      "amplitude": 0.003,
+      "phase": 160.75
     },
     {
       "name": "NU2",
-      "amplitude": 0.06178949,
-      "phase": 17.53609799999998
+      "amplitude": 0.064,
+      "phase": 2.15
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03513276,
-      "phase": 59.75843199999997
+      "amplitude": 0.04,
+      "phase": 52.2
     },
     {
       "name": "MN4",
-      "amplitude": 0.045373580000000004,
-      "phase": 68.122746
+      "amplitude": 0.052,
+      "phase": 38.17
     },
     {
       "name": "MS4",
-      "amplitude": 0.08611734,
-      "phase": 147.085077
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.01227403,
-      "phase": 234.821441
+      "amplitude": 0.102,
+      "phase": 117.12
     },
     {
       "name": "N4",
-      "amplitude": 0.00858605,
-      "phase": 50.844641000000024
+      "amplitude": 0.013,
+      "phase": 18.95
     },
     {
       "name": "M6",
-      "amplitude": 0.04910338,
-      "phase": 52.99735199999998
+      "amplitude": 0.077,
+      "phase": 5.43
     },
     {
       "name": "M8",
-      "amplitude": 0.00947924,
-      "phase": 77.96956899999998
+      "amplitude": 0.017,
+      "phase": 16.37
     },
     {
       "name": "S4",
-      "amplitude": 0.00848261,
-      "phase": 238.62813699999998
+      "amplitude": 0.012,
+      "phase": 212.85
     },
     {
       "name": "OO1",
-      "amplitude": 0.00532428,
-      "phase": 149.222507
+      "amplitude": 0.005,
+      "phase": 131.76
     },
     {
       "name": "S3",
-      "amplitude": 0.00279283,
-      "phase": 45.42709000000002
+      "amplitude": 0.002,
+      "phase": 207.92
     },
     {
       "name": "MA2",
-      "amplitude": 0.19985409,
-      "phase": 37.842624
+      "amplitude": 0.016,
+      "phase": 352.89
     },
     {
       "name": "MB2",
-      "amplitude": 0.18315952,
-      "phase": 226.678475
+      "amplitude": 0.015,
+      "phase": 123.75
     },
     {
       "name": "T3",
-      "amplitude": 0.00081104,
-      "phase": 37.69262800000001
+      "amplitude": 0.003,
+      "phase": 250.06
     },
     {
       "name": "R3",
-      "amplitude": 0.00753282,
-      "phase": 237.078143
+      "amplitude": 0.007,
+      "phase": 312.66
     },
     {
       "name": "RHO1",
-      "amplitude": 0.011000989999999999,
-      "phase": 123.61136299999998
+      "amplitude": 0.009,
+      "phase": 129.9
     },
     {
       "name": "SGM",
-      "amplitude": 0.00560493,
-      "phase": 76.85679600000003
+      "amplitude": 0.006,
+      "phase": 270.21
     },
     {
       "name": "3L2",
-      "amplitude": 0.00105247,
-      "phase": 217.251231
+      "amplitude": 0.002,
+      "phase": 105.35
     },
     {
       "name": "3N2",
-      "amplitude": 0.00203786,
-      "phase": 357.247095
+      "amplitude": 0.011,
+      "phase": 225.12
     },
     {
       "name": "2SM2",
-      "amplitude": 0.029274619999999998,
-      "phase": 335.865679
+      "amplitude": 0.031,
+      "phase": 326.44
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04736982,
-      "phase": 100.14479299999999
+      "amplitude": 0.07,
+      "phase": 55.65
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0050177799999999995,
-      "phase": 210.956003
+      "amplitude": 0.004,
+      "phase": 274.26
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00699278,
-      "phase": 226.8136
+      "amplitude": 0.009,
+      "phase": 112.11
     }
   ],
   "epoch": {

--- a/data/ticon/oosterschelde_14-oostsde14-nld-rws.json
+++ b/data/ticon/oosterschelde_14-oostsde14-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.18357196,
-      "phase": 52.48513000000003
+      "amplitude": 1.225,
+      "phase": 36.08
     },
     {
       "name": "N2",
-      "amplitude": 0.18651092,
-      "phase": 24.48017900000002
+      "amplitude": 0.195,
+      "phase": 8.57
     },
     {
       "name": "S2",
-      "amplitude": 0.31839651,
-      "phase": 108.60294199999998
+      "amplitude": 0.327,
+      "phase": 91.86
     },
     {
       "name": "K2",
-      "amplitude": 0.09365332999999999,
-      "phase": 112.60896500000001
+      "amplitude": 0.098,
+      "phase": 92.3
     },
     {
       "name": "2N2",
-      "amplitude": 0.030741900000000003,
-      "phase": 18.301033000000018
+      "amplitude": 0.036,
+      "phase": 4.65
     },
     {
       "name": "S1",
-      "amplitude": 0.00711906,
-      "phase": 4.231155999999999
+      "amplitude": 0.01,
+      "phase": 293.95
     },
     {
       "name": "K1",
-      "amplitude": 0.07174719,
-      "phase": 356.785795
+      "amplitude": 0.072,
+      "phase": 348.15
     },
     {
       "name": "P1",
-      "amplitude": 0.032794340000000005,
-      "phase": 340.131973
+      "amplitude": 0.033,
+      "phase": 333.07
     },
     {
       "name": "O1",
-      "amplitude": 0.10744717,
-      "phase": 183.422948
+      "amplitude": 0.108,
+      "phase": 175.28
     },
     {
       "name": "Q1",
-      "amplitude": 0.03999558,
-      "phase": 130.36636199999998
+      "amplitude": 0.04,
+      "phase": 122.4
     },
     {
       "name": "M1",
-      "amplitude": 0.00266722,
-      "phase": 52.82456100000002
+      "amplitude": 0.002,
+      "phase": 349.44
     },
     {
       "name": "M4",
-      "amplitude": 0.11955693,
-      "phase": 90.09140500000001
+      "amplitude": 0.139,
+      "phase": 59.74
     },
     {
       "name": "MM",
-      "amplitude": 0.00587998,
-      "phase": 100.864486
+      "amplitude": 0.007,
+      "phase": 93.21
     },
     {
       "name": "MF",
-      "amplitude": 0.00769424,
-      "phase": 132.21308799999997
+      "amplitude": 0.008,
+      "phase": 133.01
     },
     {
       "name": "SA",
-      "amplitude": 0.09794847000000001,
-      "phase": 224.697729
+      "amplitude": 0.103,
+      "phase": 225.43
     },
     {
       "name": "SSA",
-      "amplitude": 0.01648948,
-      "phase": 186.794556
+      "amplitude": 0.017,
+      "phase": 171.97
     },
     {
       "name": "T2",
-      "amplitude": 0.06239873,
-      "phase": 29.258234000000016
+      "amplitude": 0.018,
+      "phase": 74.46
     },
     {
       "name": "J1",
-      "amplitude": 0.00447099,
-      "phase": 105.76325500000002
+      "amplitude": 0.005,
+      "phase": 95.55
     },
     {
       "name": "L2",
-      "amplitude": 0.08061209,
-      "phase": 79.169602
+      "amplitude": 0.086,
+      "phase": 62.76
     },
     {
       "name": "R2",
-      "amplitude": 0.03681772,
-      "phase": 206.096266
+      "amplitude": 0.002,
+      "phase": 115.25
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006878189999999999,
-      "phase": 73.49399199999999
+      "amplitude": 0.007,
+      "phase": 70.02
     },
     {
       "name": "MSF",
-      "amplitude": 0.026900729999999998,
-      "phase": 28.87116400000002
+      "amplitude": 0.028,
+      "phase": 28.09
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0028886899999999997,
-      "phase": 231.627418
+      "amplitude": 0.003,
+      "phase": 232.35
     },
     {
       "name": "EP2",
-      "amplitude": 0.01878533,
-      "phase": 144.46754999999996
+      "amplitude": 0.018,
+      "phase": 124.24
     },
     {
       "name": "M3",
-      "amplitude": 0.00500554,
-      "phase": 119.99117000000001
+      "amplitude": 0.005,
+      "phase": 274.89
     },
     {
       "name": "MU2",
-      "amplitude": 0.09726877,
-      "phase": 171.35301600000003
+      "amplitude": 0.099,
+      "phase": 154.7
     },
     {
       "name": "MTM",
-      "amplitude": 0.00438463,
-      "phase": 192.373126
+      "amplitude": 0.005,
+      "phase": 184.33
     },
     {
       "name": "NU2",
-      "amplitude": 0.06800491,
-      "phase": 24.302557999999976
+      "amplitude": 0.069,
+      "phase": 5.25
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0410764,
-      "phase": 74.92056400000001
+      "amplitude": 0.043,
+      "phase": 56.51
     },
     {
       "name": "MN4",
-      "amplitude": 0.04072613,
-      "phase": 64.65236700000003
+      "amplitude": 0.048,
+      "phase": 35.85
     },
     {
       "name": "MS4",
-      "amplitude": 0.08127207,
-      "phase": 148.63894400000004
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.038252100000000004,
-      "phase": 188.579375
+      "amplitude": 0.095,
+      "phase": 116.89
     },
     {
       "name": "N4",
-      "amplitude": 0.010901540000000001,
-      "phase": 54.614756
+      "amplitude": 0.015,
+      "phase": 19.27
     },
     {
       "name": "M6",
-      "amplitude": 0.04865869,
-      "phase": 58.899653
+      "amplitude": 0.074,
+      "phase": 7.99
     },
     {
       "name": "M8",
-      "amplitude": 0.01081458,
-      "phase": 90.69808699999999
+      "amplitude": 0.023,
+      "phase": 27.54
     },
     {
       "name": "S4",
-      "amplitude": 0.00786404,
-      "phase": 243.450962
+      "amplitude": 0.009,
+      "phase": 209.53
     },
     {
       "name": "OO1",
-      "amplitude": 0.00406286,
-      "phase": 139.94833700000004
+      "amplitude": 0.003,
+      "phase": 120.42
     },
     {
       "name": "S3",
-      "amplitude": 0.00338163,
-      "phase": 52.34481699999998
+      "amplitude": 0.001,
+      "phase": 219
     },
     {
       "name": "MA2",
-      "amplitude": 0.21009618,
-      "phase": 34.66470099999998
+      "amplitude": 0.021,
+      "phase": 9.29
     },
     {
       "name": "MB2",
-      "amplitude": 0.19599618,
-      "phase": 239.93175300000001
+      "amplitude": 0.018,
+      "phase": 152.61
     },
     {
       "name": "T3",
-      "amplitude": 0.0009644300000000001,
-      "phase": 3.0747840000000224
+      "amplitude": 0.001,
+      "phase": 203.82
     },
     {
       "name": "R3",
-      "amplitude": 0.0086529,
-      "phase": 248.341458
+      "amplitude": 0.009,
+      "phase": 307.95
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00852447,
-      "phase": 126.31985900000001
+      "amplitude": 0.008,
+      "phase": 124.08
     },
     {
       "name": "SGM",
-      "amplitude": 0.00112749,
-      "phase": 50.34227800000002
+      "amplitude": 0.002,
+      "phase": 225.98
     },
     {
       "name": "3L2",
-      "amplitude": 0.007283410000000001,
-      "phase": 211.96657
+      "amplitude": 0.008,
+      "phase": 325.52
     },
     {
       "name": "3N2",
-      "amplitude": 0.0034093,
-      "phase": 97.80154299999998
+      "amplitude": 0.008,
+      "phase": 197.51
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03036498,
-      "phase": 341.087978
+      "amplitude": 0.031,
+      "phase": 324.86
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05010441,
-      "phase": 109.33098100000001
+      "amplitude": 0.074,
+      "phase": 57.89
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0049616,
-      "phase": 208.398342
+      "amplitude": 0.006,
+      "phase": 250.73
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00677227,
-      "phase": 224.302064
+      "amplitude": 0.008,
+      "phase": 93.98
     }
   ],
   "epoch": {

--- a/data/ticon/oosterschelde_15-oostsde15-nld-rws.json
+++ b/data/ticon/oosterschelde_15-oostsde15-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.35197828,
-      "phase": 41.31830200000002
+      "amplitude": 1.405,
+      "phase": 26.52
     },
     {
       "name": "N2",
-      "amplitude": 0.2222519,
-      "phase": 15.41324800000001
+      "amplitude": 0.229,
+      "phase": 1.37
     },
     {
       "name": "S2",
-      "amplitude": 0.37207054,
-      "phase": 96.23647800000003
+      "amplitude": 0.388,
+      "phase": 81.94
     },
     {
       "name": "K2",
-      "amplitude": 0.11034617000000001,
-      "phase": 96.70054099999999
+      "amplitude": 0.117,
+      "phase": 79.55
     },
     {
       "name": "2N2",
-      "amplitude": 0.02847198,
-      "phase": 353.005789
+      "amplitude": 0.027,
+      "phase": 346.61
     },
     {
       "name": "S1",
-      "amplitude": 0.00513353,
-      "phase": 11.37291399999998
+      "amplitude": 0.007,
+      "phase": 310.28
     },
     {
       "name": "K1",
-      "amplitude": 0.06770730999999999,
-      "phase": 357.014871
+      "amplitude": 0.068,
+      "phase": 350.8
     },
     {
       "name": "P1",
-      "amplitude": 0.03219306,
-      "phase": 339.195443
+      "amplitude": 0.036,
+      "phase": 335.44
     },
     {
       "name": "O1",
-      "amplitude": 0.10511115,
-      "phase": 179.00240199999996
+      "amplitude": 0.109,
+      "phase": 168.81
     },
     {
       "name": "Q1",
-      "amplitude": 0.035057529999999996,
-      "phase": 126.52111000000002
+      "amplitude": 0.032,
+      "phase": 129.88
     },
     {
       "name": "M1",
-      "amplitude": 0.007902329999999999,
-      "phase": 58.13162799999998
+      "amplitude": 0.002,
+      "phase": 217.03
     },
     {
       "name": "M4",
-      "amplitude": 0.1016396,
-      "phase": 80.96167000000003
+      "amplitude": 0.119,
+      "phase": 52.49
     },
     {
       "name": "MM",
-      "amplitude": 0.012038740000000001,
-      "phase": 184.932575
+      "amplitude": 0.009,
+      "phase": 147.86
     },
     {
       "name": "MF",
-      "amplitude": 0.0086869,
-      "phase": 194.554877
+      "amplitude": 0.009,
+      "phase": 193.77
     },
     {
       "name": "SA",
-      "amplitude": 0.07487244,
-      "phase": 210.550138
+      "amplitude": 0.073,
+      "phase": 216.15
     },
     {
       "name": "SSA",
-      "amplitude": 0.01433066,
-      "phase": 133.33887600000003
+      "amplitude": 0.021,
+      "phase": 122.01
     },
     {
       "name": "T2",
-      "amplitude": 0.07783823,
-      "phase": 25.301611999999977
+      "amplitude": 0.016,
+      "phase": 63.83
     },
     {
       "name": "J1",
-      "amplitude": 0.0033359,
-      "phase": 84.20255400000002
+      "amplitude": 0.006,
+      "phase": 7.84
     },
     {
       "name": "L2",
-      "amplitude": 0.08994824,
-      "phase": 63.46619700000002
+      "amplitude": 0.099,
+      "phase": 50.62
     },
     {
       "name": "R2",
-      "amplitude": 0.04256464,
-      "phase": 183.027078
+      "amplitude": 0.007,
+      "phase": 161.69
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00647981,
-      "phase": 101.38305000000003
+      "amplitude": 0.007,
+      "phase": 58.28
     },
     {
       "name": "MSF",
-      "amplitude": 0.02840449,
-      "phase": 16.51551599999999
+      "amplitude": 0.03,
+      "phase": 18.19
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00461955,
-      "phase": 148.099402
+      "amplitude": 0.012,
+      "phase": 121.79
     },
     {
       "name": "EP2",
-      "amplitude": 0.02260219,
-      "phase": 134.02748099999997
+      "amplitude": 0.019,
+      "phase": 140.48
     },
     {
       "name": "M3",
-      "amplitude": 0.0041131,
-      "phase": 125.33961899999997
+      "amplitude": 0.006,
+      "phase": 18.28
     },
     {
       "name": "MU2",
-      "amplitude": 0.09780395,
-      "phase": 155.33638599999995
+      "amplitude": 0.107,
+      "phase": 140.32
     },
     {
       "name": "MTM",
-      "amplitude": 0.0049028100000000005,
-      "phase": 122.22814900000003
+      "amplitude": 0.006,
+      "phase": 174.43
     },
     {
       "name": "NU2",
-      "amplitude": 0.07372012,
-      "phase": 12.351565999999991
+      "amplitude": 0.078,
+      "phase": 355.59
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04563206,
-      "phase": 58.273729
+      "amplitude": 0.053,
+      "phase": 48.24
     },
     {
       "name": "MN4",
-      "amplitude": 0.034680970000000005,
-      "phase": 58.988135
+      "amplitude": 0.035,
+      "phase": 33.15
     },
     {
       "name": "MS4",
-      "amplitude": 0.0715291,
-      "phase": 140.04212
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.01162908,
-      "phase": 202.029263
+      "amplitude": 0.081,
+      "phase": 106.41
     },
     {
       "name": "N4",
-      "amplitude": 0.00714526,
-      "phase": 42.392255999999975
+      "amplitude": 0.015,
+      "phase": 352.03
     },
     {
       "name": "M6",
-      "amplitude": 0.05855362,
-      "phase": 41.288175000000024
+      "amplitude": 0.088,
+      "phase": 350.02
     },
     {
       "name": "M8",
-      "amplitude": 0.01104059,
-      "phase": 49.09120300000001
+      "amplitude": 0.019,
+      "phase": 352.44
     },
     {
       "name": "S4",
-      "amplitude": 0.0075279,
-      "phase": 236.99909
+      "amplitude": 0.01,
+      "phase": 211.89
     },
     {
       "name": "OO1",
-      "amplitude": 0.005613,
-      "phase": 139.51038
+      "amplitude": 0.009,
+      "phase": 116.77
     },
     {
       "name": "S3",
-      "amplitude": 0.0028691499999999996,
-      "phase": 46.403317000000015
+      "amplitude": 0.007,
+      "phase": 191.89
     },
     {
       "name": "MA2",
-      "amplitude": 0.24359255999999999,
-      "phase": 31.280012
+      "amplitude": 0.027,
+      "phase": 325.69
     },
     {
       "name": "MB2",
-      "amplitude": 0.22560877999999998,
-      "phase": 222.772403
+      "amplitude": 0.019,
+      "phase": 136.06
     },
     {
       "name": "T3",
-      "amplitude": 0.0011057200000000001,
-      "phase": 49.868930999999975
+      "amplitude": 0.008,
+      "phase": 231.18
     },
     {
       "name": "R3",
-      "amplitude": 0.00860233,
-      "phase": 239.294611
+      "amplitude": 0.009,
+      "phase": 342.85
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00960714,
-      "phase": 130.650302
+      "amplitude": 0.008,
+      "phase": 166.37
     },
     {
       "name": "SGM",
-      "amplitude": 0.00388521,
-      "phase": 77.96808499999997
+      "amplitude": 0.004,
+      "phase": 286.67
     },
     {
       "name": "3L2",
-      "amplitude": 0.00137469,
-      "phase": 36.89375899999999
+      "amplitude": 0.008,
+      "phase": 68.35
     },
     {
       "name": "3N2",
-      "amplitude": 0.00193788,
-      "phase": 25.337204999999983
+      "amplitude": 0.011,
+      "phase": 215.52
     },
     {
       "name": "2SM2",
-      "amplitude": 0.032673890000000004,
-      "phase": 328.415146
+      "amplitude": 0.036,
+      "phase": 325.77
     },
     {
       "name": "2MS6",
-      "amplitude": 0.057958119999999995,
-      "phase": 88.944998
+      "amplitude": 0.084,
+      "phase": 43.59
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0031478,
-      "phase": 149.588461
+      "amplitude": 0.003,
+      "phase": 327.7
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00467948,
-      "phase": 192.740273
+      "amplitude": 0.005,
+      "phase": 83.1
     }
   ],
   "epoch": {

--- a/data/ticon/oslebshausen-4910060-deu-wsv.json
+++ b/data/ticon/oslebshausen-4910060-deu-wsv.json
@@ -1,6 +1,6 @@
 {
   "name": "Oslebshausen",
-  "region": "City state Bremen",
+  "region": "Bremen",
   "country": "Germany",
   "continent": "Europe",
   "latitude": 53.121302,
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.7707794221982693,
-      "phase": 38.43084758772994
+      "amplitude": 1.771,
+      "phase": 38.43
     },
     {
       "name": "N2",
-      "amplitude": 0.2696381394024103,
-      "phase": 14.492781348794665
+      "amplitude": 0.27,
+      "phase": 14.49
     },
     {
       "name": "S2",
-      "amplitude": 0.44543347424100793,
-      "phase": 119.75082569133752
+      "amplitude": 0.445,
+      "phase": 119.75
     },
     {
       "name": "K2",
-      "amplitude": 0.13068860217591582,
-      "phase": 118.12990850283768
+      "amplitude": 0.131,
+      "phase": 118.13
     },
     {
       "name": "2N2",
-      "amplitude": 0.02786623903205163,
-      "phase": 353.8789151325424
+      "amplitude": 0.028,
+      "phase": 353.88
     },
     {
       "name": "S1",
-      "amplitude": 0.015784223613913823,
-      "phase": 89.25900989360821
+      "amplitude": 0.016,
+      "phase": 89.26
     },
     {
       "name": "K1",
-      "amplitude": 0.06795788527480787,
-      "phase": 74.49328879629888
+      "amplitude": 0.068,
+      "phase": 74.49
     },
     {
       "name": "P1",
-      "amplitude": 0.029023250466287228,
-      "phase": 81.40075368182329
+      "amplitude": 0.029,
+      "phase": 81.4
     },
     {
       "name": "O1",
-      "amplitude": 0.08705049530006367,
-      "phase": 280.47004802798443
+      "amplitude": 0.087,
+      "phase": 280.47
     },
     {
       "name": "Q1",
-      "amplitude": 0.02345563423809972,
-      "phase": 219.0950402463804
+      "amplitude": 0.023,
+      "phase": 219.1
     },
     {
       "name": "M1",
-      "amplitude": 0.002554644936272219,
-      "phase": 136.32465306231842
+      "amplitude": 0.003,
+      "phase": 136.32
     },
     {
       "name": "M4",
-      "amplitude": 0.17130394989954728,
-      "phase": 341.13854625888894
+      "amplitude": 0.171,
+      "phase": 341.14
     },
     {
       "name": "MM",
-      "amplitude": 0.010303939946646324,
-      "phase": 104.67408247854019
+      "amplitude": 0.01,
+      "phase": 104.67
     },
     {
       "name": "MF",
-      "amplitude": 0.012248278917545381,
-      "phase": 96.5611057790191
+      "amplitude": 0.012,
+      "phase": 96.56
     },
     {
       "name": "SA",
-      "amplitude": 0.070436882229423,
-      "phase": 282.80416378474206
+      "amplitude": 0.07,
+      "phase": 282.8
     },
     {
       "name": "SSA",
-      "amplitude": 0.05553240522972619,
-      "phase": 237.01355661587212
+      "amplitude": 0.056,
+      "phase": 237.01
     },
     {
       "name": "T2",
-      "amplitude": 0.02633114864658237,
-      "phase": 79.85289400190783
+      "amplitude": 0.026,
+      "phase": 79.85
     },
     {
       "name": "J1",
-      "amplitude": 0.003833735837103143,
-      "phase": 199.37053514670848
+      "amplitude": 0.004,
+      "phase": 199.37
     },
     {
       "name": "L2",
-      "amplitude": 0.16066674668646933,
-      "phase": 51.834301163319196
+      "amplitude": 0.161,
+      "phase": 51.83
     },
     {
       "name": "R2",
-      "amplitude": 0.009246391619618372,
-      "phase": 245.52790663753402
+      "amplitude": 0.009,
+      "phase": 245.53
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004879314659729977,
-      "phase": 160.50033808809485
+      "amplitude": 0.005,
+      "phase": 160.5
     },
     {
       "name": "MSF",
-      "amplitude": 0.05197048198308102,
-      "phase": 64.90197281971132
+      "amplitude": 0.052,
+      "phase": 64.9
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00767793604145986,
-      "phase": 37.183764575568546
+      "amplitude": 0.008,
+      "phase": 37.18
     },
     {
       "name": "EP2",
-      "amplitude": 0.04957898141283038,
-      "phase": 93.86828940845135
+      "amplitude": 0.05,
+      "phase": 93.87
     },
     {
       "name": "M3",
-      "amplitude": 0.004819812948054821,
-      "phase": 114.5489758372915
+      "amplitude": 0.005,
+      "phase": 114.55
     },
     {
       "name": "MU2",
-      "amplitude": 0.24458065358256934,
-      "phase": 117.5239168199912
+      "amplitude": 0.245,
+      "phase": 117.52
     },
     {
       "name": "MTM",
-      "amplitude": 0.001906667344707079,
-      "phase": 228.00369086418627
+      "amplitude": 0.002,
+      "phase": 228
     },
     {
       "name": "NU2",
-      "amplitude": 0.11565039626282443,
-      "phase": 348.43280324441935
+      "amplitude": 0.116,
+      "phase": 348.43
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07571907091057364,
-      "phase": 52.29459411885591
+      "amplitude": 0.076,
+      "phase": 52.29
     },
     {
       "name": "MN4",
-      "amplitude": 0.05584711621196878,
-      "phase": 317.60146977480593
+      "amplitude": 0.056,
+      "phase": 317.6
     },
     {
       "name": "MS4",
-      "amplitude": 0.10941962969999519,
-      "phase": 59.02925393401796
+      "amplitude": 0.109,
+      "phase": 59.03
     },
     {
       "name": "N4",
-      "amplitude": 0.011309155229448527,
-      "phase": 294.00408147139376
+      "amplitude": 0.011,
+      "phase": 294
     },
     {
       "name": "M6",
-      "amplitude": 0.08313227039441648,
-      "phase": 176.83006519692765
+      "amplitude": 0.083,
+      "phase": 176.83
     },
     {
       "name": "M8",
-      "amplitude": 0.02619353400785974,
-      "phase": 143.65165079391602
+      "amplitude": 0.026,
+      "phase": 143.65
     },
     {
       "name": "S4",
-      "amplitude": 0.013836512571576937,
-      "phase": 204.40967649657173
+      "amplitude": 0.014,
+      "phase": 204.41
     },
     {
       "name": "OO1",
-      "amplitude": 0.0024326895321071917,
-      "phase": 232.54556684373284
+      "amplitude": 0.002,
+      "phase": 232.55
     },
     {
       "name": "S3",
-      "amplitude": 0.0012170663382719692,
-      "phase": 6.237407803500673
+      "amplitude": 0.001,
+      "phase": 6.24
     },
     {
       "name": "MA2",
-      "amplitude": 0.09081607804905101,
-      "phase": 4.226124729338494
+      "amplitude": 0.091,
+      "phase": 4.23
     },
     {
       "name": "MB2",
-      "amplitude": 0.034002484069555576,
-      "phase": 248.55831314680472
+      "amplitude": 0.034,
+      "phase": 248.56
     },
     {
       "name": "T3",
-      "amplitude": 0.0017389143027183905,
-      "phase": 85.97608423547854
+      "amplitude": 0.002,
+      "phase": 85.98
     },
     {
       "name": "R3",
-      "amplitude": 0.005751226424031196,
-      "phase": 120.93760142093487
+      "amplitude": 0.006,
+      "phase": 120.94
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005392506974457136,
-      "phase": 229.0038341700287
+      "amplitude": 0.005,
+      "phase": 229
     },
     {
       "name": "SGM",
-      "amplitude": 0.006172288097624615,
-      "phase": 51.69877544688836
+      "amplitude": 0.006,
+      "phase": 51.7
     },
     {
       "name": "3L2",
-      "amplitude": 0.004291831959877827,
-      "phase": 328.6633390033744
+      "amplitude": 0.004,
+      "phase": 328.66
     },
     {
       "name": "3N2",
-      "amplitude": 0.028351168563528355,
-      "phase": 195.1578893999409
+      "amplitude": 0.028,
+      "phase": 195.16
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04880845426293113,
-      "phase": 341.1511604420081
+      "amplitude": 0.049,
+      "phase": 341.15
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08326458976098973,
-      "phase": 254.2060315249048
+      "amplitude": 0.083,
+      "phase": 254.21
     },
     {
       "name": "2MK5",
-      "amplitude": 0.009337607224092997,
-      "phase": 177.76717287922656
+      "amplitude": 0.009,
+      "phase": 177.77
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006751990228501654,
-      "phase": 357.66094375275406
+      "amplitude": 0.007,
+      "phase": 357.66
     }
   ],
   "epoch": {

--- a/data/ticon/osteriffmpm-5970096-deu-wsv.json
+++ b/data/ticon/osteriffmpm-5970096-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2342906586773634,
-      "phase": 5.156692768007588
+      "amplitude": 1.234,
+      "phase": 5.16
     },
     {
       "name": "N2",
-      "amplitude": 0.1933089960238178,
-      "phase": 338.87605654046916
+      "amplitude": 0.193,
+      "phase": 338.88
     },
     {
       "name": "S2",
-      "amplitude": 0.3044226488099099,
-      "phase": 74.92572113380788
+      "amplitude": 0.304,
+      "phase": 74.93
     },
     {
       "name": "K2",
-      "amplitude": 0.09073206390555574,
-      "phase": 73.14590504110623
+      "amplitude": 0.091,
+      "phase": 73.15
     },
     {
       "name": "2N2",
-      "amplitude": 0.019522082825434422,
-      "phase": 325.27901040516815
+      "amplitude": 0.02,
+      "phase": 325.28
     },
     {
       "name": "S1",
-      "amplitude": 0.012940660027426602,
-      "phase": 57.980803121844474
+      "amplitude": 0.013,
+      "phase": 57.98
     },
     {
       "name": "K1",
-      "amplitude": 0.07118667615201789,
-      "phase": 59.4214387593521
+      "amplitude": 0.071,
+      "phase": 59.42
     },
     {
       "name": "P1",
-      "amplitude": 0.029792545418585958,
-      "phase": 58.673271623791436
+      "amplitude": 0.03,
+      "phase": 58.67
     },
     {
       "name": "O1",
-      "amplitude": 0.09025044404467612,
-      "phase": 266.0715700496682
+      "amplitude": 0.09,
+      "phase": 266.07
     },
     {
       "name": "Q1",
-      "amplitude": 0.02859773853331618,
-      "phase": 207.92087277547816
+      "amplitude": 0.029,
+      "phase": 207.92
     },
     {
       "name": "M1",
-      "amplitude": 0.0026817648433005168,
-      "phase": 128.44436028592452
+      "amplitude": 0.003,
+      "phase": 128.44
     },
     {
       "name": "M4",
-      "amplitude": 0.12041199290014101,
-      "phase": 247.46901418956952
+      "amplitude": 0.12,
+      "phase": 247.47
     },
     {
       "name": "MM",
-      "amplitude": 0.015189050702222694,
-      "phase": 144.79035182549546
+      "amplitude": 0.015,
+      "phase": 144.79
     },
     {
       "name": "MF",
-      "amplitude": 0.01899112085895667,
-      "phase": 114.39015550727345
+      "amplitude": 0.019,
+      "phase": 114.39
     },
     {
       "name": "SA",
-      "amplitude": 0.0934627004821612,
-      "phase": 237.93008847524928
+      "amplitude": 0.093,
+      "phase": 237.93
     },
     {
       "name": "SSA",
-      "amplitude": 0.05901195857637377,
-      "phase": 204.14954493838138
+      "amplitude": 0.059,
+      "phase": 204.15
     },
     {
       "name": "T2",
-      "amplitude": 0.016729419652355408,
-      "phase": 61.13299826345673
+      "amplitude": 0.017,
+      "phase": 61.13
     },
     {
       "name": "J1",
-      "amplitude": 0.005378621367972037,
-      "phase": 176.03612035585638
+      "amplitude": 0.005,
+      "phase": 176.04
     },
     {
       "name": "L2",
-      "amplitude": 0.1065762966901068,
-      "phase": 25.279906457244408
+      "amplitude": 0.107,
+      "phase": 25.28
     },
     {
       "name": "R2",
-      "amplitude": 0.0040817515426138104,
-      "phase": 42.62868952794753
+      "amplitude": 0.004,
+      "phase": 42.63
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006410373572642765,
-      "phase": 135.84662238142198
+      "amplitude": 0.006,
+      "phase": 135.85
     },
     {
       "name": "MSF",
-      "amplitude": 0.04223062933233201,
-      "phase": 72.59157846546668
+      "amplitude": 0.042,
+      "phase": 72.59
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007763391325903967,
-      "phase": 198.624087553156
+      "amplitude": 0.008,
+      "phase": 198.62
     },
     {
       "name": "EP2",
-      "amplitude": 0.030502294518196128,
-      "phase": 71.85492968284808
+      "amplitude": 0.031,
+      "phase": 71.85
     },
     {
       "name": "M3",
-      "amplitude": 0.0029617706368049875,
-      "phase": 24.083985444031555
+      "amplitude": 0.003,
+      "phase": 24.08
     },
     {
       "name": "MU2",
-      "amplitude": 0.13605257060617798,
-      "phase": 97.28367435848111
+      "amplitude": 0.136,
+      "phase": 97.28
     },
     {
       "name": "MTM",
-      "amplitude": 0.0115455025337294,
-      "phase": 233.37687003091543
+      "amplitude": 0.012,
+      "phase": 233.38
     },
     {
       "name": "NU2",
-      "amplitude": 0.07523940607951386,
-      "phase": 325.80662874435086
+      "amplitude": 0.075,
+      "phase": 325.81
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0466416903255905,
-      "phase": 19.197213440941994
+      "amplitude": 0.047,
+      "phase": 19.2
     },
     {
       "name": "MN4",
-      "amplitude": 0.041412502024172126,
-      "phase": 224.59337295368783
+      "amplitude": 0.041,
+      "phase": 224.59
     },
     {
       "name": "MS4",
-      "amplitude": 0.07218330312285973,
-      "phase": 315.5489446105652
+      "amplitude": 0.072,
+      "phase": 315.55
     },
     {
       "name": "N4",
-      "amplitude": 0.008982391316230425,
-      "phase": 207.42713272377088
+      "amplitude": 0.009,
+      "phase": 207.43
     },
     {
       "name": "M6",
-      "amplitude": 0.07220495604529599,
-      "phase": 96.75490095620694
+      "amplitude": 0.072,
+      "phase": 96.75
     },
     {
       "name": "M8",
-      "amplitude": 0.023336556618037196,
-      "phase": 11.506493885637042
+      "amplitude": 0.023,
+      "phase": 11.51
     },
     {
       "name": "S4",
-      "amplitude": 0.007210404648479788,
-      "phase": 79.30010438291595
+      "amplitude": 0.007,
+      "phase": 79.3
     },
     {
       "name": "OO1",
-      "amplitude": 0.003230974414018316,
-      "phase": 189.41906674943715
+      "amplitude": 0.003,
+      "phase": 189.42
     },
     {
       "name": "S3",
-      "amplitude": 0.0006774640700938589,
-      "phase": 288.921241189747
+      "amplitude": 0.001,
+      "phase": 288.92
     },
     {
       "name": "MA2",
-      "amplitude": 0.02829482311737139,
-      "phase": 310.4509523799262
+      "amplitude": 0.028,
+      "phase": 310.45
     },
     {
       "name": "MB2",
-      "amplitude": 0.02667651135768291,
-      "phase": 64.92550402435427
+      "amplitude": 0.027,
+      "phase": 64.93
     },
     {
       "name": "T3",
-      "amplitude": 0.00031644778486238166,
-      "phase": 160.83578727747567
+      "amplitude": 0,
+      "phase": 160.84
     },
     {
       "name": "R3",
-      "amplitude": 0.003376417083093495,
-      "phase": 54.50101980851974
+      "amplitude": 0.003,
+      "phase": 54.5
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0056283110789995625,
-      "phase": 224.54987948721322
+      "amplitude": 0.006,
+      "phase": 224.55
     },
     {
       "name": "SGM",
-      "amplitude": 0.004230958150887833,
-      "phase": 95.74835831226721
+      "amplitude": 0.004,
+      "phase": 95.75
     },
     {
       "name": "3L2",
-      "amplitude": 0.008000839254961057,
-      "phase": 241.43026348423552
+      "amplitude": 0.008,
+      "phase": 241.43
     },
     {
       "name": "3N2",
-      "amplitude": 0.017225941045736166,
-      "phase": 179.35474174068338
+      "amplitude": 0.017,
+      "phase": 179.35
     },
     {
       "name": "2SM2",
-      "amplitude": 0.028615741274653654,
-      "phase": 300.86491637281586
+      "amplitude": 0.029,
+      "phase": 300.86
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0695180168566286,
-      "phase": 163.63727434920452
+      "amplitude": 0.07,
+      "phase": 163.64
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004972395655402797,
-      "phase": 101.16323679496372
+      "amplitude": 0.005,
+      "phase": 101.16
     },
     {
       "name": "2MO5",
-      "amplitude": 0.002527214201500102,
-      "phase": 353.96940807346226
+      "amplitude": 0.003,
+      "phase": 353.97
     }
   ],
   "epoch": {

--- a/data/ticon/otterndorfmpm-5990011-deu-wsv.json
+++ b/data/ticon/otterndorfmpm-5990011-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.252083081031192,
-      "phase": 353.68643991681074
+      "amplitude": 1.252,
+      "phase": 353.69
     },
     {
       "name": "N2",
-      "amplitude": 0.19707229773623106,
-      "phase": 327.45725881841236
+      "amplitude": 0.197,
+      "phase": 327.46
     },
     {
       "name": "S2",
-      "amplitude": 0.3165801435846445,
-      "phase": 63.20551059167792
+      "amplitude": 0.317,
+      "phase": 63.21
     },
     {
       "name": "K2",
-      "amplitude": 0.09398692332739235,
-      "phase": 61.66134970182691
+      "amplitude": 0.094,
+      "phase": 61.66
     },
     {
       "name": "2N2",
-      "amplitude": 0.020108466867615193,
-      "phase": 313.0018986492992
+      "amplitude": 0.02,
+      "phase": 313
     },
     {
       "name": "S1",
-      "amplitude": 0.013296128268911921,
-      "phase": 52.165261215129476
+      "amplitude": 0.013,
+      "phase": 52.17
     },
     {
       "name": "K1",
-      "amplitude": 0.07165487774237478,
-      "phase": 53.34878612175447
+      "amplitude": 0.072,
+      "phase": 53.35
     },
     {
       "name": "P1",
-      "amplitude": 0.029935543958785525,
-      "phase": 52.21358771190444
+      "amplitude": 0.03,
+      "phase": 52.21
     },
     {
       "name": "O1",
-      "amplitude": 0.09045879108843252,
-      "phase": 260.2838799186329
+      "amplitude": 0.09,
+      "phase": 260.28
     },
     {
       "name": "Q1",
-      "amplitude": 0.028793877455272187,
-      "phase": 202.59596806478717
+      "amplitude": 0.029,
+      "phase": 202.6
     },
     {
       "name": "M1",
-      "amplitude": 0.0024698657228857702,
-      "phase": 122.18375524536901
+      "amplitude": 0.002,
+      "phase": 122.18
     },
     {
       "name": "M4",
-      "amplitude": 0.11948366707247365,
-      "phase": 233.37035863594713
+      "amplitude": 0.119,
+      "phase": 233.37
     },
     {
       "name": "MM",
-      "amplitude": 0.020243808586597935,
-      "phase": 151.31557538632046
+      "amplitude": 0.02,
+      "phase": 151.32
     },
     {
       "name": "MF",
-      "amplitude": 0.017802214162945366,
-      "phase": 120.46582783449668
+      "amplitude": 0.018,
+      "phase": 120.47
     },
     {
       "name": "SA",
-      "amplitude": 0.10038048520399831,
-      "phase": 241.58929837417753
+      "amplitude": 0.1,
+      "phase": 241.59
     },
     {
       "name": "SSA",
-      "amplitude": 0.05178313213479352,
-      "phase": 205.82308064354018
+      "amplitude": 0.052,
+      "phase": 205.82
     },
     {
       "name": "T2",
-      "amplitude": 0.016274598550687497,
-      "phase": 48.930120251794904
+      "amplitude": 0.016,
+      "phase": 48.93
     },
     {
       "name": "J1",
-      "amplitude": 0.005388336182816883,
-      "phase": 169.72746941450714
+      "amplitude": 0.005,
+      "phase": 169.73
     },
     {
       "name": "L2",
-      "amplitude": 0.10532891087053886,
-      "phase": 12.869349977966351
+      "amplitude": 0.105,
+      "phase": 12.87
     },
     {
       "name": "R2",
-      "amplitude": 0.003515651429713907,
-      "phase": 21.147182271484155
+      "amplitude": 0.004,
+      "phase": 21.15
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006701094376679928,
-      "phase": 131.73859917412165
+      "amplitude": 0.007,
+      "phase": 131.74
     },
     {
       "name": "MSF",
-      "amplitude": 0.03866302291005644,
-      "phase": 67.79104597066737
+      "amplitude": 0.039,
+      "phase": 67.79
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009178336151311856,
-      "phase": 208.6462892279899
+      "amplitude": 0.009,
+      "phase": 208.65
     },
     {
       "name": "EP2",
-      "amplitude": 0.030239903766728027,
-      "phase": 60.872538384034954
+      "amplitude": 0.03,
+      "phase": 60.87
     },
     {
       "name": "M3",
-      "amplitude": 0.003054079912929984,
-      "phase": 12.341286249047016
+      "amplitude": 0.003,
+      "phase": 12.34
     },
     {
       "name": "MU2",
-      "amplitude": 0.13357325924527627,
-      "phase": 85.13904388670483
+      "amplitude": 0.134,
+      "phase": 85.14
     },
     {
       "name": "MTM",
-      "amplitude": 0.005630958947504441,
-      "phase": 230.8065656328752
+      "amplitude": 0.006,
+      "phase": 230.81
     },
     {
       "name": "NU2",
-      "amplitude": 0.07530674450791465,
-      "phase": 314.0636603085299
+      "amplitude": 0.075,
+      "phase": 314.06
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.047192453696575154,
-      "phase": 7.261740847248348
+      "amplitude": 0.047,
+      "phase": 7.26
     },
     {
       "name": "MN4",
-      "amplitude": 0.041333139016248736,
-      "phase": 210.76516144942272
+      "amplitude": 0.041,
+      "phase": 210.77
     },
     {
       "name": "MS4",
-      "amplitude": 0.07262013346622745,
-      "phase": 300.0037961628234
+      "amplitude": 0.073,
+      "phase": 300
     },
     {
       "name": "N4",
-      "amplitude": 0.009026024981442183,
-      "phase": 192.4242052067346
+      "amplitude": 0.009,
+      "phase": 192.42
     },
     {
       "name": "M6",
-      "amplitude": 0.0723028616931385,
-      "phase": 74.81424202091625
+      "amplitude": 0.072,
+      "phase": 74.81
     },
     {
       "name": "M8",
-      "amplitude": 0.017440683976917008,
-      "phase": 352.5808915143533
+      "amplitude": 0.017,
+      "phase": 352.58
     },
     {
       "name": "S4",
-      "amplitude": 0.007553247547945371,
-      "phase": 58.26437060056253
+      "amplitude": 0.008,
+      "phase": 58.26
     },
     {
       "name": "OO1",
-      "amplitude": 0.0036920527310851316,
-      "phase": 182.87798648489454
+      "amplitude": 0.004,
+      "phase": 182.88
     },
     {
       "name": "S3",
-      "amplitude": 0.0008098397134365554,
-      "phase": 266.3743576125504
+      "amplitude": 0.001,
+      "phase": 266.37
     },
     {
       "name": "MA2",
-      "amplitude": 0.03400741407664721,
-      "phase": 296.1690403580471
+      "amplitude": 0.034,
+      "phase": 296.17
     },
     {
       "name": "MB2",
-      "amplitude": 0.027171849880874517,
-      "phase": 53.538410915350426
+      "amplitude": 0.027,
+      "phase": 53.54
     },
     {
       "name": "T3",
-      "amplitude": 0.0002357635472427647,
-      "phase": 263.6491639888556
+      "amplitude": 0,
+      "phase": 263.65
     },
     {
       "name": "R3",
-      "amplitude": 0.003758635922661885,
-      "phase": 36.89106216554859
+      "amplitude": 0.004,
+      "phase": 36.89
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006197405253438102,
-      "phase": 212.96456799585422
+      "amplitude": 0.006,
+      "phase": 212.96
     },
     {
       "name": "SGM",
-      "amplitude": 0.0037261953898649106,
-      "phase": 93.94401758087349
+      "amplitude": 0.004,
+      "phase": 93.94
     },
     {
       "name": "3L2",
-      "amplitude": 0.007374554471365516,
-      "phase": 235.26353468474392
+      "amplitude": 0.007,
+      "phase": 235.26
     },
     {
       "name": "3N2",
-      "amplitude": 0.015398437651685162,
-      "phase": 166.67201713422696
+      "amplitude": 0.015,
+      "phase": 166.67
     },
     {
       "name": "2SM2",
-      "amplitude": 0.029777717817415863,
-      "phase": 287.4267488257939
+      "amplitude": 0.03,
+      "phase": 287.43
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06997299291483237,
-      "phase": 140.96089352646527
+      "amplitude": 0.07,
+      "phase": 140.96
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0047039567500440325,
-      "phase": 85.28385208603288
+      "amplitude": 0.005,
+      "phase": 85.28
     },
     {
       "name": "2MO5",
-      "amplitude": 0.002863407804324121,
-      "phase": 339.4337400500747
+      "amplitude": 0.003,
+      "phase": 339.43
     }
   ],
   "epoch": {

--- a/data/ticon/oudeschild-oudsd-nld-rws.json
+++ b/data/ticon/oudeschild-oudsd-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.5984199,
-      "phase": 198.212358
+      "amplitude": 0.618,
+      "phase": 186.24
     },
     {
       "name": "N2",
-      "amplitude": 0.08990228,
-      "phase": 181.251878
+      "amplitude": 0.094,
+      "phase": 170.3
     },
     {
       "name": "S2",
-      "amplitude": 0.16386284,
-      "phase": 267.16348800000003
+      "amplitude": 0.168,
+      "phase": 254.97
     },
     {
       "name": "K2",
-      "amplitude": 0.046910749999999994,
-      "phase": 266.910325
+      "amplitude": 0.05,
+      "phase": 251.45
     },
     {
       "name": "2N2",
-      "amplitude": 0.01094331,
-      "phase": 144.674711
+      "amplitude": 0.012,
+      "phase": 137.22
     },
     {
       "name": "S1",
-      "amplitude": 0.00709801,
-      "phase": 357.977905
+      "amplitude": 0.01,
+      "phase": 313.7
     },
     {
       "name": "K1",
-      "amplitude": 0.07278470000000001,
-      "phase": 9.487741000000028
+      "amplitude": 0.073,
+      "phase": 3.23
     },
     {
       "name": "P1",
-      "amplitude": 0.03225236,
-      "phase": 0.188603999999998
+      "amplitude": 0.033,
+      "phase": 354.76
     },
     {
       "name": "O1",
-      "amplitude": 0.10123647999999999,
-      "phase": 205.546201
+      "amplitude": 0.101,
+      "phase": 200.06
     },
     {
       "name": "Q1",
-      "amplitude": 0.03422689,
-      "phase": 150.92764699999998
+      "amplitude": 0.034,
+      "phase": 145.12
     },
     {
       "name": "M1",
-      "amplitude": 0.00170955,
-      "phase": 242.953122
+      "amplitude": 0.002,
+      "phase": 22.18
     },
     {
       "name": "M4",
-      "amplitude": 0.07703763000000001,
-      "phase": 215.940668
+      "amplitude": 0.088,
+      "phase": 193.37
     },
     {
       "name": "MM",
-      "amplitude": 0.01339548,
-      "phase": 140.168473
+      "amplitude": 0.013,
+      "phase": 137.43
     },
     {
       "name": "MF",
-      "amplitude": 0.00631131,
-      "phase": 180.889357
+      "amplitude": 0.007,
+      "phase": 184.01
     },
     {
       "name": "SA",
-      "amplitude": 0.11526569,
-      "phase": 228.984571
+      "amplitude": 0.125,
+      "phase": 228.92
     },
     {
       "name": "SSA",
-      "amplitude": 0.03896124,
-      "phase": 175.909676
+      "amplitude": 0.041,
+      "phase": 167.47
     },
     {
       "name": "T2",
-      "amplitude": 0.026858979999999998,
-      "phase": 190.261823
+      "amplitude": 0.009,
+      "phase": 220.93
     },
     {
       "name": "J1",
-      "amplitude": 0.0038253199999999997,
-      "phase": 119.61140899999998
+      "amplitude": 0.004,
+      "phase": 113.2
     },
     {
       "name": "L2",
-      "amplitude": 0.05290925,
-      "phase": 203.197659
+      "amplitude": 0.055,
+      "phase": 191.76
     },
     {
       "name": "R2",
-      "amplitude": 0.01627341,
-      "phase": 23.14538299999998
+      "amplitude": 0.003,
+      "phase": 60.61
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00623665,
-      "phase": 82.43528300000003
+      "amplitude": 0.007,
+      "phase": 82.53
     },
     {
       "name": "MSF",
-      "amplitude": 0.03204919,
-      "phase": 42.40243700000002
+      "amplitude": 0.033,
+      "phase": 42.78
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00462446,
-      "phase": 7.781180000000006
+      "amplitude": 0.005,
+      "phase": 7.74
     },
     {
       "name": "EP2",
-      "amplitude": 0.015341229999999999,
-      "phase": 267.36927000000003
+      "amplitude": 0.016,
+      "phase": 255.54
     },
     {
       "name": "M3",
-      "amplitude": 0.0036516300000000003,
-      "phase": 349.375125
+      "amplitude": 0.004,
+      "phase": 152.91
     },
     {
       "name": "MU2",
-      "amplitude": 0.08348592,
-      "phase": 285.857617
+      "amplitude": 0.086,
+      "phase": 274.2
     },
     {
       "name": "MTM",
-      "amplitude": 0.00762676,
-      "phase": 238.723748
+      "amplitude": 0.007,
+      "phase": 224.81
     },
     {
       "name": "NU2",
-      "amplitude": 0.0365449,
-      "phase": 158.03668900000002
+      "amplitude": 0.039,
+      "phase": 144.21
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02545116,
-      "phase": 197.063977
+      "amplitude": 0.028,
+      "phase": 186.43
     },
     {
       "name": "MN4",
-      "amplitude": 0.026250719999999998,
-      "phase": 189.916716
+      "amplitude": 0.03,
+      "phase": 167.77
     },
     {
       "name": "MS4",
-      "amplitude": 0.04429143,
-      "phase": 274.714961
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.01818583,
-      "phase": 346.351063
+      "amplitude": 0.05,
+      "phase": 252.75
     },
     {
       "name": "N4",
-      "amplitude": 0.00629591,
-      "phase": 169.67616499999997
+      "amplitude": 0.008,
+      "phase": 147.14
     },
     {
       "name": "M6",
-      "amplitude": 0.027691379999999998,
-      "phase": 323.632367
+      "amplitude": 0.04,
+      "phase": 289.99
     },
     {
       "name": "M8",
-      "amplitude": 0.0076163,
-      "phase": 2.503586999999982
+      "amplitude": 0.015,
+      "phase": 322.72
     },
     {
       "name": "S4",
-      "amplitude": 0.00329889,
-      "phase": 10.22815300000002
+      "amplitude": 0.003,
+      "phase": 340.14
     },
     {
       "name": "OO1",
-      "amplitude": 0.0027988,
-      "phase": 153.36843299999998
+      "amplitude": 0.003,
+      "phase": 127.73
     },
     {
       "name": "S3",
-      "amplitude": 0.00062881,
-      "phase": 124.46364699999998
+      "amplitude": 0,
+      "phase": 319.12
     },
     {
       "name": "MA2",
-      "amplitude": 0.08974373999999999,
-      "phase": 178.12149799999997
+      "amplitude": 0.02,
+      "phase": 147.83
     },
     {
       "name": "MB2",
-      "amplitude": 0.0685189,
-      "phase": 38.057285999999976
+      "amplitude": 0.004,
+      "phase": 169.52
     },
     {
       "name": "T3",
-      "amplitude": 0.00079474,
-      "phase": 98.59887600000002
+      "amplitude": 0.001,
+      "phase": 264.86
     },
     {
       "name": "R3",
-      "amplitude": 0.0006690699999999999,
-      "phase": 230.590766
+      "amplitude": 0,
+      "phase": 315.5
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00671091,
-      "phase": 138.780849
+      "amplitude": 0.007,
+      "phase": 134.64
     },
     {
       "name": "SGM",
-      "amplitude": 0.00184407,
-      "phase": 256.731794
+      "amplitude": 0.001,
+      "phase": 90.6
     },
     {
       "name": "3L2",
-      "amplitude": 0.00542021,
-      "phase": 20.57687199999998
+      "amplitude": 0.006,
+      "phase": 128.21
     },
     {
       "name": "3N2",
-      "amplitude": 0.00416331,
-      "phase": 102.73368199999999
+      "amplitude": 0.007,
+      "phase": 359.77
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0194205,
-      "phase": 102.95504699999998
+      "amplitude": 0.02,
+      "phase": 92.79
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0276079,
-      "phase": 17.05800499999998
+      "amplitude": 0.039,
+      "phase": 343.01
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00686435,
-      "phase": 353.842968
+      "amplitude": 0.009,
+      "phase": 51.3
     },
     {
       "name": "2MO5",
-      "amplitude": 0.006794829999999999,
-      "phase": 8.888412000000017
+      "amplitude": 0.008,
+      "phase": 253.94
     }
   ],
   "epoch": {

--- a/data/ticon/over-5950010-deu-wsv.json
+++ b/data/ticon/over-5950010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.348316277245938,
-      "phase": 104.48919024489828
+      "amplitude": 1.348,
+      "phase": 104.49
     },
     {
       "name": "N2",
-      "amplitude": 0.1989979971166771,
-      "phase": 78.09779176014473
+      "amplitude": 0.199,
+      "phase": 78.1
     },
     {
       "name": "S2",
-      "amplitude": 0.30499650888409563,
-      "phase": 184.2736674181139
+      "amplitude": 0.305,
+      "phase": 184.27
     },
     {
       "name": "K2",
-      "amplitude": 0.08855045435411746,
-      "phase": 184.03978847189398
+      "amplitude": 0.089,
+      "phase": 184.04
     },
     {
       "name": "2N2",
-      "amplitude": 0.020903896931656833,
-      "phase": 55.59489197889371
+      "amplitude": 0.021,
+      "phase": 55.59
     },
     {
       "name": "S1",
-      "amplitude": 0.01929817741273756,
-      "phase": 109.2868531027072
+      "amplitude": 0.019,
+      "phase": 109.29
     },
     {
       "name": "K1",
-      "amplitude": 0.06709465161948916,
-      "phase": 117.69209552102689
+      "amplitude": 0.067,
+      "phase": 117.69
     },
     {
       "name": "P1",
-      "amplitude": 0.02773370403790505,
-      "phase": 108.5687868458109
+      "amplitude": 0.028,
+      "phase": 108.57
     },
     {
       "name": "O1",
-      "amplitude": 0.08279823298410859,
-      "phase": 320.220033424585
+      "amplitude": 0.083,
+      "phase": 320.22
     },
     {
       "name": "Q1",
-      "amplitude": 0.022923729579003356,
-      "phase": 258.1973553990437
+      "amplitude": 0.023,
+      "phase": 258.2
     },
     {
       "name": "M1",
-      "amplitude": 0.0021787304088160915,
-      "phase": 163.56183993462162
+      "amplitude": 0.002,
+      "phase": 163.56
     },
     {
       "name": "M4",
-      "amplitude": 0.16810596198199043,
-      "phase": 124.93474683592035
+      "amplitude": 0.168,
+      "phase": 124.93
     },
     {
       "name": "MM",
-      "amplitude": 0.0160013597077139,
-      "phase": 99.72889962939087
+      "amplitude": 0.016,
+      "phase": 99.73
     },
     {
       "name": "MF",
-      "amplitude": 0.020058576423620637,
-      "phase": 89.14564775491317
+      "amplitude": 0.02,
+      "phase": 89.15
     },
     {
       "name": "SA",
-      "amplitude": 0.150291843050173,
-      "phase": 315.67361102087654
+      "amplitude": 0.15,
+      "phase": 315.67
     },
     {
       "name": "SSA",
-      "amplitude": 0.05723411071484636,
-      "phase": 279.5186422144991
+      "amplitude": 0.057,
+      "phase": 279.52
     },
     {
       "name": "T2",
-      "amplitude": 0.009048138720240058,
-      "phase": 161.65566968797066
+      "amplitude": 0.009,
+      "phase": 161.66
     },
     {
       "name": "J1",
-      "amplitude": 0.006616601240070681,
-      "phase": 245.77544004787921
+      "amplitude": 0.007,
+      "phase": 245.78
     },
     {
       "name": "L2",
-      "amplitude": 0.12892270450488222,
-      "phase": 122.78514049765886
+      "amplitude": 0.129,
+      "phase": 122.79
     },
     {
       "name": "R2",
-      "amplitude": 0.011956967276974253,
-      "phase": 276.16698122947
+      "amplitude": 0.012,
+      "phase": 276.17
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005309174271909055,
-      "phase": 190.9028128867969
+      "amplitude": 0.005,
+      "phase": 190.9
     },
     {
       "name": "MSF",
-      "amplitude": 0.08623785241188664,
-      "phase": 66.7564210561211
+      "amplitude": 0.086,
+      "phase": 66.76
     },
     {
       "name": "MSQM",
-      "amplitude": 0.010543010433970459,
-      "phase": 29.889991151335153
+      "amplitude": 0.011,
+      "phase": 29.89
     },
     {
       "name": "EP2",
-      "amplitude": 0.0369098597826401,
-      "phase": 164.8562289894562
+      "amplitude": 0.037,
+      "phase": 164.86
     },
     {
       "name": "M3",
-      "amplitude": 0.003188081234856602,
-      "phase": 189.7936261266751
+      "amplitude": 0.003,
+      "phase": 189.79
     },
     {
       "name": "MU2",
-      "amplitude": 0.1936222381036134,
-      "phase": 192.06744877946014
+      "amplitude": 0.194,
+      "phase": 192.07
     },
     {
       "name": "MTM",
-      "amplitude": 0.0022430260383393464,
-      "phase": 211.83775106917756
+      "amplitude": 0.002,
+      "phase": 211.84
     },
     {
       "name": "NU2",
-      "amplitude": 0.09334898474562124,
-      "phase": 58.57626667820341
+      "amplitude": 0.093,
+      "phase": 58.58
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05820515372384642,
-      "phase": 123.0283527798914
+      "amplitude": 0.058,
+      "phase": 123.03
     },
     {
       "name": "MN4",
-      "amplitude": 0.054878065876281246,
-      "phase": 97.9785746812716
+      "amplitude": 0.055,
+      "phase": 97.98
     },
     {
       "name": "MS4",
-      "amplitude": 0.08828645874928558,
-      "phase": 202.06299687836784
+      "amplitude": 0.088,
+      "phase": 202.06
     },
     {
       "name": "N4",
-      "amplitude": 0.01086465300875881,
-      "phase": 75.2991485449258
+      "amplitude": 0.011,
+      "phase": 75.3
     },
     {
       "name": "M6",
-      "amplitude": 0.05961381943246663,
-      "phase": 29.293560035745998
+      "amplitude": 0.06,
+      "phase": 29.29
     },
     {
       "name": "M8",
-      "amplitude": 0.02835477047011135,
-      "phase": 34.763084329254866
+      "amplitude": 0.028,
+      "phase": 34.76
     },
     {
       "name": "S4",
-      "amplitude": 0.006684662010400885,
-      "phase": 349.599410947713
+      "amplitude": 0.007,
+      "phase": 349.6
     },
     {
       "name": "OO1",
-      "amplitude": 0.0030266602091817427,
-      "phase": 253.86382324735655
+      "amplitude": 0.003,
+      "phase": 253.86
     },
     {
       "name": "S3",
-      "amplitude": 0.0009532432783918537,
-      "phase": 83.9684762955734
+      "amplitude": 0.001,
+      "phase": 83.97
     },
     {
       "name": "MA2",
-      "amplitude": 0.05367495124467258,
-      "phase": 22.884540469094645
+      "amplitude": 0.054,
+      "phase": 22.88
     },
     {
       "name": "MB2",
-      "amplitude": 0.043325517035724036,
-      "phase": 273.50757651441563
+      "amplitude": 0.043,
+      "phase": 273.51
     },
     {
       "name": "T3",
-      "amplitude": 0.001873426154014873,
-      "phase": 186.21668961739633
+      "amplitude": 0.002,
+      "phase": 186.22
     },
     {
       "name": "R3",
-      "amplitude": 0.005577983890573228,
-      "phase": 209.41073331865408
+      "amplitude": 0.006,
+      "phase": 209.41
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005331921664395826,
-      "phase": 264.86293289598
+      "amplitude": 0.005,
+      "phase": 264.86
     },
     {
       "name": "SGM",
-      "amplitude": 0.0051205814683215585,
-      "phase": 94.09882213054675
+      "amplitude": 0.005,
+      "phase": 94.1
     },
     {
       "name": "3L2",
-      "amplitude": 0.002857686545090949,
-      "phase": 54.286971956706
+      "amplitude": 0.003,
+      "phase": 54.29
     },
     {
       "name": "3N2",
-      "amplitude": 0.033868539836100005,
-      "phase": 260.8433724498876
+      "amplitude": 0.034,
+      "phase": 260.84
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03361455411286011,
-      "phase": 54.593662834886686
+      "amplitude": 0.034,
+      "phase": 54.59
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05337823827107713,
-      "phase": 104.45506611790944
+      "amplitude": 0.053,
+      "phase": 104.46
     },
     {
       "name": "2MK5",
-      "amplitude": 0.004741283852458253,
-      "phase": 19.739072823265417
+      "amplitude": 0.005,
+      "phase": 19.74
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0031782162155934977,
-      "phase": 253.74137621179887
+      "amplitude": 0.003,
+      "phase": 253.74
     }
   ],
   "epoch": {

--- a/data/ticon/papenburg-3790010-deu-wsv.json
+++ b/data/ticon/papenburg-3790010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.5392547971051556,
-      "phase": 350.0476832087925
+      "amplitude": 1.539,
+      "phase": 350.05
     },
     {
       "name": "N2",
-      "amplitude": 0.2343607413897847,
-      "phase": 327.6594367131162
+      "amplitude": 0.234,
+      "phase": 327.66
     },
     {
       "name": "S2",
-      "amplitude": 0.37644590608097295,
-      "phase": 69.39295261462325
+      "amplitude": 0.376,
+      "phase": 69.39
     },
     {
       "name": "K2",
-      "amplitude": 0.11089135230821118,
-      "phase": 69.25506408139404
+      "amplitude": 0.111,
+      "phase": 69.26
     },
     {
       "name": "2N2",
-      "amplitude": 0.022268033203480576,
-      "phase": 312.9662800025899
+      "amplitude": 0.022,
+      "phase": 312.97
     },
     {
       "name": "S1",
-      "amplitude": 0.018286155362099914,
-      "phase": 81.86860902239977
+      "amplitude": 0.018,
+      "phase": 81.87
     },
     {
       "name": "K1",
-      "amplitude": 0.07552810353290117,
-      "phase": 57.91121373487425
+      "amplitude": 0.076,
+      "phase": 57.91
     },
     {
       "name": "P1",
-      "amplitude": 0.03404128045092844,
-      "phase": 54.490364863384684
+      "amplitude": 0.034,
+      "phase": 54.49
     },
     {
       "name": "O1",
-      "amplitude": 0.08861327591104984,
-      "phase": 261.52162292287437
+      "amplitude": 0.089,
+      "phase": 261.52
     },
     {
       "name": "Q1",
-      "amplitude": 0.024904123287269507,
-      "phase": 197.68623734967338
+      "amplitude": 0.025,
+      "phase": 197.69
     },
     {
       "name": "M1",
-      "amplitude": 0.002770421829797857,
-      "phase": 117.67264327565488
+      "amplitude": 0.003,
+      "phase": 117.67
     },
     {
       "name": "M4",
-      "amplitude": 0.227197351029752,
-      "phase": 230.49976708035464
+      "amplitude": 0.227,
+      "phase": 230.5
     },
     {
       "name": "MM",
-      "amplitude": 0.014008830211175183,
-      "phase": 72.24971166158207
+      "amplitude": 0.014,
+      "phase": 72.25
     },
     {
       "name": "MF",
-      "amplitude": 0.008603326700237529,
-      "phase": 55.178583496385784
+      "amplitude": 0.009,
+      "phase": 55.18
     },
     {
       "name": "SA",
-      "amplitude": 0.0991248227983149,
-      "phase": 270.2609216796476
+      "amplitude": 0.099,
+      "phase": 270.26
     },
     {
       "name": "SSA",
-      "amplitude": 0.054565290339742244,
-      "phase": 246.66528966720597
+      "amplitude": 0.055,
+      "phase": 246.67
     },
     {
       "name": "T2",
-      "amplitude": 0.018284343727571924,
-      "phase": 0.850848302530494
+      "amplitude": 0.018,
+      "phase": 0.85
     },
     {
       "name": "J1",
-      "amplitude": 0.005289212536040163,
-      "phase": 173.65370259237636
+      "amplitude": 0.005,
+      "phase": 173.65
     },
     {
       "name": "L2",
-      "amplitude": 0.1446601517794492,
-      "phase": 1.1665175556804002
+      "amplitude": 0.145,
+      "phase": 1.17
     },
     {
       "name": "R2",
-      "amplitude": 0.017138244443902516,
-      "phase": 194.7250414142633
+      "amplitude": 0.017,
+      "phase": 194.73
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004354535352705847,
-      "phase": 141.34547172359044
+      "amplitude": 0.004,
+      "phase": 141.35
     },
     {
       "name": "MSF",
-      "amplitude": 0.0518812365224598,
-      "phase": 43.28308569004366
+      "amplitude": 0.052,
+      "phase": 43.28
     },
     {
       "name": "MSQM",
-      "amplitude": 0.006286073736248773,
-      "phase": 48.531090267358195
+      "amplitude": 0.006,
+      "phase": 48.53
     },
     {
       "name": "EP2",
-      "amplitude": 0.043146604025399805,
-      "phase": 55.07011156494161
+      "amplitude": 0.043,
+      "phase": 55.07
     },
     {
       "name": "M3",
-      "amplitude": 0.005166078987971275,
-      "phase": 46.025336253534476
+      "amplitude": 0.005,
+      "phase": 46.03
     },
     {
       "name": "MU2",
-      "amplitude": 0.20670344781565642,
-      "phase": 71.99498948493613
+      "amplitude": 0.207,
+      "phase": 71.99
     },
     {
       "name": "MTM",
-      "amplitude": 0.005364230221056114,
-      "phase": 356.1991766430646
+      "amplitude": 0.005,
+      "phase": 356.2
     },
     {
       "name": "NU2",
-      "amplitude": 0.10124451696669341,
-      "phase": 300.8835104092243
+      "amplitude": 0.101,
+      "phase": 300.88
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06725933098907472,
-      "phase": 2.821080542563834
+      "amplitude": 0.067,
+      "phase": 2.82
     },
     {
       "name": "MN4",
-      "amplitude": 0.07094994043965352,
-      "phase": 206.11598359404067
+      "amplitude": 0.071,
+      "phase": 206.12
     },
     {
       "name": "MS4",
-      "amplitude": 0.13488382610509553,
-      "phase": 313.1748295660805
+      "amplitude": 0.135,
+      "phase": 313.17
     },
     {
       "name": "N4",
-      "amplitude": 0.013535567931668505,
-      "phase": 185.64504090836576
+      "amplitude": 0.014,
+      "phase": 185.65
     },
     {
       "name": "M6",
-      "amplitude": 0.10348920066092891,
-      "phase": 91.8725799963371
+      "amplitude": 0.103,
+      "phase": 91.87
     },
     {
       "name": "M8",
-      "amplitude": 0.03254475317705121,
-      "phase": 318.066968505716
+      "amplitude": 0.033,
+      "phase": 318.07
     },
     {
       "name": "S4",
-      "amplitude": 0.015026893906659204,
-      "phase": 112.97261425038346
+      "amplitude": 0.015,
+      "phase": 112.97
     },
     {
       "name": "OO1",
-      "amplitude": 0.003220185037070568,
-      "phase": 203.7970896151419
+      "amplitude": 0.003,
+      "phase": 203.8
     },
     {
       "name": "S3",
-      "amplitude": 0.00181797801229989,
-      "phase": 319.3812483583639
+      "amplitude": 0.002,
+      "phase": 319.38
     },
     {
       "name": "MA2",
-      "amplitude": 0.0992686389157784,
-      "phase": 292.3455040788018
+      "amplitude": 0.099,
+      "phase": 292.35
     },
     {
       "name": "MB2",
-      "amplitude": 0.06422129443933905,
-      "phase": 177.6193519427053
+      "amplitude": 0.064,
+      "phase": 177.62
     },
     {
       "name": "T3",
-      "amplitude": 0.0012144024461287243,
-      "phase": 24.18667570659545
+      "amplitude": 0.001,
+      "phase": 24.19
     },
     {
       "name": "R3",
-      "amplitude": 0.006427027102395889,
-      "phase": 43.25614802578298
+      "amplitude": 0.006,
+      "phase": 43.26
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005517315302064021,
-      "phase": 224.10296198959526
+      "amplitude": 0.006,
+      "phase": 224.1
     },
     {
       "name": "SGM",
-      "amplitude": 0.006439542961757818,
-      "phase": 40.52010253294617
+      "amplitude": 0.006,
+      "phase": 40.52
     },
     {
       "name": "3L2",
-      "amplitude": 0.0009317279305831802,
-      "phase": 251.76180022006514
+      "amplitude": 0.001,
+      "phase": 251.76
     },
     {
       "name": "3N2",
-      "amplitude": 0.03026556411086594,
-      "phase": 131.93656523511703
+      "amplitude": 0.03,
+      "phase": 131.94
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0411411501787935,
-      "phase": 288.35921689152286
+      "amplitude": 0.041,
+      "phase": 288.36
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0955225214334827,
-      "phase": 165.0617189964862
+      "amplitude": 0.096,
+      "phase": 165.06
     },
     {
       "name": "2MK5",
-      "amplitude": 0.015029894372322118,
-      "phase": 119.77057276379134
+      "amplitude": 0.015,
+      "phase": 119.77
     },
     {
       "name": "2MO5",
-      "amplitude": 0.010203547556555302,
-      "phase": 329.75472747888494
+      "amplitude": 0.01,
+      "phase": 329.75
     }
   ],
   "epoch": {

--- a/data/ticon/parksluis-parkss-nld-rws.json
+++ b/data/ticon/parksluis-parkss-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.72234657,
-      "phase": 88.92045200000001
+      "amplitude": 0.745,
+      "phase": 71.98
     },
     {
       "name": "N2",
-      "amplitude": 0.11581635,
-      "phase": 61.93374499999999
+      "amplitude": 0.112,
+      "phase": 45.84
     },
     {
       "name": "S2",
-      "amplitude": 0.17373492,
-      "phase": 148.728112
+      "amplitude": 0.178,
+      "phase": 131.36
     },
     {
       "name": "K2",
-      "amplitude": 0.05053712,
-      "phase": 155.40479500000004
+      "amplitude": 0.055,
+      "phase": 131.54
     },
     {
       "name": "2N2",
-      "amplitude": 0.00980278,
-      "phase": 44.72344700000002
+      "amplitude": 0.008,
+      "phase": 31.61
     },
     {
       "name": "S1",
-      "amplitude": 0.00617459,
-      "phase": 358.429609
+      "amplitude": 0.009,
+      "phase": 291.95
     },
     {
       "name": "K1",
-      "amplitude": 0.06690927,
-      "phase": 359.701686
+      "amplitude": 0.067,
+      "phase": 350.98
     },
     {
       "name": "P1",
-      "amplitude": 0.029446970000000003,
-      "phase": 349.987449
+      "amplitude": 0.029,
+      "phase": 343.4
     },
     {
       "name": "O1",
-      "amplitude": 0.09320095,
-      "phase": 190.96365
+      "amplitude": 0.093,
+      "phase": 182.49
     },
     {
       "name": "Q1",
-      "amplitude": 0.02946489,
-      "phase": 129.23713299999997
+      "amplitude": 0.03,
+      "phase": 120.81
     },
     {
       "name": "M1",
-      "amplitude": 0.00741544,
-      "phase": 68.93366100000003
+      "amplitude": 0.004,
+      "phase": 34.65
     },
     {
       "name": "M4",
-      "amplitude": 0.13659746,
-      "phase": 173.05572099999995
+      "amplitude": 0.158,
+      "phase": 135.83
     },
     {
       "name": "MM",
-      "amplitude": 0.01389539,
-      "phase": 291.79994
+      "amplitude": 0.014,
+      "phase": 289.59
     },
     {
       "name": "MF",
-      "amplitude": 0.00907956,
-      "phase": 241.74022300000001
+      "amplitude": 0.009,
+      "phase": 242.25
     },
     {
       "name": "SA",
-      "amplitude": 0.08191687,
-      "phase": 256.551568
+      "amplitude": 0.082,
+      "phase": 256.85
     },
     {
       "name": "SSA",
-      "amplitude": 0.022880940000000002,
-      "phase": 237.574036
+      "amplitude": 0.023,
+      "phase": 237.7
     },
     {
       "name": "T2",
-      "amplitude": 0.029654660000000003,
-      "phase": 74.02501000000001
+      "amplitude": 0.016,
+      "phase": 126.56
     },
     {
       "name": "J1",
-      "amplitude": 0.00195187,
-      "phase": 145.668989
+      "amplitude": 0.002,
+      "phase": 145.48
     },
     {
       "name": "L2",
-      "amplitude": 0.05134372,
-      "phase": 114.80435799999998
+      "amplitude": 0.053,
+      "phase": 95.99
     },
     {
       "name": "R2",
-      "amplitude": 0.020502189999999997,
-      "phase": 247.662609
+      "amplitude": 0.005,
+      "phase": 104.42
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00354902,
-      "phase": 64.18404399999997
+      "amplitude": 0.003,
+      "phase": 60.32
     },
     {
       "name": "MSF",
-      "amplitude": 0.01323276,
-      "phase": 51.532036000000005
+      "amplitude": 0.013,
+      "phase": 50.78
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00693126,
-      "phase": 15.496027000000026
+      "amplitude": 0.007,
+      "phase": 16.02
     },
     {
       "name": "EP2",
-      "amplitude": 0.01927063,
-      "phase": 189.472664
+      "amplitude": 0.019,
+      "phase": 173.83
     },
     {
       "name": "M3",
-      "amplitude": 0.00105936,
-      "phase": 188.89838
+      "amplitude": 0.001,
+      "phase": 330.7
     },
     {
       "name": "MU2",
-      "amplitude": 0.0786238,
-      "phase": 207.831802
+      "amplitude": 0.083,
+      "phase": 191.24
     },
     {
       "name": "MTM",
-      "amplitude": 0.0040526600000000005,
-      "phase": 21.652778000000012
+      "amplitude": 0.004,
+      "phase": 18.48
     },
     {
       "name": "NU2",
-      "amplitude": 0.04977504,
-      "phase": 56.87489499999998
+      "amplitude": 0.047,
+      "phase": 42.94
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03239749,
-      "phase": 104.42072000000002
+      "amplitude": 0.03,
+      "phase": 85.6
     },
     {
       "name": "MN4",
-      "amplitude": 0.050668040000000004,
-      "phase": 148.405983
+      "amplitude": 0.059,
+      "phase": 112.82
     },
     {
       "name": "MS4",
-      "amplitude": 0.08722353,
-      "phase": 227.868579
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03959713,
-      "phase": 231.962634
+      "amplitude": 0.1,
+      "phase": 192.66
     },
     {
       "name": "N4",
-      "amplitude": 0.01044075,
-      "phase": 137.015486
+      "amplitude": 0.01,
+      "phase": 104.97
     },
     {
       "name": "M6",
-      "amplitude": 0.02837073,
-      "phase": 176.205688
+      "amplitude": 0.041,
+      "phase": 119.73
     },
     {
       "name": "M8",
-      "amplitude": 0.00346934,
-      "phase": 280.554419
+      "amplitude": 0.008,
+      "phase": 198.68
     },
     {
       "name": "S4",
-      "amplitude": 0.008058840000000001,
-      "phase": 314.640697
+      "amplitude": 0.009,
+      "phase": 283.76
     },
     {
       "name": "OO1",
-      "amplitude": 0.0036630499999999997,
-      "phase": 176.87298399999997
+      "amplitude": 0.003,
+      "phase": 137.76
     },
     {
       "name": "S3",
-      "amplitude": 0.00185731,
-      "phase": 75.73154499999998
+      "amplitude": 0,
+      "phase": 351.49
     },
     {
       "name": "MA2",
-      "amplitude": 0.12376903,
-      "phase": 69.97240599999998
+      "amplitude": 0.012,
+      "phase": 98.46
     },
     {
       "name": "MB2",
-      "amplitude": 0.10679116000000001,
-      "phase": 281.199659
+      "amplitude": 0.014,
+      "phase": 139.76
     },
     {
       "name": "T3",
-      "amplitude": 0.001727,
-      "phase": 60.54035799999997
+      "amplitude": 0.002,
+      "phase": 232.93
     },
     {
       "name": "R3",
-      "amplitude": 0.005238660000000001,
-      "phase": 280.728415
+      "amplitude": 0.006,
+      "phase": 335.45
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00402534,
-      "phase": 137.70975399999998
+      "amplitude": 0.004,
+      "phase": 133.61
     },
     {
       "name": "SGM",
-      "amplitude": 0.00289699,
-      "phase": 84.07954699999999
+      "amplitude": 0.003,
+      "phase": 263.33
     },
     {
       "name": "3L2",
-      "amplitude": 0.026893919999999998,
-      "phase": 12.735224000000017
+      "amplitude": 0.025,
+      "phase": 89.21
     },
     {
       "name": "3N2",
-      "amplitude": 0.011554249999999999,
-      "phase": 155.54104899999993
+      "amplitude": 0.013,
+      "phase": 214.81
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02300533,
-      "phase": 20.908416999999986
+      "amplitude": 0.023,
+      "phase": 5.16
     },
     {
       "name": "2MS6",
-      "amplitude": 0.024584079999999998,
-      "phase": 228.44128
+      "amplitude": 0.035,
+      "phase": 173.81
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00781309,
-      "phase": 321.560673
+      "amplitude": 0.01,
+      "phase": 359.66
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00959522,
-      "phase": 326.794921
+      "amplitude": 0.012,
+      "phase": 193.58
     }
   ],
   "epoch": {

--- a/data/ticon/pellwormanleger-9550021-deu-wsv.json
+++ b/data/ticon/pellwormanleger-9550021-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4304745690822256,
-      "phase": 349.6785599163567
+      "amplitude": 1.43,
+      "phase": 349.68
     },
     {
       "name": "N2",
-      "amplitude": 0.22875266197595903,
-      "phase": 324.6910174602729
+      "amplitude": 0.229,
+      "phase": 324.69
     },
     {
       "name": "S2",
-      "amplitude": 0.3747742340591581,
-      "phase": 62.40390800269421
+      "amplitude": 0.375,
+      "phase": 62.4
     },
     {
       "name": "K2",
-      "amplitude": 0.11190157192048182,
-      "phase": 60.39741276651762
+      "amplitude": 0.112,
+      "phase": 60.4
     },
     {
       "name": "2N2",
-      "amplitude": 0.026077166939166195,
-      "phase": 303.0371775529894
+      "amplitude": 0.026,
+      "phase": 303.04
     },
     {
       "name": "S1",
-      "amplitude": 0.011807291280268183,
-      "phase": 13.912787488218669
+      "amplitude": 0.012,
+      "phase": 13.91
     },
     {
       "name": "K1",
-      "amplitude": 0.06644859093424968,
-      "phase": 41.59016966020903
+      "amplitude": 0.066,
+      "phase": 41.59
     },
     {
       "name": "P1",
-      "amplitude": 0.03023655984474015,
-      "phase": 44.72052602610876
+      "amplitude": 0.03,
+      "phase": 44.72
     },
     {
       "name": "O1",
-      "amplitude": 0.09091764127895229,
-      "phase": 251.7077563685036
+      "amplitude": 0.091,
+      "phase": 251.71
     },
     {
       "name": "Q1",
-      "amplitude": 0.029127894480513606,
-      "phase": 193.47142515530155
+      "amplitude": 0.029,
+      "phase": 193.47
     },
     {
       "name": "M1",
-      "amplitude": 0.0019209474122389423,
-      "phase": 112.35830630199911
+      "amplitude": 0.002,
+      "phase": 112.36
     },
     {
       "name": "M4",
-      "amplitude": 0.13048283523916201,
-      "phase": 167.41641218705388
+      "amplitude": 0.13,
+      "phase": 167.42
     },
     {
       "name": "MM",
-      "amplitude": 0.029106029488683807,
-      "phase": 178.67067910245157
+      "amplitude": 0.029,
+      "phase": 178.67
     },
     {
       "name": "MF",
-      "amplitude": 0.01122632597609357,
-      "phase": 174.3442558402071
+      "amplitude": 0.011,
+      "phase": 174.34
     },
     {
       "name": "SA",
-      "amplitude": 0.12391604487583269,
-      "phase": 230.10906298054567
+      "amplitude": 0.124,
+      "phase": 230.11
     },
     {
       "name": "SSA",
-      "amplitude": 0.048150657534911684,
-      "phase": 208.52079026396532
+      "amplitude": 0.048,
+      "phase": 208.52
     },
     {
       "name": "T2",
-      "amplitude": 0.017687080997758953,
-      "phase": 36.503306716467705
+      "amplitude": 0.018,
+      "phase": 36.5
     },
     {
       "name": "J1",
-      "amplitude": 0.002871232559615767,
-      "phase": 189.22946688419168
+      "amplitude": 0.003,
+      "phase": 189.23
     },
     {
       "name": "L2",
-      "amplitude": 0.11769329063222268,
-      "phase": 6.69470234518127
+      "amplitude": 0.118,
+      "phase": 6.69
     },
     {
       "name": "R2",
-      "amplitude": 0.002181564401339393,
-      "phase": 359.6488530979801
+      "amplitude": 0.002,
+      "phase": 359.65
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005685773167984817,
-      "phase": 133.0459374800584
+      "amplitude": 0.006,
+      "phase": 133.05
     },
     {
       "name": "MSF",
-      "amplitude": 0.00455159436717588,
-      "phase": 33.897046709684275
+      "amplitude": 0.005,
+      "phase": 33.9
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00836206658881787,
-      "phase": 58.099660118579095
+      "amplitude": 0.008,
+      "phase": 58.1
     },
     {
       "name": "EP2",
-      "amplitude": 0.03597844919145018,
-      "phase": 50.235037866209666
+      "amplitude": 0.036,
+      "phase": 50.24
     },
     {
       "name": "M3",
-      "amplitude": 0.002903679520953794,
-      "phase": 48.78425659962147
+      "amplitude": 0.003,
+      "phase": 48.78
     },
     {
       "name": "MU2",
-      "amplitude": 0.15475010190427166,
-      "phase": 73.01334749072424
+      "amplitude": 0.155,
+      "phase": 73.01
     },
     {
       "name": "MTM",
-      "amplitude": 0.007060900126039731,
-      "phase": 236.0614922092135
+      "amplitude": 0.007,
+      "phase": 236.06
     },
     {
       "name": "NU2",
-      "amplitude": 0.08375458060271536,
-      "phase": 306.04684086557876
+      "amplitude": 0.084,
+      "phase": 306.05
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05537708020712527,
-      "phase": 0.6795160071162627
+      "amplitude": 0.055,
+      "phase": 0.68
     },
     {
       "name": "MN4",
-      "amplitude": 0.04221133329180201,
-      "phase": 143.7905756889802
+      "amplitude": 0.042,
+      "phase": 143.79
     },
     {
       "name": "MS4",
-      "amplitude": 0.08178325018747862,
-      "phase": 243.52801563096182
+      "amplitude": 0.082,
+      "phase": 243.53
     },
     {
       "name": "N4",
-      "amplitude": 0.008869636345226226,
-      "phase": 124.56301630992647
+      "amplitude": 0.009,
+      "phase": 124.56
     },
     {
       "name": "M6",
-      "amplitude": 0.05716213510302319,
-      "phase": 10.844846303768122
+      "amplitude": 0.057,
+      "phase": 10.84
     },
     {
       "name": "M8",
-      "amplitude": 0.004255232294570015,
-      "phase": 257.5458046837993
+      "amplitude": 0.004,
+      "phase": 257.55
     },
     {
       "name": "S4",
-      "amplitude": 0.0089772507602612,
-      "phase": 21.13590376580686
+      "amplitude": 0.009,
+      "phase": 21.14
     },
     {
       "name": "OO1",
-      "amplitude": 0.002587006733532747,
-      "phase": 224.17998066012058
+      "amplitude": 0.003,
+      "phase": 224.18
     },
     {
       "name": "S3",
-      "amplitude": 0.0005117627443410115,
-      "phase": 193.90672523650807
+      "amplitude": 0.001,
+      "phase": 193.91
     },
     {
       "name": "MA2",
-      "amplitude": 0.05063649051826164,
-      "phase": 289.4873898901999
+      "amplitude": 0.051,
+      "phase": 289.49
     },
     {
       "name": "MB2",
-      "amplitude": 0.02137755509270317,
-      "phase": 54.77344236560555
+      "amplitude": 0.021,
+      "phase": 54.77
     },
     {
       "name": "T3",
-      "amplitude": 0.0009448291407283406,
-      "phase": 165.7317786607705
+      "amplitude": 0.001,
+      "phase": 165.73
     },
     {
       "name": "R3",
-      "amplitude": 0.0013965582022907657,
-      "phase": 29.769537984589704
+      "amplitude": 0.001,
+      "phase": 29.77
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006221641915857032,
-      "phase": 196.95569280215545
+      "amplitude": 0.006,
+      "phase": 196.96
     },
     {
       "name": "SGM",
-      "amplitude": 0.0016017703777957762,
-      "phase": 54.81980943205781
+      "amplitude": 0.002,
+      "phase": 54.82
     },
     {
       "name": "3L2",
-      "amplitude": 0.004110007992330186,
-      "phase": 260.91257433114185
+      "amplitude": 0.004,
+      "phase": 260.91
     },
     {
       "name": "3N2",
-      "amplitude": 0.014153802379979659,
-      "phase": 149.16409387457549
+      "amplitude": 0.014,
+      "phase": 149.16
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03847163030805669,
-      "phase": 283.1743384650575
+      "amplitude": 0.038,
+      "phase": 283.17
     },
     {
       "name": "2MS6",
-      "amplitude": 0.057859327555263344,
-      "phase": 78.13309654450768
+      "amplitude": 0.058,
+      "phase": 78.13
     },
     {
       "name": "2MK5",
-      "amplitude": 0.006825948860107846,
-      "phase": 54.89033255700315
+      "amplitude": 0.007,
+      "phase": 54.89
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004814857075769127,
-      "phase": 256.29696026476864
+      "amplitude": 0.005,
+      "phase": 256.3
     }
   ],
   "epoch": {

--- a/data/ticon/petten_zuid-pettzd-nld-rws.json
+++ b/data/ticon/petten_zuid-pettzd-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.6528614899999999,
-      "phase": 145.942681
+      "amplitude": 0.676,
+      "phase": 130.6
     },
     {
       "name": "N2",
-      "amplitude": 0.09474297999999999,
-      "phase": 131.61850800000002
+      "amplitude": 0.098,
+      "phase": 114.81
     },
     {
       "name": "S2",
-      "amplitude": 0.17596651000000002,
-      "phase": 209.485034
+      "amplitude": 0.183,
+      "phase": 194.34
     },
     {
       "name": "K2",
-      "amplitude": 0.05313159,
-      "phase": 208.828286
+      "amplitude": 0.057,
+      "phase": 193.26
     },
     {
       "name": "2N2",
-      "amplitude": 0.00628422,
-      "phase": 90.92854399999999
+      "amplitude": 0.007,
+      "phase": 97.75
     },
     {
       "name": "S1",
-      "amplitude": 0.0077538799999999995,
-      "phase": 13.587261000000012
+      "amplitude": 0.008,
+      "phase": 302.97
     },
     {
       "name": "K1",
-      "amplitude": 0.07164107,
-      "phase": 353.87466
+      "amplitude": 0.072,
+      "phase": 345.84
     },
     {
       "name": "P1",
-      "amplitude": 0.03159865,
-      "phase": 345.918683
+      "amplitude": 0.032,
+      "phase": 337.6
     },
     {
       "name": "O1",
-      "amplitude": 0.10149910000000001,
-      "phase": 185.305967
+      "amplitude": 0.101,
+      "phase": 177.73
     },
     {
       "name": "Q1",
-      "amplitude": 0.03734338,
-      "phase": 128.548537
+      "amplitude": 0.037,
+      "phase": 122.2
     },
     {
       "name": "M1",
-      "amplitude": 0.00231139,
-      "phase": 325.111621
+      "amplitude": 0.004,
+      "phase": 30.56
     },
     {
       "name": "M4",
-      "amplitude": 0.13369897,
-      "phase": 182.129788
+      "amplitude": 0.154,
+      "phase": 147.4
     },
     {
       "name": "MM",
-      "amplitude": 0.0199364,
-      "phase": 172.55669799999998
+      "amplitude": 0.021,
+      "phase": 174.63
     },
     {
       "name": "MF",
-      "amplitude": 0.01021131,
-      "phase": 344.11620800000003
+      "amplitude": 0.009,
+      "phase": 346.47
     },
     {
       "name": "SA",
-      "amplitude": 0.08512465000000001,
-      "phase": 205.136879
+      "amplitude": 0.079,
+      "phase": 205.58
     },
     {
       "name": "SSA",
-      "amplitude": 0.02391386,
-      "phase": 177.737167
+      "amplitude": 0.025,
+      "phase": 179.38
     },
     {
       "name": "T2",
-      "amplitude": 0.040947370000000004,
-      "phase": 139.31115699999998
+      "amplitude": 0.015,
+      "phase": 161.52
     },
     {
       "name": "J1",
-      "amplitude": 0.00179569,
-      "phase": 74.57297900000003
+      "amplitude": 0.002,
+      "phase": 65.96
     },
     {
       "name": "L2",
-      "amplitude": 0.06404741,
-      "phase": 152.304262
+      "amplitude": 0.065,
+      "phase": 135.2
     },
     {
       "name": "R2",
-      "amplitude": 0.0219043,
-      "phase": 295.136998
+      "amplitude": 0.003,
+      "phase": 168.39
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00634929,
-      "phase": 90.31246299999998
+      "amplitude": 0.006,
+      "phase": 81.13
     },
     {
       "name": "MSF",
-      "amplitude": 0.02961465,
-      "phase": 22.912379999999985
+      "amplitude": 0.029,
+      "phase": 22.12
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00607266,
-      "phase": 142.972127
+      "amplitude": 0.006,
+      "phase": 142.62
     },
     {
       "name": "EP2",
-      "amplitude": 0.01694792,
-      "phase": 220.428658
+      "amplitude": 0.017,
+      "phase": 206.27
     },
     {
       "name": "M3",
-      "amplitude": 0.00476647,
-      "phase": 297.295048
+      "amplitude": 0.005,
+      "phase": 92.24
     },
     {
       "name": "MU2",
-      "amplitude": 0.07607233,
-      "phase": 238.978037
+      "amplitude": 0.079,
+      "phase": 223.62
     },
     {
       "name": "MTM",
-      "amplitude": 0.013514600000000002,
-      "phase": 22.734042999999986
+      "amplitude": 0.013,
+      "phase": 20.28
     },
     {
       "name": "NU2",
-      "amplitude": 0.03834373,
-      "phase": 111.32117
+      "amplitude": 0.04,
+      "phase": 88.05
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03030843,
-      "phase": 145.27511700000002
+      "amplitude": 0.029,
+      "phase": 132.43
     },
     {
       "name": "MN4",
-      "amplitude": 0.045135680000000004,
-      "phase": 157.903236
+      "amplitude": 0.051,
+      "phase": 123.87
     },
     {
       "name": "MS4",
-      "amplitude": 0.0776684,
-      "phase": 237.477058
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.02384064,
-      "phase": 301.027426
+      "amplitude": 0.089,
+      "phase": 205.49
     },
     {
       "name": "N4",
-      "amplitude": 0.006912939999999999,
-      "phase": 110.39948200000003
+      "amplitude": 0.008,
+      "phase": 79.94
     },
     {
       "name": "M6",
-      "amplitude": 0.05345269,
-      "phase": 284.84263
+      "amplitude": 0.071,
+      "phase": 231.6
     },
     {
       "name": "M8",
-      "amplitude": 0.01433281,
-      "phase": 343.282113
+      "amplitude": 0.026,
+      "phase": 263.29
     },
     {
       "name": "S4",
-      "amplitude": 0.0039036599999999998,
-      "phase": 309.393307
+      "amplitude": 0.005,
+      "phase": 287.37
     },
     {
       "name": "OO1",
-      "amplitude": 0.005515170000000001,
-      "phase": 167.46764499999995
+      "amplitude": 0.005,
+      "phase": 157.63
     },
     {
       "name": "S3",
-      "amplitude": 0.00056332,
-      "phase": 110.765398
+      "amplitude": 0,
+      "phase": 312.91
     },
     {
       "name": "MA2",
-      "amplitude": 0.12732003,
-      "phase": 128.81449199999997
+      "amplitude": 0.023,
+      "phase": 84.32
     },
     {
       "name": "MB2",
-      "amplitude": 0.0950275,
-      "phase": 340.150473
+      "amplitude": 0.012,
+      "phase": 100.04
     },
     {
       "name": "T3",
-      "amplitude": 0.0009736899999999999,
-      "phase": 69.074993
+      "amplitude": 0.001,
+      "phase": 245.36
     },
     {
       "name": "R3",
-      "amplitude": 0.0007238500000000001,
-      "phase": 169.367971
+      "amplitude": 0.001,
+      "phase": 254.57
     },
     {
       "name": "RHO1",
-      "amplitude": 0.009596780000000001,
-      "phase": 146.36108000000002
+      "amplitude": 0.009,
+      "phase": 138.92
     },
     {
       "name": "SGM",
-      "amplitude": 0.0013447,
-      "phase": 184.938036
+      "amplitude": 0.001,
+      "phase": 348.65
     },
     {
       "name": "3L2",
-      "amplitude": 0.0051161900000000005,
-      "phase": 327.867228
+      "amplitude": 0.005,
+      "phase": 37.75
     },
     {
       "name": "3N2",
-      "amplitude": 0.00302494,
-      "phase": 126.13360399999999
+      "amplitude": 0.012,
+      "phase": 290.12
     },
     {
       "name": "2SM2",
-      "amplitude": 0.021158549999999998,
-      "phase": 56.775750000000016
+      "amplitude": 0.022,
+      "phase": 40.23
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05386656,
-      "phase": 333.03749
+      "amplitude": 0.074,
+      "phase": 282.22
     },
     {
       "name": "2MK5",
-      "amplitude": 0.014215750000000001,
-      "phase": 295.57903899999997
+      "amplitude": 0.017,
+      "phase": 340.5
     },
     {
       "name": "2MO5",
-      "amplitude": 0.011227039999999999,
-      "phase": 310.840182
+      "amplitude": 0.014,
+      "phase": 181.97
     }
   ],
   "epoch": {

--- a/data/ticon/pinnausperrwerkap-5970019-deu-wsv.json
+++ b/data/ticon/pinnausperrwerkap-5970019-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2734892218648615,
-      "phase": 58.29494123357506
+      "amplitude": 1.273,
+      "phase": 58.29
     },
     {
       "name": "N2",
-      "amplitude": 0.19357118252543343,
-      "phase": 31.80781977193425
+      "amplitude": 0.194,
+      "phase": 31.81
     },
     {
       "name": "S2",
-      "amplitude": 0.293057341871223,
-      "phase": 132.21359210659432
+      "amplitude": 0.293,
+      "phase": 132.21
     },
     {
       "name": "K2",
-      "amplitude": 0.08831966896153876,
-      "phase": 130.63925854614922
+      "amplitude": 0.088,
+      "phase": 130.64
     },
     {
       "name": "2N2",
-      "amplitude": 0.021575061795352648,
-      "phase": 0.5125471195964906
+      "amplitude": 0.022,
+      "phase": 0.51
     },
     {
       "name": "S1",
-      "amplitude": 0.01843009834396888,
-      "phase": 85.56745946553292
+      "amplitude": 0.018,
+      "phase": 85.57
     },
     {
       "name": "K1",
-      "amplitude": 0.06901424142994375,
-      "phase": 88.09086265530192
+      "amplitude": 0.069,
+      "phase": 88.09
     },
     {
       "name": "P1",
-      "amplitude": 0.029660159603636813,
-      "phase": 86.91212787869307
+      "amplitude": 0.03,
+      "phase": 86.91
     },
     {
       "name": "O1",
-      "amplitude": 0.0890063268060264,
-      "phase": 293.0690526290595
+      "amplitude": 0.089,
+      "phase": 293.07
     },
     {
       "name": "Q1",
-      "amplitude": 0.025166544134122223,
-      "phase": 231.17147257149816
+      "amplitude": 0.025,
+      "phase": 231.17
     },
     {
       "name": "M1",
-      "amplitude": 0.0010098792970462196,
-      "phase": 128.77015555582966
+      "amplitude": 0.001,
+      "phase": 128.77
     },
     {
       "name": "M4",
-      "amplitude": 0.11737955864936836,
-      "phase": 343.1324043604667
+      "amplitude": 0.117,
+      "phase": 343.13
     },
     {
       "name": "MM",
-      "amplitude": 0.01601246922523215,
-      "phase": 111.24074446688837
+      "amplitude": 0.016,
+      "phase": 111.24
     },
     {
       "name": "MF",
-      "amplitude": 0.012127008754092856,
-      "phase": 100.57340412374657
+      "amplitude": 0.012,
+      "phase": 100.57
     },
     {
       "name": "SA",
-      "amplitude": 0.06431512240488292,
-      "phase": 252.4246967779022
+      "amplitude": 0.064,
+      "phase": 252.42
     },
     {
       "name": "SSA",
-      "amplitude": 0.05653443284720696,
-      "phase": 245.78967462985221
+      "amplitude": 0.057,
+      "phase": 245.79
     },
     {
       "name": "T2",
-      "amplitude": 0.01606502957174712,
-      "phase": 117.04902403803237
+      "amplitude": 0.016,
+      "phase": 117.05
     },
     {
       "name": "J1",
-      "amplitude": 0.005577320225841994,
-      "phase": 229.89063672984489
+      "amplitude": 0.006,
+      "phase": 229.89
     },
     {
       "name": "L2",
-      "amplitude": 0.10915869307854674,
-      "phase": 77.25901701499504
+      "amplitude": 0.109,
+      "phase": 77.26
     },
     {
       "name": "R2",
-      "amplitude": 0.0052851262909355485,
-      "phase": 59.935073901625174
+      "amplitude": 0.005,
+      "phase": 59.94
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006421497532008154,
-      "phase": 180.44575471935968
+      "amplitude": 0.006,
+      "phase": 180.45
     },
     {
       "name": "MSF",
-      "amplitude": 0.0509608230629163,
-      "phase": 56.88478987836004
+      "amplitude": 0.051,
+      "phase": 56.88
     },
     {
       "name": "MSQM",
-      "amplitude": 0.02327592693590413,
-      "phase": 54.86362559732311
+      "amplitude": 0.023,
+      "phase": 54.86
     },
     {
       "name": "EP2",
-      "amplitude": 0.03318794870484752,
-      "phase": 124.7732935936508
+      "amplitude": 0.033,
+      "phase": 124.77
     },
     {
       "name": "M3",
-      "amplitude": 0.002156041553046855,
-      "phase": 117.07374095232666
+      "amplitude": 0.002,
+      "phase": 117.07
     },
     {
       "name": "MU2",
-      "amplitude": 0.1668787962186179,
-      "phase": 150.89637666771682
+      "amplitude": 0.167,
+      "phase": 150.9
     },
     {
       "name": "MTM",
-      "amplitude": 0.006059605270226573,
-      "phase": 278.52735769555335
+      "amplitude": 0.006,
+      "phase": 278.53
     },
     {
       "name": "NU2",
-      "amplitude": 0.08529703258421154,
-      "phase": 16.140221838340608
+      "amplitude": 0.085,
+      "phase": 16.14
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05103534104162343,
-      "phase": 75.23260840786105
+      "amplitude": 0.051,
+      "phase": 75.23
     },
     {
       "name": "MN4",
-      "amplitude": 0.03992184101112353,
-      "phase": 318.73394464425223
+      "amplitude": 0.04,
+      "phase": 318.73
     },
     {
       "name": "MS4",
-      "amplitude": 0.0683165636052136,
-      "phase": 53.63574940736771
+      "amplitude": 0.068,
+      "phase": 53.64
     },
     {
       "name": "N4",
-      "amplitude": 0.006870941427659236,
-      "phase": 289.4566668907171
+      "amplitude": 0.007,
+      "phase": 289.46
     },
     {
       "name": "M6",
-      "amplitude": 0.09047528358397208,
-      "phase": 230.26806315999264
+      "amplitude": 0.09,
+      "phase": 230.27
     },
     {
       "name": "M8",
-      "amplitude": 0.030009938124296146,
-      "phase": 189.60041699351495
+      "amplitude": 0.03,
+      "phase": 189.6
     },
     {
       "name": "S4",
-      "amplitude": 0.006276172140276077,
-      "phase": 186.25271061098456
+      "amplitude": 0.006,
+      "phase": 186.25
     },
     {
       "name": "OO1",
-      "amplitude": 0.003248256726037765,
-      "phase": 255.73161951932184
+      "amplitude": 0.003,
+      "phase": 255.73
     },
     {
       "name": "S3",
-      "amplitude": 0.0007336197239089491,
-      "phase": 298.7717045571308
+      "amplitude": 0.001,
+      "phase": 298.77
     },
     {
       "name": "MA2",
-      "amplitude": 0.029477705677214208,
-      "phase": 6.98036474658403
+      "amplitude": 0.029,
+      "phase": 6.98
     },
     {
       "name": "MB2",
-      "amplitude": 0.02646963687856907,
-      "phase": 93.7247470080872
+      "amplitude": 0.026,
+      "phase": 93.72
     },
     {
       "name": "T3",
-      "amplitude": 0.0013118972318042748,
-      "phase": 106.0015970041249
+      "amplitude": 0.001,
+      "phase": 106
     },
     {
       "name": "R3",
-      "amplitude": 0.003526059113539535,
-      "phase": 125.05645079086639
+      "amplitude": 0.004,
+      "phase": 125.06
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006428162685076891,
-      "phase": 219.41351858082885
+      "amplitude": 0.006,
+      "phase": 219.41
     },
     {
       "name": "SGM",
-      "amplitude": 0.004872498272071206,
-      "phase": 34.674528361858165
+      "amplitude": 0.005,
+      "phase": 34.67
     },
     {
       "name": "3L2",
-      "amplitude": 0.0024611262558267197,
-      "phase": 249.4980611132546
+      "amplitude": 0.002,
+      "phase": 249.5
     },
     {
       "name": "3N2",
-      "amplitude": 0.01400880222548811,
-      "phase": 206.70239274086833
+      "amplitude": 0.014,
+      "phase": 206.7
     },
     {
       "name": "2SM2",
-      "amplitude": 0.032079976084890494,
-      "phase": 2.6116556719836694
+      "amplitude": 0.032,
+      "phase": 2.61
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08650844077785419,
-      "phase": 300.491502699238
+      "amplitude": 0.087,
+      "phase": 300.49
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005048766561984768,
-      "phase": 234.61643113161495
+      "amplitude": 0.005,
+      "phase": 234.62
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00448932116249296,
-      "phase": 110.67511640890928
+      "amplitude": 0.004,
+      "phase": 110.68
     }
   ],
   "epoch": {

--- a/data/ticon/pinnausperrwerkbp-5970018-deu-wsv.json
+++ b/data/ticon/pinnausperrwerkbp-5970018-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2671236177331129,
-      "phase": 57.76852729406306
+      "amplitude": 1.267,
+      "phase": 57.77
     },
     {
       "name": "N2",
-      "amplitude": 0.1894389456391423,
-      "phase": 31.79356702025109
+      "amplitude": 0.189,
+      "phase": 31.79
     },
     {
       "name": "S2",
-      "amplitude": 0.2843317454733573,
-      "phase": 132.67103074668591
+      "amplitude": 0.284,
+      "phase": 132.67
     },
     {
       "name": "K2",
-      "amplitude": 0.08783938407007491,
-      "phase": 131.53157744569592
+      "amplitude": 0.088,
+      "phase": 131.53
     },
     {
       "name": "2N2",
-      "amplitude": 0.01969606594786218,
-      "phase": 13.794320215480468
+      "amplitude": 0.02,
+      "phase": 13.79
     },
     {
       "name": "S1",
-      "amplitude": 0.016565261827107585,
-      "phase": 69.58421925947391
+      "amplitude": 0.017,
+      "phase": 69.58
     },
     {
       "name": "K1",
-      "amplitude": 0.0658197517570678,
-      "phase": 87.85665286949325
+      "amplitude": 0.066,
+      "phase": 87.86
     },
     {
       "name": "P1",
-      "amplitude": 0.029673894646081434,
-      "phase": 88.10086184544298
+      "amplitude": 0.03,
+      "phase": 88.1
     },
     {
       "name": "O1",
-      "amplitude": 0.084232436394624,
-      "phase": 293.01413294745737
+      "amplitude": 0.084,
+      "phase": 293.01
     },
     {
       "name": "Q1",
-      "amplitude": 0.02500945873050401,
-      "phase": 231.2204146743182
+      "amplitude": 0.025,
+      "phase": 231.22
     },
     {
       "name": "M1",
-      "amplitude": 0.0019371534321512812,
-      "phase": 139.05622188378362
+      "amplitude": 0.002,
+      "phase": 139.06
     },
     {
       "name": "M4",
-      "amplitude": 0.12133676485748492,
-      "phase": 337.4215932858838
+      "amplitude": 0.121,
+      "phase": 337.42
     },
     {
       "name": "MM",
-      "amplitude": 0.017616531199246332,
-      "phase": 140.32815829384379
+      "amplitude": 0.018,
+      "phase": 140.33
     },
     {
       "name": "MF",
-      "amplitude": 0.01557194555406071,
-      "phase": 109.04852305771863
+      "amplitude": 0.016,
+      "phase": 109.05
     },
     {
       "name": "SA",
-      "amplitude": 0.06119525801719733,
-      "phase": 229.08593628532046
+      "amplitude": 0.061,
+      "phase": 229.09
     },
     {
       "name": "SSA",
-      "amplitude": 0.044759669197714846,
-      "phase": 222.5055854746403
+      "amplitude": 0.045,
+      "phase": 222.51
     },
     {
       "name": "T2",
-      "amplitude": 0.014995009239499625,
-      "phase": 113.84506907809708
+      "amplitude": 0.015,
+      "phase": 113.85
     },
     {
       "name": "J1",
-      "amplitude": 0.004604950214789613,
-      "phase": 221.9247229073073
+      "amplitude": 0.005,
+      "phase": 221.92
     },
     {
       "name": "L2",
-      "amplitude": 0.1153625323115355,
-      "phase": 78.6032098012102
+      "amplitude": 0.115,
+      "phase": 78.6
     },
     {
       "name": "R2",
-      "amplitude": 0.007944654780539028,
-      "phase": 89.52205317344158
+      "amplitude": 0.008,
+      "phase": 89.52
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004892011675621294,
-      "phase": 167.74947963954628
+      "amplitude": 0.005,
+      "phase": 167.75
     },
     {
       "name": "MSF",
-      "amplitude": 0.05630246997042934,
-      "phase": 68.02669117021651
+      "amplitude": 0.056,
+      "phase": 68.03
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007102314359753783,
-      "phase": 39.612895110299576
+      "amplitude": 0.007,
+      "phase": 39.61
     },
     {
       "name": "EP2",
-      "amplitude": 0.03586567946522392,
-      "phase": 124.14694155187851
+      "amplitude": 0.036,
+      "phase": 124.15
     },
     {
       "name": "M3",
-      "amplitude": 0.0017850156934757899,
-      "phase": 112.06751912313092
+      "amplitude": 0.002,
+      "phase": 112.07
     },
     {
       "name": "MU2",
-      "amplitude": 0.16938932790914088,
-      "phase": 149.7494611169824
+      "amplitude": 0.169,
+      "phase": 149.75
     },
     {
       "name": "MTM",
-      "amplitude": 0.003189272845529795,
-      "phase": 189.6358650481364
+      "amplitude": 0.003,
+      "phase": 189.64
     },
     {
       "name": "NU2",
-      "amplitude": 0.08590315761482246,
-      "phase": 15.466826957749163
+      "amplitude": 0.086,
+      "phase": 15.47
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05226117089181815,
-      "phase": 76.16413006323108
+      "amplitude": 0.052,
+      "phase": 76.16
     },
     {
       "name": "MN4",
-      "amplitude": 0.03952478770908234,
-      "phase": 312.4594209217162
+      "amplitude": 0.04,
+      "phase": 312.46
     },
     {
       "name": "MS4",
-      "amplitude": 0.07206668305934562,
-      "phase": 49.3183865656319
+      "amplitude": 0.072,
+      "phase": 49.32
     },
     {
       "name": "N4",
-      "amplitude": 0.00776467112092575,
-      "phase": 293.36701254313954
+      "amplitude": 0.008,
+      "phase": 293.37
     },
     {
       "name": "M6",
-      "amplitude": 0.08679308005232345,
-      "phase": 229.5734955358723
+      "amplitude": 0.087,
+      "phase": 229.57
     },
     {
       "name": "M8",
-      "amplitude": 0.028707446326858302,
-      "phase": 183.56155947454525
+      "amplitude": 0.029,
+      "phase": 183.56
     },
     {
       "name": "S4",
-      "amplitude": 0.0061610691565982326,
-      "phase": 182.02919393344976
+      "amplitude": 0.006,
+      "phase": 182.03
     },
     {
       "name": "OO1",
-      "amplitude": 0.0027108127618889143,
-      "phase": 235.72725546844765
+      "amplitude": 0.003,
+      "phase": 235.73
     },
     {
       "name": "S3",
-      "amplitude": 0.002504699345849921,
-      "phase": 33.44563579477159
+      "amplitude": 0.003,
+      "phase": 33.45
     },
     {
       "name": "MA2",
-      "amplitude": 0.035564851003789304,
-      "phase": 4.236738550307393
+      "amplitude": 0.036,
+      "phase": 4.24
     },
     {
       "name": "MB2",
-      "amplitude": 0.03133109005235004,
-      "phase": 107.11638304365442
+      "amplitude": 0.031,
+      "phase": 107.12
     },
     {
       "name": "T3",
-      "amplitude": 0.0010216176870713725,
-      "phase": 28.222615805146006
+      "amplitude": 0.001,
+      "phase": 28.22
     },
     {
       "name": "R3",
-      "amplitude": 0.005513815467594872,
-      "phase": 111.98852070978478
+      "amplitude": 0.006,
+      "phase": 111.99
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006314586627490242,
-      "phase": 243.4380254595912
+      "amplitude": 0.006,
+      "phase": 243.44
     },
     {
       "name": "SGM",
-      "amplitude": 0.004000175981307681,
-      "phase": 71.26138216906384
+      "amplitude": 0.004,
+      "phase": 71.26
     },
     {
       "name": "3L2",
-      "amplitude": 0.004485384561790057,
-      "phase": 322.9572303964074
+      "amplitude": 0.004,
+      "phase": 322.96
     },
     {
       "name": "3N2",
-      "amplitude": 0.012085050710176378,
-      "phase": 188.7892548938992
+      "amplitude": 0.012,
+      "phase": 188.79
     },
     {
       "name": "2SM2",
-      "amplitude": 0.032060838873869894,
-      "phase": 1.1491980294196082
+      "amplitude": 0.032,
+      "phase": 1.15
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08211526762054859,
-      "phase": 300.2734298421991
+      "amplitude": 0.082,
+      "phase": 300.27
     },
     {
       "name": "2MK5",
-      "amplitude": 0.003742267215691093,
-      "phase": 234.9421528807913
+      "amplitude": 0.004,
+      "phase": 234.94
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004267321704997723,
-      "phase": 131.9009499737914
+      "amplitude": 0.004,
+      "phase": 131.9
     }
   ],
   "epoch": {

--- a/data/ticon/platform_a12-a12-nld-rws.json
+++ b/data/ticon/platform_a12-a12-nld-rws.json
@@ -33,253 +33,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.26416762,
-      "phase": 148.27099599999997
+      "amplitude": 0.272,
+      "phase": 131.12
     },
     {
       "name": "N2",
-      "amplitude": 0.05027035,
-      "phase": 121.208575
+      "amplitude": 0.052,
+      "phase": 103.97
     },
     {
       "name": "S2",
-      "amplitude": 0.0734908,
-      "phase": 190.825452
+      "amplitude": 0.075,
+      "phase": 173.14
     },
     {
       "name": "K2",
-      "amplitude": 0.01896761,
-      "phase": 196.528905
+      "amplitude": 0.021,
+      "phase": 171.99
     },
     {
       "name": "2N2",
-      "amplitude": 0.0064275800000000004,
-      "phase": 100.10193400000003
+      "amplitude": 0.007,
+      "phase": 81.79
     },
     {
       "name": "S1",
-      "amplitude": 0.0019207299999999998,
-      "phase": 276.94158400000003
+      "amplitude": 0.005,
+      "phase": 226.79
     },
     {
       "name": "K1",
-      "amplitude": 0.0363526,
-      "phase": 319.797013
+      "amplitude": 0.036,
+      "phase": 311
     },
     {
       "name": "P1",
-      "amplitude": 0.01044457,
-      "phase": 303.580116
+      "amplitude": 0.011,
+      "phase": 299.64
     },
     {
       "name": "O1",
-      "amplitude": 0.03763531,
-      "phase": 164.03990399999998
+      "amplitude": 0.038,
+      "phase": 155.92
     },
     {
       "name": "Q1",
-      "amplitude": 0.01401485,
-      "phase": 107.685315
+      "amplitude": 0.014,
+      "phase": 99.41
     },
     {
       "name": "M1",
-      "amplitude": 0.00072451,
-      "phase": 234.47852899999998
+      "amplitude": 0.001,
+      "phase": 20.3
     },
     {
       "name": "M4",
-      "amplitude": 0.03204408,
-      "phase": 25.19802900000002
+      "amplitude": 0.037,
+      "phase": 346.87
     },
     {
       "name": "MM",
-      "amplitude": 0.02322079,
-      "phase": 179.90749299999993
+      "amplitude": 0.023,
+      "phase": 179.54
     },
     {
       "name": "MF",
-      "amplitude": 0.014154469999999999,
-      "phase": 179.49965399999996
+      "amplitude": 0.013,
+      "phase": 179.22
     },
     {
       "name": "SA",
-      "amplitude": 0.09263877000000001,
-      "phase": 233.31906800000002
+      "amplitude": 0.099,
+      "phase": 233
     },
     {
       "name": "SSA",
-      "amplitude": 0.01744772,
-      "phase": 186.345432
+      "amplitude": 0.02,
+      "phase": 184.52
     },
     {
       "name": "T2",
-      "amplitude": 0.01237365,
-      "phase": 107.05118299999998
+      "amplitude": 0.004,
+      "phase": 174.57
     },
     {
       "name": "J1",
-      "amplitude": 0.00164927,
-      "phase": 20.26990699999999
+      "amplitude": 0.002,
+      "phase": 9.99
     },
     {
       "name": "L2",
-      "amplitude": 0.01333968,
-      "phase": 183.852088
+      "amplitude": 0.013,
+      "phase": 164.3
     },
     {
       "name": "R2",
-      "amplitude": 0.0097711,
-      "phase": 293.88946699999997
+      "amplitude": 0.001,
+      "phase": 176.78
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00260825,
-      "phase": 61.045038999999974
+      "amplitude": 0.003,
+      "phase": 56.09
     },
     {
       "name": "MSF",
-      "amplitude": 0.00791862,
-      "phase": 262.496053
+      "amplitude": 0.008,
+      "phase": 261.73
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00050768,
-      "phase": 241.976433
+      "amplitude": 0.001,
+      "phase": 245.51
     },
     {
       "name": "EP2",
-      "amplitude": 0.00150797,
-      "phase": 267.249211
+      "amplitude": 0.001,
+      "phase": 258.83
     },
     {
       "name": "M3",
-      "amplitude": 0.00108768,
-      "phase": 74.12252899999999
+      "amplitude": 0.001,
+      "phase": 226.19
     },
     {
       "name": "MU2",
-      "amplitude": 0.00601552,
-      "phase": 317.886102
+      "amplitude": 0.006,
+      "phase": 297.81
     },
     {
       "name": "MTM",
-      "amplitude": 0.00390512,
-      "phase": 204.46787
+      "amplitude": 0.003,
+      "phase": 198.81
     },
     {
       "name": "NU2",
-      "amplitude": 0.012396560000000001,
-      "phase": 128.265809
+      "amplitude": 0.013,
+      "phase": 111.73
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00546653,
-      "phase": 177.38177300000007
+      "amplitude": 0.006,
+      "phase": 155
     },
     {
       "name": "MN4",
-      "amplitude": 0.01110395,
-      "phase": 346.854105
+      "amplitude": 0.013,
+      "phase": 310.95
     },
     {
       "name": "MS4",
-      "amplitude": 0.0108558,
-      "phase": 105.75534900000002
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.01160333,
-      "phase": 284.314136
+      "amplitude": 0.013,
+      "phase": 68.57
     },
     {
       "name": "N4",
-      "amplitude": 0.0020234,
-      "phase": 313.470024
+      "amplitude": 0.003,
+      "phase": 275.76
     },
     {
       "name": "M6",
-      "amplitude": 0.005277039999999999,
-      "phase": 86.16243400000002
+      "amplitude": 0.007,
+      "phase": 32.72
     },
     {
       "name": "M8",
-      "amplitude": 0.0013156,
-      "phase": 5.612167999999997
+      "amplitude": 0.002,
+      "phase": 284.22
     },
     {
       "name": "S4",
-      "amplitude": 0.00257606,
-      "phase": 7.923119999999983
+      "amplitude": 0.003,
+      "phase": 338.16
     },
     {
       "name": "OO1",
-      "amplitude": 0.00118052,
-      "phase": 127.10276199999998
+      "amplitude": 0.001,
+      "phase": 111.73
     },
     {
       "name": "S3",
-      "amplitude": 0.00021456,
-      "phase": 256.64984
+      "amplitude": 0,
+      "phase": 94.07
     },
     {
       "name": "MA2",
-      "amplitude": 0.0421635,
-      "phase": 122.88438200000002
+      "amplitude": 0.002,
+      "phase": 29.68
     },
     {
       "name": "MB2",
-      "amplitude": 0.04065597000000001,
-      "phase": 342.434803
+      "amplitude": 0.003,
+      "phase": 210.61
     },
     {
       "name": "T3",
-      "amplitude": 0.00014323,
-      "phase": 46.472718999999984
+      "amplitude": 0,
+      "phase": 169.86
     },
     {
       "name": "R3",
-      "amplitude": 0.00039600000000000003,
-      "phase": 75.74607800000001
+      "amplitude": 0,
+      "phase": 157.06
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00231188,
-      "phase": 112.00061099999999
+      "amplitude": 0.002,
+      "phase": 103.19
     },
     {
       "name": "SGM",
-      "amplitude": 0.00220863,
-      "phase": 229.431172
+      "amplitude": 0.002,
+      "phase": 49.23
     },
     {
       "name": "3L2",
-      "amplitude": 0.00069678,
-      "phase": 328.086484
+      "amplitude": 0.001,
+      "phase": 31.37
     },
     {
       "name": "3N2",
-      "amplitude": 0.00045852999999999996,
-      "phase": 197.491935
+      "amplitude": 0.001,
+      "phase": 335.7
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00255909,
-      "phase": 92.873648
+      "amplitude": 0.003,
+      "phase": 75.25
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00336548,
-      "phase": 142.42850399999998
+      "amplitude": 0.004,
+      "phase": 89.94
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00066091,
-      "phase": 193.31151
+      "amplitude": 0.001,
+      "phase": 240.35
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00067948,
-      "phase": 274.312449
+      "amplitude": 0.001,
+      "phase": 132.48
     }
   ],
   "epoch": {

--- a/data/ticon/platform_d15_a-d15-nld-rws.json
+++ b/data/ticon/platform_d15_a-d15-nld-rws.json
@@ -33,253 +33,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.60679363,
-      "phase": 174.66999399999997
+      "amplitude": 0.626,
+      "phase": 157.56
     },
     {
       "name": "N2",
-      "amplitude": 0.1141325,
-      "phase": 151.596702
+      "amplitude": 0.117,
+      "phase": 135.2
     },
     {
       "name": "S2",
-      "amplitude": 0.19512854999999998,
-      "phase": 223.856775
+      "amplitude": 0.2,
+      "phase": 206.15
     },
     {
       "name": "K2",
-      "amplitude": 0.0505688,
-      "phase": 228.446271
+      "amplitude": 0.057,
+      "phase": 204.89
     },
     {
       "name": "2N2",
-      "amplitude": 0.015053160000000001,
-      "phase": 133.86778400000003
+      "amplitude": 0.015,
+      "phase": 118.38
     },
     {
       "name": "S1",
-      "amplitude": 0.00456335,
-      "phase": 302.561504
+      "amplitude": 0.008,
+      "phase": 239.84
     },
     {
       "name": "K1",
-      "amplitude": 0.06343646,
-      "phase": 319.751185
+      "amplitude": 0.063,
+      "phase": 310.99
     },
     {
       "name": "P1",
-      "amplitude": 0.01995749,
-      "phase": 301.503669
+      "amplitude": 0.02,
+      "phase": 296.42
     },
     {
       "name": "O1",
-      "amplitude": 0.06982511,
-      "phase": 156.06287299999997
+      "amplitude": 0.069,
+      "phase": 148.09
     },
     {
       "name": "Q1",
-      "amplitude": 0.02380878,
-      "phase": 100.60800799999998
+      "amplitude": 0.024,
+      "phase": 93.49
     },
     {
       "name": "M1",
-      "amplitude": 0.0010380699999999999,
-      "phase": 238.857097
+      "amplitude": 0.001,
+      "phase": 357.62
     },
     {
       "name": "M4",
-      "amplitude": 0.02233072,
-      "phase": 330.702907
+      "amplitude": 0.026,
+      "phase": 295.37
     },
     {
       "name": "MM",
-      "amplitude": 0.01835196,
-      "phase": 184.004043
+      "amplitude": 0.019,
+      "phase": 181.18
     },
     {
       "name": "MF",
-      "amplitude": 0.01366344,
-      "phase": 181.086037
+      "amplitude": 0.013,
+      "phase": 180.64
     },
     {
       "name": "SA",
-      "amplitude": 0.07769364000000001,
-      "phase": 217.34373
+      "amplitude": 0.085,
+      "phase": 216.07
     },
     {
       "name": "SSA",
-      "amplitude": 0.01003541,
-      "phase": 153.64748800000007
+      "amplitude": 0.013,
+      "phase": 148.07
     },
     {
       "name": "T2",
-      "amplitude": 0.03448624,
-      "phase": 137.590078
+      "amplitude": 0.011,
+      "phase": 198.03
     },
     {
       "name": "J1",
-      "amplitude": 0.00320964,
-      "phase": 23.514973999999995
+      "amplitude": 0.003,
+      "phase": 14.76
     },
     {
       "name": "L2",
-      "amplitude": 0.03065346,
-      "phase": 188.04201
+      "amplitude": 0.031,
+      "phase": 169.22
     },
     {
       "name": "R2",
-      "amplitude": 0.02741686,
-      "phase": 326.818248
+      "amplitude": 0.002,
+      "phase": 230.05
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0044238,
-      "phase": 55.12196399999999
+      "amplitude": 0.004,
+      "phase": 51.02
     },
     {
       "name": "MSF",
-      "amplitude": 0.00701339,
-      "phase": 260.650935
+      "amplitude": 0.006,
+      "phase": 255.43
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0012622500000000001,
-      "phase": 308.785451
+      "amplitude": 0.002,
+      "phase": 289.99
     },
     {
       "name": "EP2",
-      "amplitude": 0.00439388,
-      "phase": 227.321145
+      "amplitude": 0.004,
+      "phase": 212.12
     },
     {
       "name": "M3",
-      "amplitude": 0.00299338,
-      "phase": 228.163445
+      "amplitude": 0.003,
+      "phase": 21.86
     },
     {
       "name": "MU2",
-      "amplitude": 0.013829880000000001,
-      "phase": 235.74528700000002
+      "amplitude": 0.015,
+      "phase": 219.55
     },
     {
       "name": "MTM",
-      "amplitude": 0.0037895299999999997,
-      "phase": 191.044134
+      "amplitude": 0.004,
+      "phase": 180.96
     },
     {
       "name": "NU2",
-      "amplitude": 0.026138210000000002,
-      "phase": 147.71252500000003
+      "amplitude": 0.027,
+      "phase": 130.95
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.01225013,
-      "phase": 174.99632700000006
+      "amplitude": 0.014,
+      "phase": 155.46
     },
     {
       "name": "MN4",
-      "amplitude": 0.009217109999999999,
-      "phase": 295.61912
+      "amplitude": 0.011,
+      "phase": 262.22
     },
     {
       "name": "MS4",
-      "amplitude": 0.00808164,
-      "phase": 2.2805700000000115
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.02749114,
-      "phase": 305.92244
+      "amplitude": 0.009,
+      "phase": 328.58
     },
     {
       "name": "N4",
-      "amplitude": 0.0020986,
-      "phase": 264.048526
+      "amplitude": 0.003,
+      "phase": 234.41
     },
     {
       "name": "M6",
-      "amplitude": 0.00364784,
-      "phase": 201.666277
+      "amplitude": 0.005,
+      "phase": 139.14
     },
     {
       "name": "M8",
-      "amplitude": 0.0026491500000000003,
-      "phase": 354.549166
+      "amplitude": 0.005,
+      "phase": 275.85
     },
     {
       "name": "S4",
-      "amplitude": 0.00185555,
-      "phase": 27.785012999999992
+      "amplitude": 0.002,
+      "phase": 355.89
     },
     {
       "name": "OO1",
-      "amplitude": 0.0019069500000000001,
-      "phase": 107.20865200000003
+      "amplitude": 0.002,
+      "phase": 86.67
     },
     {
       "name": "S3",
-      "amplitude": 0.00092184,
-      "phase": 222.292231
+      "amplitude": 0,
+      "phase": 81.76
     },
     {
       "name": "MA2",
-      "amplitude": 0.09943472,
-      "phase": 148.08666700000003
+      "amplitude": 0.006,
+      "phase": 65.13
     },
     {
       "name": "MB2",
-      "amplitude": 0.09527748000000001,
-      "phase": 11.472251000000028
+      "amplitude": 0.003,
+      "phase": 244.76
     },
     {
       "name": "T3",
-      "amplitude": 0.00042566,
-      "phase": 149.138307
+      "amplitude": 0.001,
+      "phase": 7.44
     },
     {
       "name": "R3",
-      "amplitude": 0.00289952,
-      "phase": 30.39290699999998
+      "amplitude": 0.003,
+      "phase": 97.8
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00497236,
-      "phase": 104.84535900000003
+      "amplitude": 0.005,
+      "phase": 98.83
     },
     {
       "name": "SGM",
-      "amplitude": 0.00220864,
-      "phase": 244.967357
+      "amplitude": 0.002,
+      "phase": 64.55
     },
     {
       "name": "3L2",
-      "amplitude": 0.00444292,
-      "phase": 5.368620000000021
+      "amplitude": 0.004,
+      "phase": 70.09
     },
     {
       "name": "3N2",
-      "amplitude": 0.00086058,
-      "phase": 192.540613
+      "amplitude": 0.003,
+      "phase": 295.38
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00911032,
-      "phase": 73.35434099999998
+      "amplitude": 0.009,
+      "phase": 54.95
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0047966599999999995,
-      "phase": 276.246419
+      "amplitude": 0.006,
+      "phase": 218.77
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00134651,
-      "phase": 140.458575
+      "amplitude": 0.002,
+      "phase": 178.1
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00221394,
-      "phase": 116.18593599999997
+      "amplitude": 0.003,
+      "phase": 344.07
     }
   ],
   "epoch": {

--- a/data/ticon/platform_f16_a-f16-nld-rws.json
+++ b/data/ticon/platform_f16_a-f16-nld-rws.json
@@ -33,253 +33,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.49067678000000003,
-      "phase": 197.595003
+      "amplitude": 0.506,
+      "phase": 180.57
     },
     {
       "name": "N2",
-      "amplitude": 0.08898587,
-      "phase": 174.90572299999997
+      "amplitude": 0.092,
+      "phase": 158.06
     },
     {
       "name": "S2",
-      "amplitude": 0.14697428,
-      "phase": 250.492954
+      "amplitude": 0.151,
+      "phase": 233.09
     },
     {
       "name": "K2",
-      "amplitude": 0.03772229,
-      "phase": 257.187223
+      "amplitude": 0.043,
+      "phase": 232.55
     },
     {
       "name": "2N2",
-      "amplitude": 0.0109444,
-      "phase": 156.45048599999996
+      "amplitude": 0.011,
+      "phase": 140.35
     },
     {
       "name": "S1",
-      "amplitude": 0.00336938,
-      "phase": 316.897371
+      "amplitude": 0.007,
+      "phase": 252.52
     },
     {
       "name": "K1",
-      "amplitude": 0.060324710000000004,
-      "phase": 339.56721
+      "amplitude": 0.06,
+      "phase": 330.66
     },
     {
       "name": "P1",
-      "amplitude": 0.01848569,
-      "phase": 327.348395
+      "amplitude": 0.019,
+      "phase": 321.87
     },
     {
       "name": "O1",
-      "amplitude": 0.06726320000000001,
-      "phase": 180.442305
+      "amplitude": 0.067,
+      "phase": 172.4
     },
     {
       "name": "Q1",
-      "amplitude": 0.02157934,
-      "phase": 124.95870200000002
+      "amplitude": 0.021,
+      "phase": 116.45
     },
     {
       "name": "M1",
-      "amplitude": 0.00172288,
-      "phase": 299.158162
+      "amplitude": 0.002,
+      "phase": 13.28
     },
     {
       "name": "M4",
-      "amplitude": 0.036008330000000005,
-      "phase": 323.278585
+      "amplitude": 0.042,
+      "phase": 285.54
     },
     {
       "name": "MM",
-      "amplitude": 0.01980343,
-      "phase": 195.74148
+      "amplitude": 0.02,
+      "phase": 194.55
     },
     {
       "name": "MF",
-      "amplitude": 0.012443550000000001,
-      "phase": 193.68062
+      "amplitude": 0.012,
+      "phase": 192.67
     },
     {
       "name": "SA",
-      "amplitude": 0.0861068,
-      "phase": 219.230859
+      "amplitude": 0.086,
+      "phase": 219.34
     },
     {
       "name": "SSA",
-      "amplitude": 0.01904776,
-      "phase": 154.88682399999993
+      "amplitude": 0.019,
+      "phase": 155.55
     },
     {
       "name": "T2",
-      "amplitude": 0.02605013,
-      "phase": 163.30202499999996
+      "amplitude": 0.008,
+      "phase": 217.07
     },
     {
       "name": "J1",
-      "amplitude": 0.00195339,
-      "phase": 38.57272499999999
+      "amplitude": 0.002,
+      "phase": 24.95
     },
     {
       "name": "L2",
-      "amplitude": 0.02865078,
-      "phase": 210.670483
+      "amplitude": 0.03,
+      "phase": 191.21
     },
     {
       "name": "R2",
-      "amplitude": 0.02188935,
-      "phase": 354.714134
+      "amplitude": 0.002,
+      "phase": 277.1
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00368366,
-      "phase": 83.01219600000002
+      "amplitude": 0.004,
+      "phase": 77.72
     },
     {
       "name": "MSF",
-      "amplitude": 0.0035480200000000003,
-      "phase": 299.824443
+      "amplitude": 0.003,
+      "phase": 296.04
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00128162,
-      "phase": 30.647058000000015
+      "amplitude": 0.001,
+      "phase": 22.94
     },
     {
       "name": "EP2",
-      "amplitude": 0.00511506,
-      "phase": 261.12375
+      "amplitude": 0.005,
+      "phase": 245.1
     },
     {
       "name": "M3",
-      "amplitude": 0.00165383,
-      "phase": 275.516547
+      "amplitude": 0.002,
+      "phase": 65.97
     },
     {
       "name": "MU2",
-      "amplitude": 0.018916409999999998,
-      "phase": 281.481051
+      "amplitude": 0.021,
+      "phase": 263.41
     },
     {
       "name": "MTM",
-      "amplitude": 0.00196878,
-      "phase": 173.42049999999995
+      "amplitude": 0.002,
+      "phase": 172.11
     },
     {
       "name": "NU2",
-      "amplitude": 0.02172659,
-      "phase": 168.09512300000006
+      "amplitude": 0.023,
+      "phase": 150.85
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.01231439,
-      "phase": 204.538622
+      "amplitude": 0.013,
+      "phase": 182.67
     },
     {
       "name": "MN4",
-      "amplitude": 0.0134505,
-      "phase": 295.497669
+      "amplitude": 0.016,
+      "phase": 259.49
     },
     {
       "name": "MS4",
-      "amplitude": 0.02005369,
-      "phase": 13.595392000000004
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.022875740000000002,
-      "phase": 328.651687
+      "amplitude": 0.023,
+      "phase": 338.01
     },
     {
       "name": "N4",
-      "amplitude": 0.0032945799999999996,
-      "phase": 264.79089
+      "amplitude": 0.004,
+      "phase": 231.58
     },
     {
       "name": "M6",
-      "amplitude": 0.01305471,
-      "phase": 18.826078999999993
+      "amplitude": 0.017,
+      "phase": 323.73
     },
     {
       "name": "M8",
-      "amplitude": 0.00379604,
-      "phase": 173.42870300000004
+      "amplitude": 0.007,
+      "phase": 90.96
     },
     {
       "name": "S4",
-      "amplitude": 0.0018376,
-      "phase": 85.570672
+      "amplitude": 0.002,
+      "phase": 51.88
     },
     {
       "name": "OO1",
-      "amplitude": 0.00092156,
-      "phase": 118.774813
+      "amplitude": 0.001,
+      "phase": 102.71
     },
     {
       "name": "S3",
-      "amplitude": 0.00094795,
-      "phase": 230.953951
+      "amplitude": 0,
+      "phase": 47.22
     },
     {
       "name": "MA2",
-      "amplitude": 0.08322582,
-      "phase": 170.632119
+      "amplitude": 0.007,
+      "phase": 116.83
     },
     {
       "name": "MB2",
-      "amplitude": 0.07659402,
-      "phase": 35.629727
+      "amplitude": 0.002,
+      "phase": 256.09
     },
     {
       "name": "T3",
-      "amplitude": 0.00049504,
-      "phase": 135.770307
+      "amplitude": 0,
+      "phase": 331.31
     },
     {
       "name": "R3",
-      "amplitude": 0.00182833,
-      "phase": 67.39870100000002
+      "amplitude": 0.002,
+      "phase": 130.7
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00482339,
-      "phase": 133.78999899999997
+      "amplitude": 0.005,
+      "phase": 126.58
     },
     {
       "name": "SGM",
-      "amplitude": 0.0014624899999999999,
-      "phase": 229.184126
+      "amplitude": 0.002,
+      "phase": 47.66
     },
     {
       "name": "3L2",
-      "amplitude": 0.0012731899999999998,
-      "phase": 19.117016999999976
+      "amplitude": 0.001,
+      "phase": 59.25
     },
     {
       "name": "3N2",
-      "amplitude": 0.00212201,
-      "phase": 265.41290300000003
+      "amplitude": 0.003,
+      "phase": 319.37
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00837821,
-      "phase": 104.889024
+      "amplitude": 0.008,
+      "phase": 84.02
     },
     {
       "name": "2MS6",
-      "amplitude": 0.01208888,
-      "phase": 77.125113
+      "amplitude": 0.016,
+      "phase": 21.47
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00048861,
-      "phase": 154.572861
+      "amplitude": 0.001,
+      "phase": 203.67
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0017904800000000001,
-      "phase": 126.82310999999999
+      "amplitude": 0.002,
+      "phase": 354.72
     }
   ],
   "epoch": {

--- a/data/ticon/platform_hoorn_q1_a-q1-nld-rws.json
+++ b/data/ticon/platform_hoorn_q1_a-q1-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.47869107,
-      "phase": 166.04179899999997
+      "amplitude": 0.495,
+      "phase": 149.1
     },
     {
       "name": "N2",
-      "amplitude": 0.07767641,
-      "phase": 153.75185299999998
+      "amplitude": 0.08,
+      "phase": 136.41
     },
     {
       "name": "S2",
-      "amplitude": 0.15543747,
-      "phase": 234.938778
+      "amplitude": 0.161,
+      "phase": 217.51
     },
     {
       "name": "K2",
-      "amplitude": 0.04252087,
-      "phase": 238.569602
+      "amplitude": 0.048,
+      "phase": 214.51
     },
     {
       "name": "2N2",
-      "amplitude": 0.00879447,
-      "phase": 135.991332
+      "amplitude": 0.009,
+      "phase": 117.24
     },
     {
       "name": "S1",
-      "amplitude": 0.0063367200000000005,
-      "phase": 350.292636
+      "amplitude": 0.009,
+      "phase": 278.77
     },
     {
       "name": "K1",
-      "amplitude": 0.08008447,
-      "phase": 350.150101
+      "amplitude": 0.08,
+      "phase": 341.16
     },
     {
       "name": "P1",
-      "amplitude": 0.0305884,
-      "phase": 338.022222
+      "amplitude": 0.031,
+      "phase": 331.52
     },
     {
       "name": "O1",
-      "amplitude": 0.10202243,
-      "phase": 186.548607
+      "amplitude": 0.102,
+      "phase": 178.11
     },
     {
       "name": "Q1",
-      "amplitude": 0.03276054,
-      "phase": 130.242842
+      "amplitude": 0.033,
+      "phase": 121.62
     },
     {
       "name": "M1",
-      "amplitude": 0.00058356,
-      "phase": 0.6852840000000242
+      "amplitude": 0.002,
+      "phase": 15.06
     },
     {
       "name": "M4",
-      "amplitude": 0.09481624,
-      "phase": 177.44944599999997
+      "amplitude": 0.11,
+      "phase": 141
     },
     {
       "name": "MM",
-      "amplitude": 0.01200593,
-      "phase": 175.53443400000003
+      "amplitude": 0.012,
+      "phase": 175.79
     },
     {
       "name": "MF",
-      "amplitude": 0.012847569999999999,
-      "phase": 129.52411900000004
+      "amplitude": 0.012,
+      "phase": 128.41
     },
     {
       "name": "SA",
-      "amplitude": 0.09402643,
-      "phase": 222.103312
+      "amplitude": 0.096,
+      "phase": 222.66
     },
     {
       "name": "SSA",
-      "amplitude": 0.0161404,
-      "phase": 165.99492299999997
+      "amplitude": 0.015,
+      "phase": 165.76
     },
     {
       "name": "T2",
-      "amplitude": 0.03032524,
-      "phase": 148.103497
+      "amplitude": 0.009,
+      "phase": 190.43
     },
     {
       "name": "J1",
-      "amplitude": 0.00366133,
-      "phase": 58.442543
+      "amplitude": 0.004,
+      "phase": 48.56
     },
     {
       "name": "L2",
-      "amplitude": 0.04255784,
-      "phase": 160.54081700000006
+      "amplitude": 0.044,
+      "phase": 142.53
     },
     {
       "name": "R2",
-      "amplitude": 0.022927819999999998,
-      "phase": 342.724269
+      "amplitude": 0.002,
+      "phase": 305.51
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0059594,
-      "phase": 73.20583499999998
+      "amplitude": 0.006,
+      "phase": 67.45
     },
     {
       "name": "MSF",
-      "amplitude": 0.01776365,
-      "phase": 45.55372
+      "amplitude": 0.017,
+      "phase": 44.81
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00263444,
-      "phase": 55.47719799999999
+      "amplitude": 0.002,
+      "phase": 53.54
     },
     {
       "name": "EP2",
-      "amplitude": 0.01178059,
-      "phase": 222.147138
+      "amplitude": 0.012,
+      "phase": 204.79
     },
     {
       "name": "M3",
-      "amplitude": 0.004769010000000001,
-      "phase": 296.237718
+      "amplitude": 0.005,
+      "phase": 89.25
     },
     {
       "name": "MU2",
-      "amplitude": 0.058560299999999996,
-      "phase": 234.74600700000002
+      "amplitude": 0.061,
+      "phase": 217.94
     },
     {
       "name": "MTM",
-      "amplitude": 0.00268795,
-      "phase": 266.676002
+      "amplitude": 0.003,
+      "phase": 270.77
     },
     {
       "name": "NU2",
-      "amplitude": 0.02448766,
-      "phase": 115.35726199999999
+      "amplitude": 0.026,
+      "phase": 98.62
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02177583,
-      "phase": 156.63016400000004
+      "amplitude": 0.022,
+      "phase": 138.65
     },
     {
       "name": "MN4",
-      "amplitude": 0.03175993,
-      "phase": 150.23694
+      "amplitude": 0.037,
+      "phase": 115.25
     },
     {
       "name": "MS4",
-      "amplitude": 0.05315968,
-      "phase": 237.788814
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.02653164,
-      "phase": 295.802374
+      "amplitude": 0.06,
+      "phase": 202.71
     },
     {
       "name": "N4",
-      "amplitude": 0.00702188,
-      "phase": 121.44401199999999
+      "amplitude": 0.008,
+      "phase": 87.16
     },
     {
       "name": "M6",
-      "amplitude": 0.044900409999999995,
-      "phase": 280.382212
+      "amplitude": 0.06,
+      "phase": 224.01
     },
     {
       "name": "M8",
-      "amplitude": 0.00757138,
-      "phase": 351.99769200000003
+      "amplitude": 0.014,
+      "phase": 269.86
     },
     {
       "name": "S4",
-      "amplitude": 0.00182942,
-      "phase": 312.325434
+      "amplitude": 0.002,
+      "phase": 271.17
     },
     {
       "name": "OO1",
-      "amplitude": 0.00302875,
-      "phase": 146.288724
+      "amplitude": 0.003,
+      "phase": 132
     },
     {
       "name": "S3",
-      "amplitude": 0.00061877,
-      "phase": 289.202081
+      "amplitude": 0,
+      "phase": 85.12
     },
     {
       "name": "MA2",
-      "amplitude": 0.08872612,
-      "phase": 139.340668
+      "amplitude": 0.013,
+      "phase": 99.73
     },
     {
       "name": "MB2",
-      "amplitude": 0.07141695,
-      "phase": 6.427822999999989
+      "amplitude": 0.006,
+      "phase": 134.85
     },
     {
       "name": "T3",
-      "amplitude": 0.00037108000000000003,
-      "phase": 85.777218
+      "amplitude": 0,
+      "phase": 227.75
     },
     {
       "name": "R3",
-      "amplitude": 0.00127456,
-      "phase": 128.89293199999997
+      "amplitude": 0.001,
+      "phase": 187.54
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0074990199999999995,
-      "phase": 132.575868
+      "amplitude": 0.008,
+      "phase": 125.06
     },
     {
       "name": "SGM",
-      "amplitude": 0.0016558200000000001,
-      "phase": 201.98565
+      "amplitude": 0.002,
+      "phase": 17.29
     },
     {
       "name": "3L2",
-      "amplitude": 0.00315647,
-      "phase": 34.094700999999986
+      "amplitude": 0.003,
+      "phase": 112.35
     },
     {
       "name": "3N2",
-      "amplitude": 0.0020638699999999998,
-      "phase": 9.252638999999988
+      "amplitude": 0.007,
+      "phase": 271.24
     },
     {
       "name": "2SM2",
-      "amplitude": 0.01793751,
-      "phase": 63.828783999999985
+      "amplitude": 0.018,
+      "phase": 45.05
     },
     {
       "name": "2MS6",
-      "amplitude": 0.042437579999999996,
-      "phase": 333.018303
+      "amplitude": 0.056,
+      "phase": 276.78
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00980921,
-      "phase": 283.587615
+      "amplitude": 0.012,
+      "phase": 327.64
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0061814899999999996,
-      "phase": 309.065056
+      "amplitude": 0.008,
+      "phase": 175.12
     }
   ],
   "epoch": {

--- a/data/ticon/platform_j6-j6-nld-rws.json
+++ b/data/ticon/platform_j6-j6-nld-rws.json
@@ -33,253 +33,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.66572972,
-      "phase": 187.318496
+      "amplitude": 0.687,
+      "phase": 170.21
     },
     {
       "name": "N2",
-      "amplitude": 0.12500178,
-      "phase": 166.920024
+      "amplitude": 0.13,
+      "phase": 149.77
     },
     {
       "name": "S2",
-      "amplitude": 0.2217654,
-      "phase": 238.816709
+      "amplitude": 0.228,
+      "phase": 221.09
     },
     {
       "name": "K2",
-      "amplitude": 0.057542369999999995,
-      "phase": 243.809854
+      "amplitude": 0.066,
+      "phase": 219.62
     },
     {
       "name": "2N2",
-      "amplitude": 0.01675149,
-      "phase": 147.46372099999996
+      "amplitude": 0.018,
+      "phase": 130.68
     },
     {
       "name": "S1",
-      "amplitude": 0.00660411,
-      "phase": 313.075697
+      "amplitude": 0.011,
+      "phase": 252.56
     },
     {
       "name": "K1",
-      "amplitude": 0.08177873999999999,
-      "phase": 329.026908
+      "amplitude": 0.082,
+      "phase": 319.99
     },
     {
       "name": "P1",
-      "amplitude": 0.025156019999999998,
-      "phase": 310.600887
+      "amplitude": 0.026,
+      "phase": 305.33
     },
     {
       "name": "O1",
-      "amplitude": 0.09101013999999999,
-      "phase": 163.61276299999997
+      "amplitude": 0.091,
+      "phase": 155.52
     },
     {
       "name": "Q1",
-      "amplitude": 0.03169889,
-      "phase": 107.60006399999997
+      "amplitude": 0.032,
+      "phase": 99.53
     },
     {
       "name": "M1",
-      "amplitude": 0.00195582,
-      "phase": 249.534763
+      "amplitude": 0.002,
+      "phase": 1.24
     },
     {
       "name": "M4",
-      "amplitude": 0.018746290000000002,
-      "phase": 298.053226
+      "amplitude": 0.022,
+      "phase": 261.13
     },
     {
       "name": "MM",
-      "amplitude": 0.01450629,
-      "phase": 194.800433
+      "amplitude": 0.015,
+      "phase": 192.25
     },
     {
       "name": "MF",
-      "amplitude": 0.014304760000000001,
-      "phase": 176.294178
+      "amplitude": 0.014,
+      "phase": 175.97
     },
     {
       "name": "SA",
-      "amplitude": 0.07713358000000001,
-      "phase": 227.637754
+      "amplitude": 0.086,
+      "phase": 223.05
     },
     {
       "name": "SSA",
-      "amplitude": 0.0211647,
-      "phase": 139.66631
+      "amplitude": 0.025,
+      "phase": 140.65
     },
     {
       "name": "T2",
-      "amplitude": 0.03967287,
-      "phase": 152.83381299999996
+      "amplitude": 0.012,
+      "phase": 208.86
     },
     {
       "name": "J1",
-      "amplitude": 0.004030290000000001,
-      "phase": 34.953220999999985
+      "amplitude": 0.004,
+      "phase": 26.03
     },
     {
       "name": "L2",
-      "amplitude": 0.033897119999999996,
-      "phase": 191.770887
+      "amplitude": 0.035,
+      "phase": 172.08
     },
     {
       "name": "R2",
-      "amplitude": 0.03238264,
-      "phase": 342.659636
+      "amplitude": 0.003,
+      "phase": 281.45
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00560489,
-      "phase": 59.050873000000024
+      "amplitude": 0.006,
+      "phase": 53.23
     },
     {
       "name": "MSF",
-      "amplitude": 0.00746958,
-      "phase": 251.451951
+      "amplitude": 0.007,
+      "phase": 251.25
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0029821199999999996,
-      "phase": 44.003011000000015
+      "amplitude": 0.003,
+      "phase": 40.65
     },
     {
       "name": "EP2",
-      "amplitude": 0.00590935,
-      "phase": 226.83823
+      "amplitude": 0.006,
+      "phase": 204.9
     },
     {
       "name": "M3",
-      "amplitude": 0.00499412,
-      "phase": 249.939977
+      "amplitude": 0.005,
+      "phase": 42.49
     },
     {
       "name": "MU2",
-      "amplitude": 0.023718379999999997,
-      "phase": 232.36688700000002
+      "amplitude": 0.025,
+      "phase": 216.08
     },
     {
       "name": "MTM",
-      "amplitude": 0.00360761,
-      "phase": 229.675732
+      "amplitude": 0.003,
+      "phase": 229.01
     },
     {
       "name": "NU2",
-      "amplitude": 0.02794773,
-      "phase": 157.38096599999994
+      "amplitude": 0.029,
+      "phase": 140.03
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.01447242,
-      "phase": 178.30066499999998
+      "amplitude": 0.016,
+      "phase": 158.8
     },
     {
       "name": "MN4",
-      "amplitude": 0.00789102,
-      "phase": 276.253266
+      "amplitude": 0.009,
+      "phase": 240.71
     },
     {
       "name": "MS4",
-      "amplitude": 0.01339034,
-      "phase": 332.638202
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.032982580000000004,
-      "phase": 315.598137
+      "amplitude": 0.015,
+      "phase": 296.79
     },
     {
       "name": "N4",
-      "amplitude": 0.0018967899999999998,
-      "phase": 251.192951
+      "amplitude": 0.002,
+      "phase": 217.52
     },
     {
       "name": "M6",
-      "amplitude": 0.01242394,
-      "phase": 234.868886
+      "amplitude": 0.016,
+      "phase": 177.78
     },
     {
       "name": "M8",
-      "amplitude": 0.00071621,
-      "phase": 311.177147
+      "amplitude": 0.002,
+      "phase": 219.86
     },
     {
       "name": "S4",
-      "amplitude": 0.00212737,
-      "phase": 48.087424
+      "amplitude": 0.002,
+      "phase": 15.04
     },
     {
       "name": "OO1",
-      "amplitude": 0.00254359,
-      "phase": 116.20098899999999
+      "amplitude": 0.003,
+      "phase": 97.05
     },
     {
       "name": "S3",
-      "amplitude": 0.00132692,
-      "phase": 218.018335
+      "amplitude": 0,
+      "phase": 72.11
     },
     {
       "name": "MA2",
-      "amplitude": 0.10935816000000001,
-      "phase": 160.61519599999997
+      "amplitude": 0.007,
+      "phase": 86.77
     },
     {
       "name": "MB2",
-      "amplitude": 0.10665332,
-      "phase": 26.195374000000015
+      "amplitude": 0.002,
+      "phase": 50.36
     },
     {
       "name": "T3",
-      "amplitude": 0.00028372,
-      "phase": 186.414242
+      "amplitude": 0.001,
+      "phase": 24.52
     },
     {
       "name": "R3",
-      "amplitude": 0.0038783800000000003,
-      "phase": 44.976223000000005
+      "amplitude": 0.004,
+      "phase": 106.01
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00646334,
-      "phase": 108.54396400000002
+      "amplitude": 0.007,
+      "phase": 101.64
     },
     {
       "name": "SGM",
-      "amplitude": 0.00291859,
-      "phase": 251.350863
+      "amplitude": 0.003,
+      "phase": 66.45
     },
     {
       "name": "3L2",
-      "amplitude": 0.00570743,
-      "phase": 15.403434000000004
+      "amplitude": 0.005,
+      "phase": 76.94
     },
     {
       "name": "3N2",
-      "amplitude": 0.00193165,
-      "phase": 328.960133
+      "amplitude": 0.005,
+      "phase": 279.38
     },
     {
       "name": "2SM2",
-      "amplitude": 0.011081289999999999,
-      "phase": 74.02799099999999
+      "amplitude": 0.011,
+      "phase": 54.19
     },
     {
       "name": "2MS6",
-      "amplitude": 0.010998270000000001,
-      "phase": 293.978872
+      "amplitude": 0.014,
+      "phase": 236.6
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0030963099999999997,
-      "phase": 106.904585
+      "amplitude": 0.004,
+      "phase": 147.99
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00377009,
-      "phase": 105.06652500000001
+      "amplitude": 0.005,
+      "phase": 330.03
     }
   ],
   "epoch": {

--- a/data/ticon/pogum-3950020-deu-wsv.json
+++ b/data/ticon/pogum-3950020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4772643098899862,
-      "phase": 317.4838365155624
+      "amplitude": 1.477,
+      "phase": 317.48
     },
     {
       "name": "N2",
-      "amplitude": 0.2331558107105924,
-      "phase": 295.00348860922577
+      "amplitude": 0.233,
+      "phase": 295
     },
     {
       "name": "S2",
-      "amplitude": 0.36538881519822447,
-      "phase": 31.75639220449625
+      "amplitude": 0.365,
+      "phase": 31.76
     },
     {
       "name": "K2",
-      "amplitude": 0.10914863509535376,
-      "phase": 27.74283482173837
+      "amplitude": 0.109,
+      "phase": 27.74
     },
     {
       "name": "2N2",
-      "amplitude": 0.025342986599508732,
-      "phase": 274.22265925039346
+      "amplitude": 0.025,
+      "phase": 274.22
     },
     {
       "name": "S1",
-      "amplitude": 0.015115794051591951,
-      "phase": 47.46400737340798
+      "amplitude": 0.015,
+      "phase": 47.46
     },
     {
       "name": "K1",
-      "amplitude": 0.07495636058510455,
-      "phase": 35.300125925274926
+      "amplitude": 0.075,
+      "phase": 35.3
     },
     {
       "name": "P1",
-      "amplitude": 0.03250871657617141,
-      "phase": 40.28121105281531
+      "amplitude": 0.033,
+      "phase": 40.28
     },
     {
       "name": "O1",
-      "amplitude": 0.09117086937567838,
-      "phase": 240.787151150392
+      "amplitude": 0.091,
+      "phase": 240.79
     },
     {
       "name": "Q1",
-      "amplitude": 0.0282556702796169,
-      "phase": 179.3438292933413
+      "amplitude": 0.028,
+      "phase": 179.34
     },
     {
       "name": "M1",
-      "amplitude": 0.0020822200291794883,
-      "phase": 91.54327660402782
+      "amplitude": 0.002,
+      "phase": 91.54
     },
     {
       "name": "M4",
-      "amplitude": 0.17269858043085673,
-      "phase": 100.04210722224286
+      "amplitude": 0.173,
+      "phase": 100.04
     },
     {
       "name": "MM",
-      "amplitude": 0.015846921160470723,
-      "phase": 147.23368366940554
+      "amplitude": 0.016,
+      "phase": 147.23
     },
     {
       "name": "MF",
-      "amplitude": 0.008121023092283316,
-      "phase": 139.1695035287163
+      "amplitude": 0.008,
+      "phase": 139.17
     },
     {
       "name": "SA",
-      "amplitude": 0.0847321317850776,
-      "phase": 221.38563256854772
+      "amplitude": 0.085,
+      "phase": 221.39
     },
     {
       "name": "SSA",
-      "amplitude": 0.039025227988946296,
-      "phase": 207.20123972661156
+      "amplitude": 0.039,
+      "phase": 207.2
     },
     {
       "name": "T2",
-      "amplitude": 0.023427829341074787,
-      "phase": 346.46488593810034
+      "amplitude": 0.023,
+      "phase": 346.46
     },
     {
       "name": "J1",
-      "amplitude": 0.002706193122354693,
-      "phase": 162.862552009296
+      "amplitude": 0.003,
+      "phase": 162.86
     },
     {
       "name": "L2",
-      "amplitude": 0.12876874868277952,
-      "phase": 330.73264558657263
+      "amplitude": 0.129,
+      "phase": 330.73
     },
     {
       "name": "R2",
-      "amplitude": 0.010508977242005384,
-      "phase": 225.0405924885509
+      "amplitude": 0.011,
+      "phase": 225.04
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005856968575277535,
-      "phase": 123.16702225001848
+      "amplitude": 0.006,
+      "phase": 123.17
     },
     {
       "name": "MSF",
-      "amplitude": 0.024371546303895514,
-      "phase": 56.02030706779465
+      "amplitude": 0.024,
+      "phase": 56.02
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007844155633770881,
-      "phase": 70.52693996009458
+      "amplitude": 0.008,
+      "phase": 70.53
     },
     {
       "name": "EP2",
-      "amplitude": 0.0383382365276013,
-      "phase": 21.374109422135405
+      "amplitude": 0.038,
+      "phase": 21.37
     },
     {
       "name": "M3",
-      "amplitude": 0.0034459206988172687,
-      "phase": 6.1442001960929815
+      "amplitude": 0.003,
+      "phase": 6.14
     },
     {
       "name": "MU2",
-      "amplitude": 0.17815232523740204,
-      "phase": 39.22514566898451
+      "amplitude": 0.178,
+      "phase": 39.23
     },
     {
       "name": "MTM",
-      "amplitude": 0.003901457313923276,
-      "phase": 260.6818123522262
+      "amplitude": 0.004,
+      "phase": 260.68
     },
     {
       "name": "NU2",
-      "amplitude": 0.09187667851926706,
-      "phase": 271.1819318418803
+      "amplitude": 0.092,
+      "phase": 271.18
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05999843867125826,
-      "phase": 330.61901950123854
+      "amplitude": 0.06,
+      "phase": 330.62
     },
     {
       "name": "MN4",
-      "amplitude": 0.05625886689434159,
-      "phase": 75.14634770309186
+      "amplitude": 0.056,
+      "phase": 75.15
     },
     {
       "name": "MS4",
-      "amplitude": 0.1016887905006604,
-      "phase": 179.90451089066892
+      "amplitude": 0.102,
+      "phase": 179.9
     },
     {
       "name": "N4",
-      "amplitude": 0.011010280627169916,
-      "phase": 54.11631806003862
+      "amplitude": 0.011,
+      "phase": 54.12
     },
     {
       "name": "M6",
-      "amplitude": 0.08412442590348865,
-      "phase": 304.27063307755253
+      "amplitude": 0.084,
+      "phase": 304.27
     },
     {
       "name": "M8",
-      "amplitude": 0.018927407807130012,
-      "phase": 104.19750980933384
+      "amplitude": 0.019,
+      "phase": 104.2
     },
     {
       "name": "S4",
-      "amplitude": 0.009691421041438036,
-      "phase": 332.1675435255816
+      "amplitude": 0.01,
+      "phase": 332.17
     },
     {
       "name": "OO1",
-      "amplitude": 0.003025674283104414,
-      "phase": 197.3520647985353
+      "amplitude": 0.003,
+      "phase": 197.35
     },
     {
       "name": "S3",
-      "amplitude": 0.0001762661458062352,
-      "phase": 339.25208520895785
+      "amplitude": 0,
+      "phase": 339.25
     },
     {
       "name": "MA2",
-      "amplitude": 0.0787342007876162,
-      "phase": 284.23703598082454
+      "amplitude": 0.079,
+      "phase": 284.24
     },
     {
       "name": "MB2",
-      "amplitude": 0.020511606676729154,
-      "phase": 222.7270951068473
+      "amplitude": 0.021,
+      "phase": 222.73
     },
     {
       "name": "T3",
-      "amplitude": 0.0007135109663021699,
-      "phase": 70.02222778536475
+      "amplitude": 0.001,
+      "phase": 70.02
     },
     {
       "name": "R3",
-      "amplitude": 0.0036400897164222423,
-      "phase": 14.840154465754779
+      "amplitude": 0.004,
+      "phase": 14.84
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005302586050006023,
-      "phase": 191.55788233657515
+      "amplitude": 0.005,
+      "phase": 191.56
     },
     {
       "name": "SGM",
-      "amplitude": 0.0032697155377361974,
-      "phase": 49.89250593701087
+      "amplitude": 0.003,
+      "phase": 49.89
     },
     {
       "name": "3L2",
-      "amplitude": 0.003980829944433985,
-      "phase": 221.38055070019175
+      "amplitude": 0.004,
+      "phase": 221.38
     },
     {
       "name": "3N2",
-      "amplitude": 0.016381899236002823,
-      "phase": 141.12473078146627
+      "amplitude": 0.016,
+      "phase": 141.12
     },
     {
       "name": "2SM2",
-      "amplitude": 0.038924983151328016,
-      "phase": 253.817774586983
+      "amplitude": 0.039,
+      "phase": 253.82
     },
     {
       "name": "2MS6",
-      "amplitude": 0.07962600422367523,
-      "phase": 12.1611046182623
+      "amplitude": 0.08,
+      "phase": 12.16
     },
     {
       "name": "2MK5",
-      "amplitude": 0.012240460102669458,
-      "phase": 337.6969620767488
+      "amplitude": 0.012,
+      "phase": 337.7
     },
     {
       "name": "2MO5",
-      "amplitude": 0.008720631836212597,
-      "phase": 181.77108982071906
+      "amplitude": 0.009,
+      "phase": 181.77
     }
   ],
   "epoch": {

--- a/data/ticon/rechtenfleth-4970030-deu-wsv.json
+++ b/data/ticon/rechtenfleth-4970030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.7350474281702764,
-      "phase": 1.6787298724932498
+      "amplitude": 1.735,
+      "phase": 1.68
     },
     {
       "name": "N2",
-      "amplitude": 0.26904768650593247,
-      "phase": 337.9291446936677
+      "amplitude": 0.269,
+      "phase": 337.93
     },
     {
       "name": "S2",
-      "amplitude": 0.4377743251992102,
-      "phase": 79.01997079870819
+      "amplitude": 0.438,
+      "phase": 79.02
     },
     {
       "name": "K2",
-      "amplitude": 0.12795215390397593,
-      "phase": 76.97451888791977
+      "amplitude": 0.128,
+      "phase": 76.97
     },
     {
       "name": "2N2",
-      "amplitude": 0.02801462650882308,
-      "phase": 316.0171598675168
+      "amplitude": 0.028,
+      "phase": 316.02
     },
     {
       "name": "S1",
-      "amplitude": 0.016968854734136986,
-      "phase": 62.76067748665798
+      "amplitude": 0.017,
+      "phase": 62.76
     },
     {
       "name": "K1",
-      "amplitude": 0.07064228364624414,
-      "phase": 52.17792482448209
+      "amplitude": 0.071,
+      "phase": 52.18
     },
     {
       "name": "P1",
-      "amplitude": 0.031621832875817955,
-      "phase": 58.38400947030141
+      "amplitude": 0.032,
+      "phase": 58.38
     },
     {
       "name": "O1",
-      "amplitude": 0.09014625861523755,
-      "phase": 259.80810444864017
+      "amplitude": 0.09,
+      "phase": 259.81
     },
     {
       "name": "Q1",
-      "amplitude": 0.026419052784876256,
-      "phase": 200.84591610280177
+      "amplitude": 0.026,
+      "phase": 200.85
     },
     {
       "name": "M1",
-      "amplitude": 0.0019894894417102228,
-      "phase": 118.86630248192682
+      "amplitude": 0.002,
+      "phase": 118.87
     },
     {
       "name": "M4",
-      "amplitude": 0.11994163365380262,
-      "phase": 188.5077880965138
+      "amplitude": 0.12,
+      "phase": 188.51
     },
     {
       "name": "MM",
-      "amplitude": 0.019564226236469598,
-      "phase": 150.04202000633086
+      "amplitude": 0.02,
+      "phase": 150.04
     },
     {
       "name": "MF",
-      "amplitude": 0.007595682390513887,
-      "phase": 112.16931763379563
+      "amplitude": 0.008,
+      "phase": 112.17
     },
     {
       "name": "SA",
-      "amplitude": 0.06888763181661867,
-      "phase": 235.12494482014108
+      "amplitude": 0.069,
+      "phase": 235.12
     },
     {
       "name": "SSA",
-      "amplitude": 0.04505446316839733,
-      "phase": 220.85908817586255
+      "amplitude": 0.045,
+      "phase": 220.86
     },
     {
       "name": "T2",
-      "amplitude": 0.025387883554542225,
-      "phase": 53.842439758461296
+      "amplitude": 0.025,
+      "phase": 53.84
     },
     {
       "name": "J1",
-      "amplitude": 0.0030027162136152096,
-      "phase": 186.9746664667074
+      "amplitude": 0.003,
+      "phase": 186.97
     },
     {
       "name": "L2",
-      "amplitude": 0.15299552583273612,
-      "phase": 16.87671188538144
+      "amplitude": 0.153,
+      "phase": 16.88
     },
     {
       "name": "R2",
-      "amplitude": 0.0006270214265841583,
-      "phase": 349.52333940209655
+      "amplitude": 0.001,
+      "phase": 349.52
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005693941231941653,
-      "phase": 145.52922217342672
+      "amplitude": 0.006,
+      "phase": 145.53
     },
     {
       "name": "MSF",
-      "amplitude": 0.03336000688224275,
-      "phase": 68.83083955219126
+      "amplitude": 0.033,
+      "phase": 68.83
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007670237158585127,
-      "phase": 54.679930518256526
+      "amplitude": 0.008,
+      "phase": 54.68
     },
     {
       "name": "EP2",
-      "amplitude": 0.04606073298335123,
-      "phase": 61.17633425309066
+      "amplitude": 0.046,
+      "phase": 61.18
     },
     {
       "name": "M3",
-      "amplitude": 0.004043216324306114,
-      "phase": 68.32353897126
+      "amplitude": 0.004,
+      "phase": 68.32
     },
     {
       "name": "MU2",
-      "amplitude": 0.21929178645611716,
-      "phase": 82.86846952249243
+      "amplitude": 0.219,
+      "phase": 82.87
     },
     {
       "name": "MTM",
-      "amplitude": 0.0030344966761891904,
-      "phase": 214.43803695360572
+      "amplitude": 0.003,
+      "phase": 214.44
     },
     {
       "name": "NU2",
-      "amplitude": 0.10904835798063156,
-      "phase": 314.40049992175113
+      "amplitude": 0.109,
+      "phase": 314.4
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07377983915148241,
-      "phase": 15.039579577271525
+      "amplitude": 0.074,
+      "phase": 15.04
     },
     {
       "name": "MN4",
-      "amplitude": 0.036468238271755826,
-      "phase": 166.5675993779647
+      "amplitude": 0.036,
+      "phase": 166.57
     },
     {
       "name": "MS4",
-      "amplitude": 0.08731888784012252,
-      "phase": 272.4717685205694
+      "amplitude": 0.087,
+      "phase": 272.47
     },
     {
       "name": "N4",
-      "amplitude": 0.007335756957080298,
-      "phase": 148.33191978446837
+      "amplitude": 0.007,
+      "phase": 148.33
     },
     {
       "name": "M6",
-      "amplitude": 0.07681264971664396,
-      "phase": 59.26834485420966
+      "amplitude": 0.077,
+      "phase": 59.27
     },
     {
       "name": "M8",
-      "amplitude": 0.016553096715050127,
-      "phase": 328.5031779247041
+      "amplitude": 0.017,
+      "phase": 328.5
     },
     {
       "name": "S4",
-      "amplitude": 0.012532553183057859,
-      "phase": 60.254107484323356
+      "amplitude": 0.013,
+      "phase": 60.25
     },
     {
       "name": "OO1",
-      "amplitude": 0.002904211162838575,
-      "phase": 204.162087605556
+      "amplitude": 0.003,
+      "phase": 204.16
     },
     {
       "name": "S3",
-      "amplitude": 0.0004957201021579354,
-      "phase": 286.921337951126
+      "amplitude": 0,
+      "phase": 286.92
     },
     {
       "name": "MA2",
-      "amplitude": 0.05379982558792494,
-      "phase": 320.24848852332656
+      "amplitude": 0.054,
+      "phase": 320.25
     },
     {
       "name": "MB2",
-      "amplitude": 0.017624511930411226,
-      "phase": 82.0175330653297
+      "amplitude": 0.018,
+      "phase": 82.02
     },
     {
       "name": "T3",
-      "amplitude": 0.00008339337990026615,
-      "phase": 156.71622912515875
+      "amplitude": 0,
+      "phase": 156.72
     },
     {
       "name": "R3",
-      "amplitude": 0.004108424651818026,
-      "phase": 68.18384911841287
+      "amplitude": 0.004,
+      "phase": 68.18
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005868055690527541,
-      "phase": 199.13557985834788
+      "amplitude": 0.006,
+      "phase": 199.14
     },
     {
       "name": "SGM",
-      "amplitude": 0.00384349897916902,
-      "phase": 31.87186885249264
+      "amplitude": 0.004,
+      "phase": 31.87
     },
     {
       "name": "3L2",
-      "amplitude": 0.004041977951238672,
-      "phase": 252.23978568270843
+      "amplitude": 0.004,
+      "phase": 252.24
     },
     {
       "name": "3N2",
-      "amplitude": 0.02346649437269697,
-      "phase": 158.70374919856158
+      "amplitude": 0.023,
+      "phase": 158.7
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04716713843671897,
-      "phase": 300.0583153334381
+      "amplitude": 0.047,
+      "phase": 300.06
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08280275065410131,
-      "phase": 131.09120754137564
+      "amplitude": 0.083,
+      "phase": 131.09
     },
     {
       "name": "2MK5",
-      "amplitude": 0.010944758494396384,
-      "phase": 60.455078679779604
+      "amplitude": 0.011,
+      "phase": 60.46
     },
     {
       "name": "2MO5",
-      "amplitude": 0.007042084895695178,
-      "phase": 249.50481538963913
+      "amplitude": 0.007,
+      "phase": 249.5
     }
   ],
   "epoch": {

--- a/data/ticon/reithrne-4960040-deu-wsv.json
+++ b/data/ticon/reithrne-4960040-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.1153348796089824,
-      "phase": 65.32784231030905
+      "amplitude": 1.115,
+      "phase": 65.33
     },
     {
       "name": "N2",
-      "amplitude": 0.16554252636108463,
-      "phase": 41.7594860617624
+      "amplitude": 0.166,
+      "phase": 41.76
     },
     {
       "name": "S2",
-      "amplitude": 0.2540028205989443,
-      "phase": 147.49552925108185
+      "amplitude": 0.254,
+      "phase": 147.5
     },
     {
       "name": "K2",
-      "amplitude": 0.07589491679264204,
-      "phase": 146.124906083015
+      "amplitude": 0.076,
+      "phase": 146.12
     },
     {
       "name": "2N2",
-      "amplitude": 0.015462799134865727,
-      "phase": 22.801273837247948
+      "amplitude": 0.015,
+      "phase": 22.8
     },
     {
       "name": "S1",
-      "amplitude": 0.0139304873946813,
-      "phase": 78.56168514708156
+      "amplitude": 0.014,
+      "phase": 78.56
     },
     {
       "name": "K1",
-      "amplitude": 0.058350938044381774,
-      "phase": 97.21050420715062
+      "amplitude": 0.058,
+      "phase": 97.21
     },
     {
       "name": "P1",
-      "amplitude": 0.02014148987725273,
-      "phase": 95.82713332937078
+      "amplitude": 0.02,
+      "phase": 95.83
     },
     {
       "name": "O1",
-      "amplitude": 0.07156061310939833,
-      "phase": 303.74062497763344
+      "amplitude": 0.072,
+      "phase": 303.74
     },
     {
       "name": "Q1",
-      "amplitude": 0.01850596456694332,
-      "phase": 240.92233573722723
+      "amplitude": 0.019,
+      "phase": 240.92
     },
     {
       "name": "M1",
-      "amplitude": 0.001740692796235151,
-      "phase": 163.69193149082616
+      "amplitude": 0.002,
+      "phase": 163.69
     },
     {
       "name": "M4",
-      "amplitude": 0.1093938253997494,
-      "phase": 64.21803344149629
+      "amplitude": 0.109,
+      "phase": 64.22
     },
     {
       "name": "MM",
-      "amplitude": 0.01841390831054576,
-      "phase": 54.10116249945861
+      "amplitude": 0.018,
+      "phase": 54.1
     },
     {
       "name": "MF",
-      "amplitude": 0.02215316618175637,
-      "phase": 81.76636716142264
+      "amplitude": 0.022,
+      "phase": 81.77
     },
     {
       "name": "SA",
-      "amplitude": 0.1280395899859624,
-      "phase": 298.36576047989575
+      "amplitude": 0.128,
+      "phase": 298.37
     },
     {
       "name": "SSA",
-      "amplitude": 0.05582466758052484,
-      "phase": 239.10167701932158
+      "amplitude": 0.056,
+      "phase": 239.1
     },
     {
       "name": "T2",
-      "amplitude": 0.012523024648504568,
-      "phase": 111.4944881231545
+      "amplitude": 0.013,
+      "phase": 111.49
     },
     {
       "name": "J1",
-      "amplitude": 0.004648310404862661,
-      "phase": 226.1608237383155
+      "amplitude": 0.005,
+      "phase": 226.16
     },
     {
       "name": "L2",
-      "amplitude": 0.10746548995339592,
-      "phase": 79.11965792209287
+      "amplitude": 0.107,
+      "phase": 79.12
     },
     {
       "name": "R2",
-      "amplitude": 0.007351330703223719,
-      "phase": 218.96460108984664
+      "amplitude": 0.007,
+      "phase": 218.96
     },
     {
       "name": "2Q1",
-      "amplitude": 0.002984161833897395,
-      "phase": 183.4030559430531
+      "amplitude": 0.003,
+      "phase": 183.4
     },
     {
       "name": "MSF",
-      "amplitude": 0.10057332864363043,
-      "phase": 67.37277195371291
+      "amplitude": 0.101,
+      "phase": 67.37
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007460680225034641,
-      "phase": 353.19725930998004
+      "amplitude": 0.007,
+      "phase": 353.2
     },
     {
       "name": "EP2",
-      "amplitude": 0.03444215683752772,
-      "phase": 124.44420796842553
+      "amplitude": 0.034,
+      "phase": 124.44
     },
     {
       "name": "M3",
-      "amplitude": 0.003136665275641985,
-      "phase": 146.67982233069733
+      "amplitude": 0.003,
+      "phase": 146.68
     },
     {
       "name": "MU2",
-      "amplitude": 0.17040397812960248,
-      "phase": 149.54792556466805
+      "amplitude": 0.17,
+      "phase": 149.55
     },
     {
       "name": "MTM",
-      "amplitude": 0.0030288768010167974,
-      "phase": 128.44851615216214
+      "amplitude": 0.003,
+      "phase": 128.45
     },
     {
       "name": "NU2",
-      "amplitude": 0.0802589438155837,
-      "phase": 14.828662043430427
+      "amplitude": 0.08,
+      "phase": 14.83
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.048971786299907526,
-      "phase": 80.95487286093436
+      "amplitude": 0.049,
+      "phase": 80.95
     },
     {
       "name": "MN4",
-      "amplitude": 0.03569913196524818,
-      "phase": 38.569339577718154
+      "amplitude": 0.036,
+      "phase": 38.57
     },
     {
       "name": "MS4",
-      "amplitude": 0.05563466782320821,
-      "phase": 141.43397370792655
+      "amplitude": 0.056,
+      "phase": 141.43
     },
     {
       "name": "N4",
-      "amplitude": 0.006933830962178167,
-      "phase": 19.36129860105524
+      "amplitude": 0.007,
+      "phase": 19.36
     },
     {
       "name": "M6",
-      "amplitude": 0.025203954441510017,
-      "phase": 187.64842934652052
+      "amplitude": 0.025,
+      "phase": 187.65
     },
     {
       "name": "M8",
-      "amplitude": 0.008014079241967505,
-      "phase": 186.19431946822988
+      "amplitude": 0.008,
+      "phase": 186.19
     },
     {
       "name": "S4",
-      "amplitude": 0.004260713444741551,
-      "phase": 301.27340954746956
+      "amplitude": 0.004,
+      "phase": 301.27
     },
     {
       "name": "OO1",
-      "amplitude": 0.0022311397357919253,
-      "phase": 263.90649684752987
+      "amplitude": 0.002,
+      "phase": 263.91
     },
     {
       "name": "S3",
-      "amplitude": 0.002200952721678422,
-      "phase": 64.67826140961489
+      "amplitude": 0.002,
+      "phase": 64.68
     },
     {
       "name": "MA2",
-      "amplitude": 0.03914785328683007,
-      "phase": 6.755738582476511
+      "amplitude": 0.039,
+      "phase": 6.76
     },
     {
       "name": "MB2",
-      "amplitude": 0.03814607243160374,
-      "phase": 214.7854688380916
+      "amplitude": 0.038,
+      "phase": 214.79
     },
     {
       "name": "T3",
-      "amplitude": 0.0014443379782580266,
-      "phase": 131.85307080378584
+      "amplitude": 0.001,
+      "phase": 131.85
     },
     {
       "name": "R3",
-      "amplitude": 0.0044912108623940865,
-      "phase": 139.69532522686575
+      "amplitude": 0.004,
+      "phase": 139.7
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004711366005710101,
-      "phase": 249.01010537781002
+      "amplitude": 0.005,
+      "phase": 249.01
     },
     {
       "name": "SGM",
-      "amplitude": 0.006319327712276936,
-      "phase": 73.92664884280475
+      "amplitude": 0.006,
+      "phase": 73.93
     },
     {
       "name": "3L2",
-      "amplitude": 0.0029958418347437203,
-      "phase": 343.83974816475757
+      "amplitude": 0.003,
+      "phase": 343.84
     },
     {
       "name": "3N2",
-      "amplitude": 0.02129676454819761,
-      "phase": 210.27225384499633
+      "amplitude": 0.021,
+      "phase": 210.27
     },
     {
       "name": "2SM2",
-      "amplitude": 0.030098912531491908,
-      "phase": 11.493097313129567
+      "amplitude": 0.03,
+      "phase": 11.49
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02368618003980442,
-      "phase": 261.96183091218427
+      "amplitude": 0.024,
+      "phase": 261.96
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0011840202504133698,
-      "phase": 141.97561832241377
+      "amplitude": 0.001,
+      "phase": 141.98
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0020476752771435756,
-      "phase": 315.3824161953329
+      "amplitude": 0.002,
+      "phase": 315.38
     }
   ],
   "epoch": {

--- a/data/ticon/ritterhude-4940030-deu-wsv.json
+++ b/data/ticon/ritterhude-4940030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2063362301714984,
-      "phase": 57.625106696814385
+      "amplitude": 1.206,
+      "phase": 57.63
     },
     {
       "name": "N2",
-      "amplitude": 0.1750178884964473,
-      "phase": 34.53252682397505
+      "amplitude": 0.175,
+      "phase": 34.53
     },
     {
       "name": "S2",
-      "amplitude": 0.27760843968254156,
-      "phase": 140.42409470785276
+      "amplitude": 0.278,
+      "phase": 140.42
     },
     {
       "name": "K2",
-      "amplitude": 0.085193486124653,
-      "phase": 142.01249105866975
+      "amplitude": 0.085,
+      "phase": 142.01
     },
     {
       "name": "2N2",
-      "amplitude": 0.016910403788842846,
-      "phase": 18.32375114348929
+      "amplitude": 0.017,
+      "phase": 18.32
     },
     {
       "name": "S1",
-      "amplitude": 0.018833352103133253,
-      "phase": 52.44945540594273
+      "amplitude": 0.019,
+      "phase": 52.45
     },
     {
       "name": "K1",
-      "amplitude": 0.04534768293653361,
-      "phase": 84.55008531473987
+      "amplitude": 0.045,
+      "phase": 84.55
     },
     {
       "name": "P1",
-      "amplitude": 0.017229311415445484,
-      "phase": 110.55749220172476
+      "amplitude": 0.017,
+      "phase": 110.56
     },
     {
       "name": "O1",
-      "amplitude": 0.057829904352749234,
-      "phase": 294.7053208297074
+      "amplitude": 0.058,
+      "phase": 294.71
     },
     {
       "name": "Q1",
-      "amplitude": 0.013833515965256723,
-      "phase": 229.10434272275802
+      "amplitude": 0.014,
+      "phase": 229.1
     },
     {
       "name": "M1",
-      "amplitude": 0.0017268669979973528,
-      "phase": 165.53338128146152
+      "amplitude": 0.002,
+      "phase": 165.53
     },
     {
       "name": "M4",
-      "amplitude": 0.19217211336270687,
-      "phase": 47.31657079582618
+      "amplitude": 0.192,
+      "phase": 47.32
     },
     {
       "name": "MM",
-      "amplitude": 0.007472417993583714,
-      "phase": 65.8803162419394
+      "amplitude": 0.007,
+      "phase": 65.88
     },
     {
       "name": "MF",
-      "amplitude": 0.01763198148977465,
-      "phase": 107.19003081828248
+      "amplitude": 0.018,
+      "phase": 107.19
     },
     {
       "name": "SA",
-      "amplitude": 0.09672889435580892,
-      "phase": 300.18766554422933
+      "amplitude": 0.097,
+      "phase": 300.19
     },
     {
       "name": "SSA",
-      "amplitude": 0.052178636711292616,
-      "phase": 239.6301098458752
+      "amplitude": 0.052,
+      "phase": 239.63
     },
     {
       "name": "T2",
-      "amplitude": 0.006662428070163448,
-      "phase": 61.34215680932601
+      "amplitude": 0.007,
+      "phase": 61.34
     },
     {
       "name": "J1",
-      "amplitude": 0.0018365419128632213,
-      "phase": 263.0746835358014
+      "amplitude": 0.002,
+      "phase": 263.07
     },
     {
       "name": "L2",
-      "amplitude": 0.11975175736203625,
-      "phase": 72.76582312699458
+      "amplitude": 0.12,
+      "phase": 72.77
     },
     {
       "name": "R2",
-      "amplitude": 0.013462339453406243,
-      "phase": 203.60512919619748
+      "amplitude": 0.013,
+      "phase": 203.61
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0022727148016591808,
-      "phase": 151.63384458849407
+      "amplitude": 0.002,
+      "phase": 151.63
     },
     {
       "name": "MSF",
-      "amplitude": 0.06312632330242442,
-      "phase": 67.3788099722878
+      "amplitude": 0.063,
+      "phase": 67.38
     },
     {
       "name": "MSQM",
-      "amplitude": 0.006228898720102133,
-      "phase": 346.10945546048504
+      "amplitude": 0.006,
+      "phase": 346.11
     },
     {
       "name": "EP2",
-      "amplitude": 0.03910337154934888,
-      "phase": 117.23061903193923
+      "amplitude": 0.039,
+      "phase": 117.23
     },
     {
       "name": "M3",
-      "amplitude": 0.003319234366957278,
-      "phase": 145.96665996574404
+      "amplitude": 0.003,
+      "phase": 145.97
     },
     {
       "name": "MU2",
-      "amplitude": 0.1905455751992866,
-      "phase": 141.5162270793993
+      "amplitude": 0.191,
+      "phase": 141.52
     },
     {
       "name": "MTM",
-      "amplitude": 0.0027317705534907776,
-      "phase": 171.66991480801596
+      "amplitude": 0.003,
+      "phase": 171.67
     },
     {
       "name": "NU2",
-      "amplitude": 0.08418420320729894,
-      "phase": 8.918621460560132
+      "amplitude": 0.084,
+      "phase": 8.92
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05665465022333971,
-      "phase": 75.24783510376119
+      "amplitude": 0.057,
+      "phase": 75.25
     },
     {
       "name": "MN4",
-      "amplitude": 0.05910846852092669,
-      "phase": 21.52775094821027
+      "amplitude": 0.059,
+      "phase": 21.53
     },
     {
       "name": "MS4",
-      "amplitude": 0.10236478359469597,
-      "phase": 125.3725484069584
+      "amplitude": 0.102,
+      "phase": 125.37
     },
     {
       "name": "N4",
-      "amplitude": 0.011418124078155735,
-      "phase": 7.9046797629751495
+      "amplitude": 0.011,
+      "phase": 7.9
     },
     {
       "name": "M6",
-      "amplitude": 0.019638724866097586,
-      "phase": 305.1472719764991
+      "amplitude": 0.02,
+      "phase": 305.15
     },
     {
       "name": "M8",
-      "amplitude": 0.011958595425630198,
-      "phase": 233.65441929177786
+      "amplitude": 0.012,
+      "phase": 233.65
     },
     {
       "name": "S4",
-      "amplitude": 0.008896053326751521,
-      "phase": 292.5785873255511
+      "amplitude": 0.009,
+      "phase": 292.58
     },
     {
       "name": "OO1",
-      "amplitude": 0.0018958764410954496,
-      "phase": 295.564194795597
+      "amplitude": 0.002,
+      "phase": 295.56
     },
     {
       "name": "S3",
-      "amplitude": 0.0020219781384595084,
-      "phase": 78.65129204457105
+      "amplitude": 0.002,
+      "phase": 78.65
     },
     {
       "name": "MA2",
-      "amplitude": 0.08377888167812436,
-      "phase": 347.4830788580559
+      "amplitude": 0.084,
+      "phase": 347.48
     },
     {
       "name": "MB2",
-      "amplitude": 0.061487187644320034,
-      "phase": 212.41734268001719
+      "amplitude": 0.061,
+      "phase": 212.42
     },
     {
       "name": "T3",
-      "amplitude": 0.001087820194599233,
-      "phase": 161.85065998733035
+      "amplitude": 0.001,
+      "phase": 161.85
     },
     {
       "name": "R3",
-      "amplitude": 0.007624296905691432,
-      "phase": 107.47338923883035
+      "amplitude": 0.008,
+      "phase": 107.47
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005085216295844522,
-      "phase": 243.64515146288485
+      "amplitude": 0.005,
+      "phase": 243.65
     },
     {
       "name": "SGM",
-      "amplitude": 0.009280591501195465,
-      "phase": 66.19539375906976
+      "amplitude": 0.009,
+      "phase": 66.2
     },
     {
       "name": "3L2",
-      "amplitude": 0.0033829225667506998,
-      "phase": 330.614513086667
+      "amplitude": 0.003,
+      "phase": 330.61
     },
     {
       "name": "3N2",
-      "amplitude": 0.02569212283258432,
-      "phase": 184.1209245663037
+      "amplitude": 0.026,
+      "phase": 184.12
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03503158813066189,
-      "phase": 2.4799421835930957
+      "amplitude": 0.035,
+      "phase": 2.48
     },
     {
       "name": "2MS6",
-      "amplitude": 0.023813125225014,
-      "phase": 22.31608091132688
+      "amplitude": 0.024,
+      "phase": 22.32
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00547276933984651,
-      "phase": 36.3457587166215
+      "amplitude": 0.005,
+      "phase": 36.35
     },
     {
       "name": "2MO5",
-      "amplitude": 0.007656757211483132,
-      "phase": 239.10010439601808
+      "amplitude": 0.008,
+      "phase": 239.1
     }
   ],
   "epoch": {

--- a/data/ticon/robbensdsteert-9460010-deu-wsv.json
+++ b/data/ticon/robbensdsteert-9460010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.6029240584279099,
-      "phase": 335.6639133536355
+      "amplitude": 1.603,
+      "phase": 335.66
     },
     {
       "name": "N2",
-      "amplitude": 0.2527401503725191,
-      "phase": 310.9456157028209
+      "amplitude": 0.253,
+      "phase": 310.95
     },
     {
       "name": "S2",
-      "amplitude": 0.4181463356290498,
-      "phase": 48.453360277511024
+      "amplitude": 0.418,
+      "phase": 48.45
     },
     {
       "name": "K2",
-      "amplitude": 0.12352636786456042,
-      "phase": 45.72693447174595
+      "amplitude": 0.124,
+      "phase": 45.73
     },
     {
       "name": "2N2",
-      "amplitude": 0.02784672207934182,
-      "phase": 289.82864022982153
+      "amplitude": 0.028,
+      "phase": 289.83
     },
     {
       "name": "S1",
-      "amplitude": 0.014117877681708564,
-      "phase": 38.21738683865135
+      "amplitude": 0.014,
+      "phase": 38.22
     },
     {
       "name": "K1",
-      "amplitude": 0.07202738379897582,
-      "phase": 35.82198801078175
+      "amplitude": 0.072,
+      "phase": 35.82
     },
     {
       "name": "P1",
-      "amplitude": 0.030905293899366252,
-      "phase": 41.13596366491731
+      "amplitude": 0.031,
+      "phase": 41.14
     },
     {
       "name": "O1",
-      "amplitude": 0.09423076143395011,
-      "phase": 244.64170303823414
+      "amplitude": 0.094,
+      "phase": 244.64
     },
     {
       "name": "Q1",
-      "amplitude": 0.029191250524334727,
-      "phase": 186.03370122521608
+      "amplitude": 0.029,
+      "phase": 186.03
     },
     {
       "name": "M1",
-      "amplitude": 0.0018886496469839636,
-      "phase": 107.85788136309941
+      "amplitude": 0.002,
+      "phase": 107.86
     },
     {
       "name": "M4",
-      "amplitude": 0.10278597945208351,
-      "phase": 140.24244691973217
+      "amplitude": 0.103,
+      "phase": 140.24
     },
     {
       "name": "MM",
-      "amplitude": 0.023954796544211853,
-      "phase": 168.32363819527222
+      "amplitude": 0.024,
+      "phase": 168.32
     },
     {
       "name": "MF",
-      "amplitude": 0.009030299038909647,
-      "phase": 152.9480574503866
+      "amplitude": 0.009,
+      "phase": 152.95
     },
     {
       "name": "SA",
-      "amplitude": 0.09480912615315815,
-      "phase": 225.12744747054418
+      "amplitude": 0.095,
+      "phase": 225.13
     },
     {
       "name": "SSA",
-      "amplitude": 0.04101893064755058,
-      "phase": 211.9753312459818
+      "amplitude": 0.041,
+      "phase": 211.98
     },
     {
       "name": "T2",
-      "amplitude": 0.023530541836642972,
-      "phase": 23.25002974753005
+      "amplitude": 0.024,
+      "phase": 23.25
     },
     {
       "name": "J1",
-      "amplitude": 0.0021778518562719095,
-      "phase": 164.29059178435284
+      "amplitude": 0.002,
+      "phase": 164.29
     },
     {
       "name": "L2",
-      "amplitude": 0.13142831989170392,
-      "phase": 351.9332715862318
+      "amplitude": 0.131,
+      "phase": 351.93
     },
     {
       "name": "R2",
-      "amplitude": 0.0024898844393079376,
-      "phase": 333.54050559970443
+      "amplitude": 0.002,
+      "phase": 333.54
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006254428765148954,
-      "phase": 128.90818294739472
+      "amplitude": 0.006,
+      "phase": 128.91
     },
     {
       "name": "MSF",
-      "amplitude": 0.00985370638137962,
-      "phase": 55.6181214542691
+      "amplitude": 0.01,
+      "phase": 55.62
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007431889799586537,
-      "phase": 57.085543751078035
+      "amplitude": 0.007,
+      "phase": 57.09
     },
     {
       "name": "EP2",
-      "amplitude": 0.0381145921718454,
-      "phase": 36.76832318322084
+      "amplitude": 0.038,
+      "phase": 36.77
     },
     {
       "name": "M3",
-      "amplitude": 0.004195579435822535,
-      "phase": 16.67692689464377
+      "amplitude": 0.004,
+      "phase": 16.68
     },
     {
       "name": "MU2",
-      "amplitude": 0.17289179431222734,
-      "phase": 58.63201698392925
+      "amplitude": 0.173,
+      "phase": 58.63
     },
     {
       "name": "MTM",
-      "amplitude": 0.006665202748479835,
-      "phase": 243.88261577674265
+      "amplitude": 0.007,
+      "phase": 243.88
     },
     {
       "name": "NU2",
-      "amplitude": 0.09435828065298746,
-      "phase": 292.4378913748484
+      "amplitude": 0.094,
+      "phase": 292.44
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06340531395644645,
-      "phase": 347.17894892369526
+      "amplitude": 0.063,
+      "phase": 347.18
     },
     {
       "name": "MN4",
-      "amplitude": 0.03141380645556924,
-      "phase": 119.91219886194773
+      "amplitude": 0.031,
+      "phase": 119.91
     },
     {
       "name": "MS4",
-      "amplitude": 0.07430531109854815,
-      "phase": 221.92392020060709
+      "amplitude": 0.074,
+      "phase": 221.92
     },
     {
       "name": "N4",
-      "amplitude": 0.006788559137592159,
-      "phase": 100.63627078762835
+      "amplitude": 0.007,
+      "phase": 100.64
     },
     {
       "name": "M6",
-      "amplitude": 0.05323545417916865,
-      "phase": 340.0967295257525
+      "amplitude": 0.053,
+      "phase": 340.1
     },
     {
       "name": "M8",
-      "amplitude": 0.010791519204637426,
-      "phase": 224.14484710963376
+      "amplitude": 0.011,
+      "phase": 224.14
     },
     {
       "name": "S4",
-      "amplitude": 0.01049633252869626,
-      "phase": 1.5054491394896559
+      "amplitude": 0.01,
+      "phase": 1.51
     },
     {
       "name": "OO1",
-      "amplitude": 0.0027338677033567627,
-      "phase": 200.15257952931904
+      "amplitude": 0.003,
+      "phase": 200.15
     },
     {
       "name": "S3",
-      "amplitude": 0.0006913275650525475,
-      "phase": 235.87034751754575
+      "amplitude": 0.001,
+      "phase": 235.87
     },
     {
       "name": "MA2",
-      "amplitude": 0.059551817109436474,
-      "phase": 286.2673061830446
+      "amplitude": 0.06,
+      "phase": 286.27
     },
     {
       "name": "MB2",
-      "amplitude": 0.018394660605655616,
-      "phase": 54.61630554606057
+      "amplitude": 0.018,
+      "phase": 54.62
     },
     {
       "name": "T3",
-      "amplitude": 0.0003726521505025961,
-      "phase": 132.41980887912416
+      "amplitude": 0,
+      "phase": 132.42
     },
     {
       "name": "R3",
-      "amplitude": 0.003345750245388026,
-      "phase": 44.546684683913725
+      "amplitude": 0.003,
+      "phase": 44.55
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005882221712793396,
-      "phase": 192.04822344311992
+      "amplitude": 0.006,
+      "phase": 192.05
     },
     {
       "name": "SGM",
-      "amplitude": 0.0023039963834530328,
-      "phase": 52.17907668222756
+      "amplitude": 0.002,
+      "phase": 52.18
     },
     {
       "name": "3L2",
-      "amplitude": 0.004497154610369545,
-      "phase": 229.91771756561172
+      "amplitude": 0.004,
+      "phase": 229.92
     },
     {
       "name": "3N2",
-      "amplitude": 0.020861226968766244,
-      "phase": 142.6170946320059
+      "amplitude": 0.021,
+      "phase": 142.62
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04213012300007864,
-      "phase": 270.20670240354036
+      "amplitude": 0.042,
+      "phase": 270.21
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05817259004058268,
-      "phase": 49.51700964809345
+      "amplitude": 0.058,
+      "phase": 49.52
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00735210867734717,
-      "phase": 350.58082124443047
+      "amplitude": 0.007,
+      "phase": 350.58
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00437578789410277,
-      "phase": 176.72696233212287
+      "amplitude": 0.004,
+      "phase": 176.73
     }
   ],
   "epoch": {

--- a/data/ticon/ruden-9690077-deu-wsv.json
+++ b/data/ticon/ruden-9690077-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.012827874840769147,
-      "phase": 298.4010054897575
+      "amplitude": 0.013,
+      "phase": 298.4
     },
     {
       "name": "N2",
-      "amplitude": 0.0038334617325379507,
-      "phase": 254.98517966980444
+      "amplitude": 0.004,
+      "phase": 254.99
     },
     {
       "name": "S2",
-      "amplitude": 0.0029569374877874816,
-      "phase": 258.15706701429144
+      "amplitude": 0.003,
+      "phase": 258.16
     },
     {
       "name": "K2",
-      "amplitude": 0.0012341067186534044,
-      "phase": 238.53657089777892
+      "amplitude": 0.001,
+      "phase": 238.54
     },
     {
       "name": "2N2",
-      "amplitude": 0.0007422807633719516,
-      "phase": 255.5710097795847
+      "amplitude": 0.001,
+      "phase": 255.57
     },
     {
       "name": "S1",
-      "amplitude": 0.006769307397721117,
-      "phase": 24.965700389674055
+      "amplitude": 0.007,
+      "phase": 24.97
     },
     {
       "name": "K1",
-      "amplitude": 0.007427794763712642,
-      "phase": 149.07691805348816
+      "amplitude": 0.007,
+      "phase": 149.08
     },
     {
       "name": "P1",
-      "amplitude": 0.0014776227528768336,
-      "phase": 133.50214065964258
+      "amplitude": 0.001,
+      "phase": 133.5
     },
     {
       "name": "O1",
-      "amplitude": 0.01237494153642393,
-      "phase": 143.08627111225826
+      "amplitude": 0.012,
+      "phase": 143.09
     },
     {
       "name": "Q1",
-      "amplitude": 0.0019157497647600621,
-      "phase": 102.43184117802912
+      "amplitude": 0.002,
+      "phase": 102.43
     },
     {
       "name": "M1",
-      "amplitude": 0.000588232040781721,
-      "phase": 35.83431932366483
+      "amplitude": 0.001,
+      "phase": 35.83
     },
     {
       "name": "M4",
-      "amplitude": 0.0006774434234243585,
-      "phase": 316.9346390705727
+      "amplitude": 0.001,
+      "phase": 316.93
     },
     {
       "name": "MM",
-      "amplitude": 0.010933402468317085,
-      "phase": 279.4408695153372
+      "amplitude": 0.011,
+      "phase": 279.44
     },
     {
       "name": "MF",
-      "amplitude": 0.008027151139596499,
-      "phase": 273.42042275277026
+      "amplitude": 0.008,
+      "phase": 273.42
     },
     {
       "name": "SA",
-      "amplitude": 0.0431867727384378,
-      "phase": 194.1496517014846
+      "amplitude": 0.043,
+      "phase": 194.15
     },
     {
       "name": "SSA",
-      "amplitude": 0.03439855865896259,
-      "phase": 243.23280521387923
+      "amplitude": 0.034,
+      "phase": 243.23
     },
     {
       "name": "T2",
-      "amplitude": 0.000687178073080777,
-      "phase": 249.54228691301046
+      "amplitude": 0.001,
+      "phase": 249.54
     },
     {
       "name": "J1",
-      "amplitude": 0.000769292778787898,
-      "phase": 212.09327531463802
+      "amplitude": 0.001,
+      "phase": 212.09
     },
     {
       "name": "L2",
-      "amplitude": 0.0013301521029813806,
-      "phase": 56.15612798294751
+      "amplitude": 0.001,
+      "phase": 56.16
     },
     {
       "name": "R2",
-      "amplitude": 0.0005015703350822827,
-      "phase": 47.97653572652865
+      "amplitude": 0.001,
+      "phase": 47.98
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0000946039649618524,
-      "phase": 262.8020989626218
+      "amplitude": 0,
+      "phase": 262.8
     },
     {
       "name": "MSF",
-      "amplitude": 0.0014620172045285375,
-      "phase": 255.05870226039863
+      "amplitude": 0.001,
+      "phase": 255.06
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003294572068043259,
-      "phase": 189.68360179856688
+      "amplitude": 0.003,
+      "phase": 189.68
     },
     {
       "name": "EP2",
-      "amplitude": 0.0006783220805674278,
-      "phase": 65.12570909380293
+      "amplitude": 0.001,
+      "phase": 65.13
     },
     {
       "name": "M3",
-      "amplitude": 0.00042923988467294405,
-      "phase": 282.8013927024152
+      "amplitude": 0,
+      "phase": 282.8
     },
     {
       "name": "MU2",
-      "amplitude": 0.0024233385696579347,
-      "phase": 123.20434786274194
+      "amplitude": 0.002,
+      "phase": 123.2
     },
     {
       "name": "MTM",
-      "amplitude": 0.003310143015499219,
-      "phase": 344.2706923873059
+      "amplitude": 0.003,
+      "phase": 344.27
     },
     {
       "name": "NU2",
-      "amplitude": 0.0011655970711374319,
-      "phase": 300.48940459373944
+      "amplitude": 0.001,
+      "phase": 300.49
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0006443563512100008,
-      "phase": 48.62147692548825
+      "amplitude": 0.001,
+      "phase": 48.62
     },
     {
       "name": "MN4",
-      "amplitude": 0.0003288756650363075,
-      "phase": 252.78775604291693
+      "amplitude": 0,
+      "phase": 252.79
     },
     {
       "name": "MS4",
-      "amplitude": 0.0003113419572309885,
-      "phase": 117.04844181373949
+      "amplitude": 0,
+      "phase": 117.05
     },
     {
       "name": "N4",
-      "amplitude": 0.00013203013296130673,
-      "phase": 175.89639038126086
+      "amplitude": 0,
+      "phase": 175.9
     },
     {
       "name": "M6",
-      "amplitude": 0.00008198927662941293,
-      "phase": 49.44497891512452
+      "amplitude": 0,
+      "phase": 49.44
     },
     {
       "name": "M8",
-      "amplitude": 0.00007315967744727111,
-      "phase": 229.5373442800681
+      "amplitude": 0,
+      "phase": 229.54
     },
     {
       "name": "S4",
-      "amplitude": 0.00008413672707177426,
-      "phase": 84.43399396670998
+      "amplitude": 0,
+      "phase": 84.43
     },
     {
       "name": "OO1",
-      "amplitude": 0.00031317341998779273,
-      "phase": 135.3910848201839
+      "amplitude": 0,
+      "phase": 135.39
     },
     {
       "name": "S3",
-      "amplitude": 0.0005514886036035181,
-      "phase": 331.8405346985439
+      "amplitude": 0.001,
+      "phase": 331.84
     },
     {
       "name": "MA2",
-      "amplitude": 0.0012048761442951614,
-      "phase": 308.14551769742985
+      "amplitude": 0.001,
+      "phase": 308.15
     },
     {
       "name": "MB2",
-      "amplitude": 0.0014694237152971111,
-      "phase": 85.37451551879542
+      "amplitude": 0.001,
+      "phase": 85.37
     },
     {
       "name": "T3",
-      "amplitude": 0.00035302479083205724,
-      "phase": 215.26408621708416
+      "amplitude": 0,
+      "phase": 215.26
     },
     {
       "name": "R3",
-      "amplitude": 0.0003032747568029086,
-      "phase": 331.3858099748741
+      "amplitude": 0,
+      "phase": 331.39
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00008343762962677596,
-      "phase": 132.05353414219218
+      "amplitude": 0,
+      "phase": 132.05
     },
     {
       "name": "SGM",
-      "amplitude": 0.0010096621029536865,
-      "phase": 228.63620301047249
+      "amplitude": 0.001,
+      "phase": 228.64
     },
     {
       "name": "3L2",
-      "amplitude": 0.00017348188520376967,
-      "phase": 194.74156193503583
+      "amplitude": 0,
+      "phase": 194.74
     },
     {
       "name": "3N2",
-      "amplitude": 0.0005388525585677067,
-      "phase": 208.40525461595504
+      "amplitude": 0.001,
+      "phase": 208.41
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0005484551951135746,
-      "phase": 30.30454194533752
+      "amplitude": 0.001,
+      "phase": 30.3
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0001167449311861886,
-      "phase": 147.21335782737032
+      "amplitude": 0,
+      "phase": 147.21
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000026881828047713258,
-      "phase": 347.65056125407796
+      "amplitude": 0,
+      "phase": 347.65
     },
     {
       "name": "2MO5",
-      "amplitude": 0.000025858640127615332,
-      "phase": 195.71225381239262
+      "amplitude": 0,
+      "phase": 195.71
     }
   ],
   "epoch": {

--- a/data/ticon/sassnitz-9670065-deu-wsv.json
+++ b/data/ticon/sassnitz-9670065-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.010009273519598716,
-      "phase": 267.41279537664644
+      "amplitude": 0.01,
+      "phase": 267.41
     },
     {
       "name": "N2",
-      "amplitude": 0.0031877993465591558,
-      "phase": 233.07095578706395
+      "amplitude": 0.003,
+      "phase": 233.07
     },
     {
       "name": "S2",
-      "amplitude": 0.0039052810707339855,
-      "phase": 236.69983098585067
+      "amplitude": 0.004,
+      "phase": 236.7
     },
     {
       "name": "K2",
-      "amplitude": 0.001244283376608621,
-      "phase": 211.27499833154312
+      "amplitude": 0.001,
+      "phase": 211.27
     },
     {
       "name": "2N2",
-      "amplitude": 0.0005016664061362719,
-      "phase": 229.1828943344741
+      "amplitude": 0.001,
+      "phase": 229.18
     },
     {
       "name": "S1",
-      "amplitude": 0.004489957116980215,
-      "phase": 353.8104860739313
+      "amplitude": 0.004,
+      "phase": 353.81
     },
     {
       "name": "K1",
-      "amplitude": 0.008153791625431476,
-      "phase": 150.2917478759689
+      "amplitude": 0.008,
+      "phase": 150.29
     },
     {
       "name": "P1",
-      "amplitude": 0.00177709668730587,
-      "phase": 161.46663090069956
+      "amplitude": 0.002,
+      "phase": 161.47
     },
     {
       "name": "O1",
-      "amplitude": 0.012646396435746247,
-      "phase": 136.30580241399366
+      "amplitude": 0.013,
+      "phase": 136.31
     },
     {
       "name": "Q1",
-      "amplitude": 0.001599507010100757,
-      "phase": 100.1016917043064
+      "amplitude": 0.002,
+      "phase": 100.1
     },
     {
       "name": "M1",
-      "amplitude": 0.0006770596613471349,
-      "phase": 39.31191344528281
+      "amplitude": 0.001,
+      "phase": 39.31
     },
     {
       "name": "M4",
-      "amplitude": 0.0005412593046328393,
-      "phase": 236.9382041653167
+      "amplitude": 0.001,
+      "phase": 236.94
     },
     {
       "name": "MM",
-      "amplitude": 0.011499043255742273,
-      "phase": 272.89414536077345
+      "amplitude": 0.011,
+      "phase": 272.89
     },
     {
       "name": "MF",
-      "amplitude": 0.007735309415866558,
-      "phase": 270.2772417170717
+      "amplitude": 0.008,
+      "phase": 270.28
     },
     {
       "name": "SA",
-      "amplitude": 0.047501511508620066,
-      "phase": 206.22184570204377
+      "amplitude": 0.048,
+      "phase": 206.22
     },
     {
       "name": "SSA",
-      "amplitude": 0.037405384546667586,
-      "phase": 242.5940488162347
+      "amplitude": 0.037,
+      "phase": 242.59
     },
     {
       "name": "T2",
-      "amplitude": 0.0006930162182330765,
-      "phase": 231.44864430666374
+      "amplitude": 0.001,
+      "phase": 231.45
     },
     {
       "name": "J1",
-      "amplitude": 0.0006946537036576923,
-      "phase": 189.5504675383081
+      "amplitude": 0.001,
+      "phase": 189.55
     },
     {
       "name": "L2",
-      "amplitude": 0.0008789220312831413,
-      "phase": 33.54040388912051
+      "amplitude": 0.001,
+      "phase": 33.54
     },
     {
       "name": "R2",
-      "amplitude": 0.0004180807787003882,
-      "phase": 2.583467318463704
+      "amplitude": 0,
+      "phase": 2.58
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00015448353709946987,
-      "phase": 49.77313601545387
+      "amplitude": 0,
+      "phase": 49.77
     },
     {
       "name": "MSF",
-      "amplitude": 0.0006935641093423628,
-      "phase": 257.7183174155686
+      "amplitude": 0.001,
+      "phase": 257.72
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0033951735757235288,
-      "phase": 194.76758282389272
+      "amplitude": 0.003,
+      "phase": 194.77
     },
     {
       "name": "EP2",
-      "amplitude": 0.0004973010201849389,
-      "phase": 42.86716305588686
+      "amplitude": 0,
+      "phase": 42.87
     },
     {
       "name": "M3",
-      "amplitude": 0.0002559351185774805,
-      "phase": 237.49573212006482
+      "amplitude": 0,
+      "phase": 237.5
     },
     {
       "name": "MU2",
-      "amplitude": 0.0019167544986874686,
-      "phase": 107.76555778272615
+      "amplitude": 0.002,
+      "phase": 107.77
     },
     {
       "name": "MTM",
-      "amplitude": 0.0032230525802951545,
-      "phase": 333.98729006863016
+      "amplitude": 0.003,
+      "phase": 333.99
     },
     {
       "name": "NU2",
-      "amplitude": 0.001086290028242184,
-      "phase": 275.84873481964695
+      "amplitude": 0.001,
+      "phase": 275.85
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0004998966097152843,
-      "phase": 17.080178328600425
+      "amplitude": 0,
+      "phase": 17.08
     },
     {
       "name": "MN4",
-      "amplitude": 0.00023616569516131055,
-      "phase": 176.67837158867496
+      "amplitude": 0,
+      "phase": 176.68
     },
     {
       "name": "MS4",
-      "amplitude": 0.0002247320955057765,
-      "phase": 40.37763425030232
+      "amplitude": 0,
+      "phase": 40.38
     },
     {
       "name": "N4",
-      "amplitude": 0.0000742839184015437,
-      "phase": 96.91648011173447
+      "amplitude": 0,
+      "phase": 96.92
     },
     {
       "name": "M6",
-      "amplitude": 0.00014359241177732554,
-      "phase": 333.09252746216237
+      "amplitude": 0,
+      "phase": 333.09
     },
     {
       "name": "M8",
-      "amplitude": 0.000013064975764475854,
-      "phase": 166.77967489911862
+      "amplitude": 0,
+      "phase": 166.78
     },
     {
       "name": "S4",
-      "amplitude": 0.000044088244548463486,
-      "phase": 71.8722011623783
+      "amplitude": 0,
+      "phase": 71.87
     },
     {
       "name": "OO1",
-      "amplitude": 0.00036134892045625174,
-      "phase": 103.93924949762777
+      "amplitude": 0,
+      "phase": 103.94
     },
     {
       "name": "S3",
-      "amplitude": 0.00032250736951817504,
-      "phase": 274.38706374685387
+      "amplitude": 0,
+      "phase": 274.39
     },
     {
       "name": "MA2",
-      "amplitude": 0.0011343589491831646,
-      "phase": 294.06870786736596
+      "amplitude": 0.001,
+      "phase": 294.07
     },
     {
       "name": "MB2",
-      "amplitude": 0.0011802224185868725,
-      "phase": 77.52764355070371
+      "amplitude": 0.001,
+      "phase": 77.53
     },
     {
       "name": "T3",
-      "amplitude": 0.00017963922265780655,
-      "phase": 150.18689667614075
+      "amplitude": 0,
+      "phase": 150.19
     },
     {
       "name": "R3",
-      "amplitude": 0.0002252255986685175,
-      "phase": 288.7875104557127
+      "amplitude": 0,
+      "phase": 288.79
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00011776593362476946,
-      "phase": 152.35785077745834
+      "amplitude": 0,
+      "phase": 152.36
     },
     {
       "name": "SGM",
-      "amplitude": 0.0013431110429824647,
-      "phase": 222.26941133638041
+      "amplitude": 0.001,
+      "phase": 222.27
     },
     {
       "name": "3L2",
-      "amplitude": 0.00016460401983786464,
-      "phase": 173.99937714535156
+      "amplitude": 0,
+      "phase": 174
     },
     {
       "name": "3N2",
-      "amplitude": 0.000365894824221472,
-      "phase": 175.54205397889552
+      "amplitude": 0,
+      "phase": 175.54
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0004910574905666833,
-      "phase": 5.160443768463381
+      "amplitude": 0,
+      "phase": 5.16
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0001963872342040123,
-      "phase": 63.381510492060556
+      "amplitude": 0,
+      "phase": 63.38
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000028244575238717004,
-      "phase": 136.40847967069413
+      "amplitude": 0,
+      "phase": 136.41
     },
     {
       "name": "2MO5",
-      "amplitude": 0.000004128794018037416,
-      "phase": 352.1803311424307
+      "amplitude": 0,
+      "phase": 352.18
     }
   ],
   "epoch": {

--- a/data/ticon/schaar_van_de_noord-schaarvdnd-nld-rws.json
+++ b/data/ticon/schaar_van_de_noord-schaarvdnd-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 2.04309125,
-      "phase": 76.91725200000002
+      "amplitude": 2.113,
+      "phase": 59.8
     },
     {
       "name": "N2",
-      "amplitude": 0.32729024,
-      "phase": 53.127252
+      "amplitude": 0.338,
+      "phase": 36.83
     },
     {
       "name": "S2",
-      "amplitude": 0.53291858,
-      "phase": 140.19098199999996
+      "amplitude": 0.547,
+      "phase": 122.49
     },
     {
       "name": "K2",
-      "amplitude": 0.14623628,
-      "phase": 145.72274800000002
+      "amplitude": 0.163,
+      "phase": 121.37
     },
     {
       "name": "2N2",
-      "amplitude": 0.0383618,
-      "phase": 32.35423700000001
+      "amplitude": 0.039,
+      "phase": 17.64
     },
     {
       "name": "S1",
-      "amplitude": 0.01219302,
-      "phase": 53.963570000000004
+      "amplitude": 0.009,
+      "phase": 0.14
     },
     {
       "name": "K1",
-      "amplitude": 0.06969033,
-      "phase": 26.401508999999976
+      "amplitude": 0.071,
+      "phase": 17.4
     },
     {
       "name": "P1",
-      "amplitude": 0.038542,
-      "phase": 9.002619999999979
+      "amplitude": 0.039,
+      "phase": 1.91
     },
     {
       "name": "O1",
-      "amplitude": 0.10440599,
-      "phase": 206.605256
+      "amplitude": 0.105,
+      "phase": 197.89
     },
     {
       "name": "Q1",
-      "amplitude": 0.03367646,
-      "phase": 149.756283
+      "amplitude": 0.034,
+      "phase": 141.2
     },
     {
       "name": "M1",
-      "amplitude": 0.00404218,
-      "phase": 6.193427999999983
+      "amplitude": 0.003,
+      "phase": 21.41
     },
     {
       "name": "M4",
-      "amplitude": 0.11037844,
-      "phase": 156.78203299999996
+      "amplitude": 0.126,
+      "phase": 121.81
     },
     {
       "name": "MM",
-      "amplitude": 0.01321458,
-      "phase": 56.82669599999997
+      "amplitude": 0.013,
+      "phase": 57.19
     },
     {
       "name": "MF",
-      "amplitude": 0.0134958,
-      "phase": 74.87219900000002
+      "amplitude": 0.013,
+      "phase": 75.38
     },
     {
       "name": "SA",
-      "amplitude": 0.06585575,
-      "phase": 217.905133
+      "amplitude": 0.067,
+      "phase": 217.33
     },
     {
       "name": "SSA",
-      "amplitude": 0.011247499999999999,
-      "phase": 207.49993
+      "amplitude": 0.011,
+      "phase": 205.5
     },
     {
       "name": "T2",
-      "amplitude": 0.09777576,
-      "phase": 54.615054999999984
+      "amplitude": 0.03,
+      "phase": 103.4
     },
     {
       "name": "J1",
-      "amplitude": 0.0043710500000000005,
-      "phase": 160.50716899999998
+      "amplitude": 0.004,
+      "phase": 149.03
     },
     {
       "name": "L2",
-      "amplitude": 0.16236993,
-      "phase": 93.255763
+      "amplitude": 0.168,
+      "phase": 74.88
     },
     {
       "name": "R2",
-      "amplitude": 0.07395362,
-      "phase": 247.936714
+      "amplitude": 0.002,
+      "phase": 216.7
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0047278500000000005,
-      "phase": 112.681351
+      "amplitude": 0.005,
+      "phase": 108.18
     },
     {
       "name": "MSF",
-      "amplitude": 0.057024609999999996,
-      "phase": 50.232151999999985
+      "amplitude": 0.056,
+      "phase": 49.97
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00554972,
-      "phase": 53.002335000000016
+      "amplitude": 0.005,
+      "phase": 51.23
     },
     {
       "name": "EP2",
-      "amplitude": 0.04313976,
-      "phase": 154.84251199999994
+      "amplitude": 0.043,
+      "phase": 138.11
     },
     {
       "name": "M3",
-      "amplitude": 0.0075002,
-      "phase": 187.979086
+      "amplitude": 0.008,
+      "phase": 342.08
     },
     {
       "name": "MU2",
-      "amplitude": 0.19661002,
-      "phase": 172.39983600000005
+      "amplitude": 0.206,
+      "phase": 155.41
     },
     {
       "name": "MTM",
-      "amplitude": 0.00135438,
-      "phase": 247.43883
+      "amplitude": 0.001,
+      "phase": 247.47
     },
     {
       "name": "NU2",
-      "amplitude": 0.12369374000000001,
-      "phase": 37.133196
+      "amplitude": 0.125,
+      "phase": 21.4
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07417776,
-      "phase": 93.60346700000002
+      "amplitude": 0.076,
+      "phase": 73.71
     },
     {
       "name": "MN4",
-      "amplitude": 0.0367234,
-      "phase": 130.080651
+      "amplitude": 0.042,
+      "phase": 96.57
     },
     {
       "name": "MS4",
-      "amplitude": 0.07000669,
-      "phase": 215.712928
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.10059613,
-      "phase": 213.926471
+      "amplitude": 0.079,
+      "phase": 181.6
     },
     {
       "name": "N4",
-      "amplitude": 0.00766046,
-      "phase": 105.13883900000002
+      "amplitude": 0.009,
+      "phase": 74.68
     },
     {
       "name": "M6",
-      "amplitude": 0.08536624,
-      "phase": 214.920668
+      "amplitude": 0.117,
+      "phase": 160.2
     },
     {
       "name": "M8",
-      "amplitude": 0.01669537,
-      "phase": 226.192711
+      "amplitude": 0.031,
+      "phase": 150.13
     },
     {
       "name": "S4",
-      "amplitude": 0.0030248199999999997,
-      "phase": 291.54974400000003
+      "amplitude": 0.003,
+      "phase": 260.28
     },
     {
       "name": "OO1",
-      "amplitude": 0.0052041000000000006,
-      "phase": 168.846222
+      "amplitude": 0.005,
+      "phase": 154.12
     },
     {
       "name": "S3",
-      "amplitude": 0.0034395999999999997,
-      "phase": 139.48044400000003
+      "amplitude": 0,
+      "phase": 25.13
     },
     {
       "name": "MA2",
-      "amplitude": 0.36140852,
-      "phase": 52.08482700000002
+      "amplitude": 0.037,
+      "phase": 20.1
     },
     {
       "name": "MB2",
-      "amplitude": 0.32334101,
-      "phase": 271.63727
+      "amplitude": 0.016,
+      "phase": 162.44
     },
     {
       "name": "T3",
-      "amplitude": 0.00244068,
-      "phase": 97.24420099999998
+      "amplitude": 0.003,
+      "phase": 277.27
     },
     {
       "name": "R3",
-      "amplitude": 0.011396120000000001,
-      "phase": 339.983857
+      "amplitude": 0.012,
+      "phase": 40.91
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0075438300000000005,
-      "phase": 149.62171899999998
+      "amplitude": 0.008,
+      "phase": 142.78
     },
     {
       "name": "SGM",
-      "amplitude": 0.00475987,
-      "phase": 118.95861000000002
+      "amplitude": 0.005,
+      "phase": 289.45
     },
     {
       "name": "3L2",
-      "amplitude": 0.006487349999999999,
-      "phase": 197.988233
+      "amplitude": 0.005,
+      "phase": 283.27
     },
     {
       "name": "3N2",
-      "amplitude": 0.00748406,
-      "phase": 140.27680699999996
+      "amplitude": 0.022,
+      "phase": 223.72
     },
     {
       "name": "2SM2",
-      "amplitude": 0.05361908,
-      "phase": 7.034171000000015
+      "amplitude": 0.054,
+      "phase": 348.78
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08196814,
-      "phase": 267.151944
+      "amplitude": 0.111,
+      "phase": 212.11
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00945119,
-      "phase": 209.365873
+      "amplitude": 0.012,
+      "phase": 253.43
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00539025,
-      "phase": 240.668993
+      "amplitude": 0.007,
+      "phase": 107.67
     }
   ],
   "epoch": {

--- a/data/ticon/scharhrn-9510060-deu-wsv.json
+++ b/data/ticon/scharhrn-9510060-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4321485901924917,
-      "phase": 317.93382730912026
+      "amplitude": 1.432,
+      "phase": 317.93
     },
     {
       "name": "N2",
-      "amplitude": 0.22930330136696706,
-      "phase": 292.42069840164186
+      "amplitude": 0.229,
+      "phase": 292.42
     },
     {
       "name": "S2",
-      "amplitude": 0.381649373519895,
-      "phase": 26.53896067178016
+      "amplitude": 0.382,
+      "phase": 26.54
     },
     {
       "name": "K2",
-      "amplitude": 0.11398269126555712,
-      "phase": 24.730808329054923
+      "amplitude": 0.114,
+      "phase": 24.73
     },
     {
       "name": "2N2",
-      "amplitude": 0.025317079445890785,
-      "phase": 272.6101534304987
+      "amplitude": 0.025,
+      "phase": 272.61
     },
     {
       "name": "S1",
-      "amplitude": 0.011176587885884251,
-      "phase": 18.631537265682994
+      "amplitude": 0.011,
+      "phase": 18.63
     },
     {
       "name": "K1",
-      "amplitude": 0.07261196835453775,
-      "phase": 23.83634026065255
+      "amplitude": 0.073,
+      "phase": 23.84
     },
     {
       "name": "P1",
-      "amplitude": 0.03039601260757733,
-      "phase": 30.207925703435876
+      "amplitude": 0.03,
+      "phase": 30.21
     },
     {
       "name": "O1",
-      "amplitude": 0.09482816106974497,
-      "phase": 234.65825427600385
+      "amplitude": 0.095,
+      "phase": 234.66
     },
     {
       "name": "Q1",
-      "amplitude": 0.030076688868885818,
-      "phase": 176.82540299283278
+      "amplitude": 0.03,
+      "phase": 176.83
     },
     {
       "name": "M1",
-      "amplitude": 0.0017642501732666987,
-      "phase": 90.63230374556957
+      "amplitude": 0.002,
+      "phase": 90.63
     },
     {
       "name": "M4",
-      "amplitude": 0.07886108995525733,
-      "phase": 157.27692934725815
+      "amplitude": 0.079,
+      "phase": 157.28
     },
     {
       "name": "MM",
-      "amplitude": 0.02776428085423861,
-      "phase": 174.3650027259298
+      "amplitude": 0.028,
+      "phase": 174.37
     },
     {
       "name": "MF",
-      "amplitude": 0.01032771327508919,
-      "phase": 172.59632475038177
+      "amplitude": 0.01,
+      "phase": 172.6
     },
     {
       "name": "SA",
-      "amplitude": 0.10514969705093584,
-      "phase": 224.73142249822135
+      "amplitude": 0.105,
+      "phase": 224.73
     },
     {
       "name": "SSA",
-      "amplitude": 0.03960336276100458,
-      "phase": 208.71946384993072
+      "amplitude": 0.04,
+      "phase": 208.72
     },
     {
       "name": "T2",
-      "amplitude": 0.020162692341725394,
-      "phase": 9.177712441841038
+      "amplitude": 0.02,
+      "phase": 9.18
     },
     {
       "name": "J1",
-      "amplitude": 0.0016838613071451173,
-      "phase": 151.67933027755907
+      "amplitude": 0.002,
+      "phase": 151.68
     },
     {
       "name": "L2",
-      "amplitude": 0.11181176312622593,
-      "phase": 335.9329853317744
+      "amplitude": 0.112,
+      "phase": 335.93
     },
     {
       "name": "R2",
-      "amplitude": 0.004440766670309491,
-      "phase": 345.0040563239513
+      "amplitude": 0.004,
+      "phase": 345
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006139254746388083,
-      "phase": 119.12007820230394
+      "amplitude": 0.006,
+      "phase": 119.12
     },
     {
       "name": "MSF",
-      "amplitude": 0.0047021368461444245,
-      "phase": 14.889008017514982
+      "amplitude": 0.005,
+      "phase": 14.89
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008476732960086933,
-      "phase": 68.8164187950369
+      "amplitude": 0.008,
+      "phase": 68.82
     },
     {
       "name": "EP2",
-      "amplitude": 0.031559035090501245,
-      "phase": 23.75605620599032
+      "amplitude": 0.032,
+      "phase": 23.76
     },
     {
       "name": "M3",
-      "amplitude": 0.004506609478951056,
-      "phase": 332.28744074781156
+      "amplitude": 0.005,
+      "phase": 332.29
     },
     {
       "name": "MU2",
-      "amplitude": 0.13724933212663137,
-      "phase": 47.34887703751701
+      "amplitude": 0.137,
+      "phase": 47.35
     },
     {
       "name": "MTM",
-      "amplitude": 0.00439458538175731,
-      "phase": 235.4758854947109
+      "amplitude": 0.004,
+      "phase": 235.48
     },
     {
       "name": "NU2",
-      "amplitude": 0.08099952048610148,
-      "phase": 277.9672692708049
+      "amplitude": 0.081,
+      "phase": 277.97
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.053447167209612546,
-      "phase": 329.39165569653414
+      "amplitude": 0.053,
+      "phase": 329.39
     },
     {
       "name": "MN4",
-      "amplitude": 0.027837790502975607,
-      "phase": 139.19883660519537
+      "amplitude": 0.028,
+      "phase": 139.2
     },
     {
       "name": "MS4",
-      "amplitude": 0.054926028088620564,
-      "phase": 219.48633425246706
+      "amplitude": 0.055,
+      "phase": 219.49
     },
     {
       "name": "N4",
-      "amplitude": 0.006227566974444484,
-      "phase": 119.6997473203258
+      "amplitude": 0.006,
+      "phase": 119.7
     },
     {
       "name": "M6",
-      "amplitude": 0.05237274794881235,
-      "phase": 0.006242314731366605
+      "amplitude": 0.052,
+      "phase": 0.01
     },
     {
       "name": "M8",
-      "amplitude": 0.007831543070987101,
-      "phase": 226.88162757221468
+      "amplitude": 0.008,
+      "phase": 226.88
     },
     {
       "name": "S4",
-      "amplitude": 0.007105673825196918,
-      "phase": 332.1738793168081
+      "amplitude": 0.007,
+      "phase": 332.17
     },
     {
       "name": "OO1",
-      "amplitude": 0.0023707053618143565,
-      "phase": 193.61108214050265
+      "amplitude": 0.002,
+      "phase": 193.61
     },
     {
       "name": "S3",
-      "amplitude": 0.0005902741297287529,
-      "phase": 176.33067991610937
+      "amplitude": 0.001,
+      "phase": 176.33
     },
     {
       "name": "MA2",
-      "amplitude": 0.04347326335318631,
-      "phase": 260.0227982740131
+      "amplitude": 0.043,
+      "phase": 260.02
     },
     {
       "name": "MB2",
-      "amplitude": 0.030832112233490864,
-      "phase": 28.602329989654436
+      "amplitude": 0.031,
+      "phase": 28.6
     },
     {
       "name": "T3",
-      "amplitude": 0.00035835974147997756,
-      "phase": 54.802674540629596
+      "amplitude": 0,
+      "phase": 54.8
     },
     {
       "name": "R3",
-      "amplitude": 0.002277882280958252,
-      "phase": 10.296377668642208
+      "amplitude": 0.002,
+      "phase": 10.3
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006055588052668996,
-      "phase": 182.70528440959936
+      "amplitude": 0.006,
+      "phase": 182.71
     },
     {
       "name": "SGM",
-      "amplitude": 0.0025713340080377174,
-      "phase": 51.40301192604164
+      "amplitude": 0.003,
+      "phase": 51.4
     },
     {
       "name": "3L2",
-      "amplitude": 0.004254061704345158,
-      "phase": 232.16485030275328
+      "amplitude": 0.004,
+      "phase": 232.16
     },
     {
       "name": "3N2",
-      "amplitude": 0.017520998138861585,
-      "phase": 117.55956610384965
+      "amplitude": 0.018,
+      "phase": 117.56
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03551784649861468,
-      "phase": 248.1242684769323
+      "amplitude": 0.036,
+      "phase": 248.12
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05063571734140651,
-      "phase": 58.57556891266637
+      "amplitude": 0.051,
+      "phase": 58.58
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0031095224125111272,
-      "phase": 57.9262902575864
+      "amplitude": 0.003,
+      "phase": 57.93
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004812610316631298,
-      "phase": 302.6149082821814
+      "amplitude": 0.005,
+      "phase": 302.61
     }
   ],
   "epoch": {

--- a/data/ticon/scheveningen-schevngn-nld-rws.json
+++ b/data/ticon/scheveningen-schevngn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.72465057,
-      "phase": 79.55795
+      "amplitude": 0.748,
+      "phase": 68.29
     },
     {
       "name": "N2",
-      "amplitude": 0.10481072,
-      "phase": 52.980504999999994
+      "amplitude": 0.109,
+      "phase": 42.42
     },
     {
       "name": "S2",
-      "amplitude": 0.17757574,
-      "phase": 141.93568500000003
+      "amplitude": 0.183,
+      "phase": 130.83
     },
     {
       "name": "K2",
-      "amplitude": 0.05381308,
-      "phase": 142.61684200000002
+      "amplitude": 0.057,
+      "phase": 130.75
     },
     {
       "name": "2N2",
-      "amplitude": 0.010051699999999998,
-      "phase": 18.31121300000001
+      "amplitude": 0.012,
+      "phase": 8.72
     },
     {
       "name": "S1",
-      "amplitude": 0.00753742,
-      "phase": 328.620168
+      "amplitude": 0.011,
+      "phase": 287.73
     },
     {
       "name": "K1",
-      "amplitude": 0.07821114,
-      "phase": 348.662923
+      "amplitude": 0.078,
+      "phase": 342.66
     },
     {
       "name": "P1",
-      "amplitude": 0.03475919,
-      "phase": 337.272905
+      "amplitude": 0.035,
+      "phase": 331.69
     },
     {
       "name": "O1",
-      "amplitude": 0.11177284999999999,
-      "phase": 181.068826
+      "amplitude": 0.112,
+      "phase": 175.62
     },
     {
       "name": "Q1",
-      "amplitude": 0.03972222,
-      "phase": 126.21826199999998
+      "amplitude": 0.04,
+      "phase": 120.69
     },
     {
       "name": "M1",
-      "amplitude": 0.00194591,
-      "phase": 161.91352600000005
+      "amplitude": 0.003,
+      "phase": 358.55
     },
     {
       "name": "M4",
-      "amplitude": 0.17361833000000002,
-      "phase": 130.410145
+      "amplitude": 0.201,
+      "phase": 107.71
     },
     {
       "name": "MM",
-      "amplitude": 0.01526537,
-      "phase": 138.751645
+      "amplitude": 0.015,
+      "phase": 136.84
     },
     {
       "name": "MF",
-      "amplitude": 0.00238294,
-      "phase": 235.373129
+      "amplitude": 0.003,
+      "phase": 228.06
     },
     {
       "name": "SA",
-      "amplitude": 0.10104569,
-      "phase": 220.595915
+      "amplitude": 0.106,
+      "phase": 220.73
     },
     {
       "name": "SSA",
-      "amplitude": 0.02938755,
-      "phase": 172.34929699999998
+      "amplitude": 0.031,
+      "phase": 165.91
     },
     {
       "name": "T2",
-      "amplitude": 0.02980844,
-      "phase": 76.77145300000001
+      "amplitude": 0.014,
+      "phase": 110.05
     },
     {
       "name": "J1",
-      "amplitude": 0.00402476,
-      "phase": 79.50794200000001
+      "amplitude": 0.004,
+      "phase": 72.29
     },
     {
       "name": "L2",
-      "amplitude": 0.06458642,
-      "phase": 99.47238800000002
+      "amplitude": 0.067,
+      "phase": 88.86
     },
     {
       "name": "R2",
-      "amplitude": 0.013513500000000001,
-      "phase": 248.65561
+      "amplitude": 0.002,
+      "phase": 60.47
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00696393,
-      "phase": 68.40895499999999
+      "amplitude": 0.007,
+      "phase": 63.95
     },
     {
       "name": "MSF",
-      "amplitude": 0.03657004,
-      "phase": 44.72116399999999
+      "amplitude": 0.037,
+      "phase": 44.03
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00491991,
-      "phase": 295.18539
+      "amplitude": 0.005,
+      "phase": 293.77
     },
     {
       "name": "EP2",
-      "amplitude": 0.01640382,
-      "phase": 178.71959900000002
+      "amplitude": 0.017,
+      "phase": 168.53
     },
     {
       "name": "M3",
-      "amplitude": 0.00225138,
-      "phase": 238.87651499999998
+      "amplitude": 0.002,
+      "phase": 44.12
     },
     {
       "name": "MU2",
-      "amplitude": 0.08437029000000001,
-      "phase": 196.20992
+      "amplitude": 0.087,
+      "phase": 184.6
     },
     {
       "name": "MTM",
-      "amplitude": 0.00310447,
-      "phase": 202.957696
+      "amplitude": 0.003,
+      "phase": 182.45
     },
     {
       "name": "NU2",
-      "amplitude": 0.04500753,
-      "phase": 46.596851000000015
+      "amplitude": 0.049,
+      "phase": 35.58
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03025742,
-      "phase": 97.37006200000002
+      "amplitude": 0.032,
+      "phase": 88.74
     },
     {
       "name": "MN4",
-      "amplitude": 0.061070469999999995,
-      "phase": 104.68328500000001
+      "amplitude": 0.071,
+      "phase": 82.63
     },
     {
       "name": "MS4",
-      "amplitude": 0.10617544000000001,
-      "phase": 185.613356
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.01630682,
-      "phase": 239.897625
+      "amplitude": 0.122,
+      "phase": 164.23
     },
     {
       "name": "N4",
-      "amplitude": 0.013502229999999999,
-      "phase": 78.23513700000001
+      "amplitude": 0.017,
+      "phase": 53.42
     },
     {
       "name": "M6",
-      "amplitude": 0.01677139,
-      "phase": 111.59632599999998
+      "amplitude": 0.023,
+      "phase": 78.03
     },
     {
       "name": "M8",
-      "amplitude": 0.01300781,
-      "phase": 182.477025
+      "amplitude": 0.026,
+      "phase": 143.89
     },
     {
       "name": "S4",
-      "amplitude": 0.009042139999999999,
-      "phase": 269.771218
+      "amplitude": 0.01,
+      "phase": 244.34
     },
     {
       "name": "OO1",
-      "amplitude": 0.004264899999999999,
-      "phase": 124.49449099999998
+      "amplitude": 0.004,
+      "phase": 121.37
     },
     {
       "name": "S3",
-      "amplitude": 0.00145149,
-      "phase": 41.31689799999998
+      "amplitude": 0,
+      "phase": 197.5
     },
     {
       "name": "MA2",
-      "amplitude": 0.10223903,
-      "phase": 71.33824199999998
+      "amplitude": 0.019,
+      "phase": 68.12
     },
     {
       "name": "MB2",
-      "amplitude": 0.0741965,
-      "phase": 270.093362
+      "amplitude": 0.013,
+      "phase": 122.7
     },
     {
       "name": "T3",
-      "amplitude": 0.00100112,
-      "phase": 4.277694999999994
+      "amplitude": 0.001,
+      "phase": 186.1
     },
     {
       "name": "R3",
-      "amplitude": 0.00442525,
-      "phase": 236.600411
+      "amplitude": 0.005,
+      "phase": 307.54
     },
     {
       "name": "RHO1",
-      "amplitude": 0.007826729999999999,
-      "phase": 118.05171000000001
+      "amplitude": 0.008,
+      "phase": 114.87
     },
     {
       "name": "SGM",
-      "amplitude": 0.0019414799999999998,
-      "phase": 232.861262
+      "amplitude": 0.001,
+      "phase": 61.77
     },
     {
       "name": "3L2",
-      "amplitude": 0.0020539,
-      "phase": 307.59504
+      "amplitude": 0.005,
+      "phase": 53.29
     },
     {
       "name": "3N2",
-      "amplitude": 0.0062445899999999995,
-      "phase": 16.977439000000004
+      "amplitude": 0.007,
+      "phase": 245.12
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02451248,
-      "phase": 8.52484099999998
+      "amplitude": 0.025,
+      "phase": 357.69
     },
     {
       "name": "2MS6",
-      "amplitude": 0.015665949999999998,
-      "phase": 182.33439
+      "amplitude": 0.021,
+      "phase": 151.43
     },
     {
       "name": "2MK5",
-      "amplitude": 0.01634433,
-      "phase": 251.02889
+      "amplitude": 0.02,
+      "phase": 311.41
     },
     {
       "name": "2MO5",
-      "amplitude": 0.01537342,
-      "phase": 260.04663700000003
+      "amplitude": 0.019,
+      "phase": 145.2
     }
   ],
   "epoch": {

--- a/data/ticon/schiermonnikoog-schiermnog-nld-rws.json
+++ b/data/ticon/schiermonnikoog-schiermnog-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.99954689,
-      "phase": 268.730165
+      "amplitude": 1.039,
+      "phase": 256.84
     },
     {
       "name": "N2",
-      "amplitude": 0.16257556,
-      "phase": 243.94706100000002
+      "amplitude": 0.169,
+      "phase": 233.21
     },
     {
       "name": "S2",
-      "amplitude": 0.2700768,
-      "phase": 333.301187
+      "amplitude": 0.279,
+      "phase": 321.16
     },
     {
       "name": "K2",
-      "amplitude": 0.07751125,
-      "phase": 334.415542
+      "amplitude": 0.081,
+      "phase": 319.73
     },
     {
       "name": "2N2",
-      "amplitude": 0.02200151,
-      "phase": 217.705127
+      "amplitude": 0.024,
+      "phase": 208.78
     },
     {
       "name": "S1",
-      "amplitude": 0.00460188,
-      "phase": 10.734017999999992
+      "amplitude": 0.008,
+      "phase": 316.14
     },
     {
       "name": "K1",
-      "amplitude": 0.06608744,
-      "phase": 13.089072999999985
+      "amplitude": 0.066,
+      "phase": 6.82
     },
     {
       "name": "P1",
-      "amplitude": 0.02662201,
-      "phase": 12.035592000000008
+      "amplitude": 0.027,
+      "phase": 6.62
     },
     {
       "name": "O1",
-      "amplitude": 0.08680598,
-      "phase": 218.620893
+      "amplitude": 0.087,
+      "phase": 213.22
     },
     {
       "name": "Q1",
-      "amplitude": 0.03086147,
-      "phase": 162.41968399999996
+      "amplitude": 0.031,
+      "phase": 156.85
     },
     {
       "name": "M1",
-      "amplitude": 0.0023426,
-      "phase": 234.433345
+      "amplitude": 0.001,
+      "phase": 15.8
     },
     {
       "name": "M4",
-      "amplitude": 0.09501480000000001,
-      "phase": 1.2040299999999888
+      "amplitude": 0.112,
+      "phase": 337.57
     },
     {
       "name": "MM",
-      "amplitude": 0.01158932,
-      "phase": 161.42026399999997
+      "amplitude": 0.01,
+      "phase": 156.37
     },
     {
       "name": "MF",
-      "amplitude": 0.01127616,
-      "phase": 163.41598699999997
+      "amplitude": 0.012,
+      "phase": 168.72
     },
     {
       "name": "SA",
-      "amplitude": 0.07932811000000001,
-      "phase": 232.41403400000002
+      "amplitude": 0.094,
+      "phase": 231.22
     },
     {
       "name": "SSA",
-      "amplitude": 0.040125669999999995,
-      "phase": 199.401218
+      "amplitude": 0.04,
+      "phase": 185.73
     },
     {
       "name": "T2",
-      "amplitude": 0.04388814,
-      "phase": 254.9216
+      "amplitude": 0.01,
+      "phase": 283.41
     },
     {
       "name": "J1",
-      "amplitude": 0.00283865,
-      "phase": 111.999439
+      "amplitude": 0.003,
+      "phase": 108.4
     },
     {
       "name": "L2",
-      "amplitude": 0.07150114,
-      "phase": 283.179186
+      "amplitude": 0.075,
+      "phase": 271.59
     },
     {
       "name": "R2",
-      "amplitude": 0.02178397,
-      "phase": 82.584047
+      "amplitude": 0.002,
+      "phase": 182.56
     },
     {
       "name": "2Q1",
-      "amplitude": 0.006448150000000001,
-      "phase": 99.23951
+      "amplitude": 0.006,
+      "phase": 97.23
     },
     {
       "name": "MSF",
-      "amplitude": 0.02814158,
-      "phase": 44.44988000000001
+      "amplitude": 0.029,
+      "phase": 44.31
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00880909,
-      "phase": 327.344802
+      "amplitude": 0.008,
+      "phase": 325.9
     },
     {
       "name": "EP2",
-      "amplitude": 0.016783,
-      "phase": 335.747672
+      "amplitude": 0.018,
+      "phase": 322.93
     },
     {
       "name": "M3",
-      "amplitude": 0.00392713,
-      "phase": 65.26162799999997
+      "amplitude": 0.004,
+      "phase": 229.41
     },
     {
       "name": "MU2",
-      "amplitude": 0.09061069,
-      "phase": 0.012962000000015905
+      "amplitude": 0.093,
+      "phase": 347.56
     },
     {
       "name": "MTM",
-      "amplitude": 0.01072591,
-      "phase": 265.62806
+      "amplitude": 0.01,
+      "phase": 258.28
     },
     {
       "name": "NU2",
-      "amplitude": 0.054945959999999995,
-      "phase": 232.203061
+      "amplitude": 0.058,
+      "phase": 218.16
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03589934,
-      "phase": 275.281293
+      "amplitude": 0.038,
+      "phase": 263.76
     },
     {
       "name": "MN4",
-      "amplitude": 0.03074834,
-      "phase": 334.815291
+      "amplitude": 0.036,
+      "phase": 311.16
     },
     {
       "name": "MS4",
-      "amplitude": 0.061571179999999996,
-      "phase": 77.38156200000003
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.024324759999999997,
-      "phase": 64.62843900000001
+      "amplitude": 0.071,
+      "phase": 55.29
     },
     {
       "name": "N4",
-      "amplitude": 0.00759289,
-      "phase": 306.465053
+      "amplitude": 0.01,
+      "phase": 284.58
     },
     {
       "name": "M6",
-      "amplitude": 0.01886166,
-      "phase": 154.49804700000004
+      "amplitude": 0.025,
+      "phase": 116.25
     },
     {
       "name": "M8",
-      "amplitude": 0.0041684700000000005,
-      "phase": 38.28708899999998
+      "amplitude": 0.008,
+      "phase": 8.09
     },
     {
       "name": "S4",
-      "amplitude": 0.00765255,
-      "phase": 216.520594
+      "amplitude": 0.008,
+      "phase": 196.81
     },
     {
       "name": "OO1",
-      "amplitude": 0.00293483,
-      "phase": 151.87879699999996
+      "amplitude": 0.003,
+      "phase": 139.2
     },
     {
       "name": "S3",
-      "amplitude": 0.00057287,
-      "phase": 64.49987799999997
+      "amplitude": 0,
+      "phase": 184.01
     },
     {
       "name": "MA2",
-      "amplitude": 0.15062193000000001,
-      "phase": 248.123465
+      "amplitude": 0.039,
+      "phase": 202.79
     },
     {
       "name": "MB2",
-      "amplitude": 0.11732214,
-      "phase": 103.36089800000002
+      "amplitude": 0.007,
+      "phase": 321.67
     },
     {
       "name": "T3",
-      "amplitude": 0.00169135,
-      "phase": 180.543276
+      "amplitude": 0.002,
+      "phase": 344.62
     },
     {
       "name": "R3",
-      "amplitude": 0.0031831399999999997,
-      "phase": 233.149552
+      "amplitude": 0.003,
+      "phase": 296.17
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00630516,
-      "phase": 154.750091
+      "amplitude": 0.006,
+      "phase": 150.64
     },
     {
       "name": "SGM",
-      "amplitude": 0.00307888,
-      "phase": 265.847312
+      "amplitude": 0.002,
+      "phase": 85.7
     },
     {
       "name": "3L2",
-      "amplitude": 0.01035863,
-      "phase": 51.77660500000002
+      "amplitude": 0.007,
+      "phase": 161.76
     },
     {
       "name": "3N2",
-      "amplitude": 0.00858721,
-      "phase": 161.85152800000003
+      "amplitude": 0.01,
+      "phase": 68.96
     },
     {
       "name": "2SM2",
-      "amplitude": 0.022648739999999997,
-      "phase": 189.114793
+      "amplitude": 0.023,
+      "phase": 178.98
     },
     {
       "name": "2MS6",
-      "amplitude": 0.01822162,
-      "phase": 213.982539
+      "amplitude": 0.025,
+      "phase": 174.8
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00579964,
-      "phase": 104.39889800000003
+      "amplitude": 0.008,
+      "phase": 157.73
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0026871,
-      "phase": 88.75143600000001
+      "amplitude": 0.004,
+      "phase": 336.74
     }
   ],
   "epoch": {

--- a/data/ticon/schillig-9430030-deu-wsv.json
+++ b/data/ticon/schillig-9430030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4751367147694814,
-      "phase": 318.90044097594176
+      "amplitude": 1.475,
+      "phase": 318.9
     },
     {
       "name": "N2",
-      "amplitude": 0.23463297139196942,
-      "phase": 293.90540699627866
+      "amplitude": 0.235,
+      "phase": 293.91
     },
     {
       "name": "S2",
-      "amplitude": 0.388322749512143,
-      "phase": 29.863071377904305
+      "amplitude": 0.388,
+      "phase": 29.86
     },
     {
       "name": "K2",
-      "amplitude": 0.11558162051806074,
-      "phase": 27.35082950742259
+      "amplitude": 0.116,
+      "phase": 27.35
     },
     {
       "name": "2N2",
-      "amplitude": 0.02549074316882429,
-      "phase": 274.31813997659043
+      "amplitude": 0.025,
+      "phase": 274.32
     },
     {
       "name": "S1",
-      "amplitude": 0.010118615124469668,
-      "phase": 30.03865079995785
+      "amplitude": 0.01,
+      "phase": 30.04
     },
     {
       "name": "K1",
-      "amplitude": 0.0711365528596945,
-      "phase": 26.039241789125867
+      "amplitude": 0.071,
+      "phase": 26.04
     },
     {
       "name": "P1",
-      "amplitude": 0.02970964150937046,
-      "phase": 32.92586600366269
+      "amplitude": 0.03,
+      "phase": 32.93
     },
     {
       "name": "O1",
-      "amplitude": 0.09311483337628124,
-      "phase": 235.48607223376462
+      "amplitude": 0.093,
+      "phase": 235.49
     },
     {
       "name": "Q1",
-      "amplitude": 0.02890115016751729,
-      "phase": 177.5083327591608
+      "amplitude": 0.029,
+      "phase": 177.51
     },
     {
       "name": "M1",
-      "amplitude": 0.0015580912060499347,
-      "phase": 80.29540187281543
+      "amplitude": 0.002,
+      "phase": 80.3
     },
     {
       "name": "M4",
-      "amplitude": 0.08110911569494511,
-      "phase": 131.94436646469592
+      "amplitude": 0.081,
+      "phase": 131.94
     },
     {
       "name": "MM",
-      "amplitude": 0.0220187930363097,
-      "phase": 174.45141316496733
+      "amplitude": 0.022,
+      "phase": 174.45
     },
     {
       "name": "MF",
-      "amplitude": 0.00991482501748204,
-      "phase": 176.3132103129078
+      "amplitude": 0.01,
+      "phase": 176.31
     },
     {
       "name": "SA",
-      "amplitude": 0.09835753572931785,
-      "phase": 224.1022232128566
+      "amplitude": 0.098,
+      "phase": 224.1
     },
     {
       "name": "SSA",
-      "amplitude": 0.0351503909507898,
-      "phase": 205.14092557551697
+      "amplitude": 0.035,
+      "phase": 205.14
     },
     {
       "name": "T2",
-      "amplitude": 0.020933921938831028,
-      "phase": 4.115388800611413
+      "amplitude": 0.021,
+      "phase": 4.12
     },
     {
       "name": "J1",
-      "amplitude": 0.0015663433651208652,
-      "phase": 140.29465744473782
+      "amplitude": 0.002,
+      "phase": 140.29
     },
     {
       "name": "L2",
-      "amplitude": 0.11762944406690877,
-      "phase": 335.52943780694386
+      "amplitude": 0.118,
+      "phase": 335.53
     },
     {
       "name": "R2",
-      "amplitude": 0.002390311968226765,
-      "phase": 26.489548141392106
+      "amplitude": 0.002,
+      "phase": 26.49
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005991053130195831,
-      "phase": 119.40194172686148
+      "amplitude": 0.006,
+      "phase": 119.4
     },
     {
       "name": "MSF",
-      "amplitude": 0.0039009718093575246,
-      "phase": 17.370447907411346
+      "amplitude": 0.004,
+      "phase": 17.37
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008290475282971261,
-      "phase": 64.53990982805897
+      "amplitude": 0.008,
+      "phase": 64.54
     },
     {
       "name": "EP2",
-      "amplitude": 0.03380944703529257,
-      "phase": 21.173095480366783
+      "amplitude": 0.034,
+      "phase": 21.17
     },
     {
       "name": "M3",
-      "amplitude": 0.0036186874051376415,
-      "phase": 349.60771681115114
+      "amplitude": 0.004,
+      "phase": 349.61
     },
     {
       "name": "MU2",
-      "amplitude": 0.15079754999844366,
-      "phase": 44.27360007699838
+      "amplitude": 0.151,
+      "phase": 44.27
     },
     {
       "name": "MTM",
-      "amplitude": 0.004976272473944628,
-      "phase": 243.7212666513757
+      "amplitude": 0.005,
+      "phase": 243.72
     },
     {
       "name": "NU2",
-      "amplitude": 0.084629918997072,
-      "phase": 276.77356454076994
+      "amplitude": 0.085,
+      "phase": 276.77
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0564141484040068,
-      "phase": 330.6003095488693
+      "amplitude": 0.056,
+      "phase": 330.6
     },
     {
       "name": "MN4",
-      "amplitude": 0.02585539134811113,
-      "phase": 112.51059836674466
+      "amplitude": 0.026,
+      "phase": 112.51
     },
     {
       "name": "MS4",
-      "amplitude": 0.05756444953217293,
-      "phase": 203.6339627516369
+      "amplitude": 0.058,
+      "phase": 203.63
     },
     {
       "name": "N4",
-      "amplitude": 0.005755543683408693,
-      "phase": 91.25374187670013
+      "amplitude": 0.006,
+      "phase": 91.25
     },
     {
       "name": "M6",
-      "amplitude": 0.0487867734115169,
-      "phase": 304.7933929381518
+      "amplitude": 0.049,
+      "phase": 304.79
     },
     {
       "name": "M8",
-      "amplitude": 0.007725677249352199,
-      "phase": 135.48740143963192
+      "amplitude": 0.008,
+      "phase": 135.49
     },
     {
       "name": "S4",
-      "amplitude": 0.0070337615573026965,
-      "phase": 330.8517082978306
+      "amplitude": 0.007,
+      "phase": 330.85
     },
     {
       "name": "OO1",
-      "amplitude": 0.0024546433069290506,
-      "phase": 196.76203038084103
+      "amplitude": 0.002,
+      "phase": 196.76
     },
     {
       "name": "S3",
-      "amplitude": 0.0001581139378353024,
-      "phase": 171.01410485795736
+      "amplitude": 0,
+      "phase": 171.01
     },
     {
       "name": "MA2",
-      "amplitude": 0.051106973879252296,
-      "phase": 271.65332061774785
+      "amplitude": 0.051,
+      "phase": 271.65
     },
     {
       "name": "MB2",
-      "amplitude": 0.022798082477239093,
-      "phase": 48.13078536769547
+      "amplitude": 0.023,
+      "phase": 48.13
     },
     {
       "name": "T3",
-      "amplitude": 0.0002649880485596075,
-      "phase": 34.17526624661599
+      "amplitude": 0,
+      "phase": 34.18
     },
     {
       "name": "R3",
-      "amplitude": 0.0025596785804692943,
-      "phase": 24.91249641033761
+      "amplitude": 0.003,
+      "phase": 24.91
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005851022683045161,
-      "phase": 178.68880808463723
+      "amplitude": 0.006,
+      "phase": 178.69
     },
     {
       "name": "SGM",
-      "amplitude": 0.0023038658274725367,
-      "phase": 45.586016329073175
+      "amplitude": 0.002,
+      "phase": 45.59
     },
     {
       "name": "3L2",
-      "amplitude": 0.0037106178205099246,
-      "phase": 236.71636391571013
+      "amplitude": 0.004,
+      "phase": 236.72
     },
     {
       "name": "3N2",
-      "amplitude": 0.018328528444434604,
-      "phase": 118.63147743347548
+      "amplitude": 0.018,
+      "phase": 118.63
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03792811924292489,
-      "phase": 249.92942343631142
+      "amplitude": 0.038,
+      "phase": 249.93
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05029679602487772,
-      "phase": 9.756521659847238
+      "amplitude": 0.05,
+      "phase": 9.76
     },
     {
       "name": "2MK5",
-      "amplitude": 0.003495834632447723,
-      "phase": 344.36011606382306
+      "amplitude": 0.003,
+      "phase": 344.36
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0020651461054412524,
-      "phase": 205.15943403680123
+      "amplitude": 0.002,
+      "phase": 205.16
     }
   ],
   "epoch": {

--- a/data/ticon/schleimndesp-9610025-deu-wsv.json
+++ b/data/ticon/schleimndesp-9610025-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.04739920675339321,
-      "phase": 110.08268178498969
+      "amplitude": 0.047,
+      "phase": 110.08
     },
     {
       "name": "N2",
-      "amplitude": 0.013759689496996661,
-      "phase": 57.62440102660099
+      "amplitude": 0.014,
+      "phase": 57.62
     },
     {
       "name": "S2",
-      "amplitude": 0.012107023191004767,
-      "phase": 48.24149175591549
+      "amplitude": 0.012,
+      "phase": 48.24
     },
     {
       "name": "K2",
-      "amplitude": 0.0030066828359278197,
-      "phase": 25.44173695745377
+      "amplitude": 0.003,
+      "phase": 25.44
     },
     {
       "name": "2N2",
-      "amplitude": 0.001948786611534015,
-      "phase": 26.984367699816687
+      "amplitude": 0.002,
+      "phase": 26.98
     },
     {
       "name": "S1",
-      "amplitude": 0.008289007226355626,
-      "phase": 187.58150999061417
+      "amplitude": 0.008,
+      "phase": 187.58
     },
     {
       "name": "K1",
-      "amplitude": 0.02108626202781233,
-      "phase": 211.09787311263287
+      "amplitude": 0.021,
+      "phase": 211.1
     },
     {
       "name": "P1",
-      "amplitude": 0.008006016180077374,
-      "phase": 241.8840171416562
+      "amplitude": 0.008,
+      "phase": 241.88
     },
     {
       "name": "O1",
-      "amplitude": 0.01723353920149593,
-      "phase": 105.15427581871631
+      "amplitude": 0.017,
+      "phase": 105.15
     },
     {
       "name": "Q1",
-      "amplitude": 0.005164282424104948,
-      "phase": 307.96574100299176
+      "amplitude": 0.005,
+      "phase": 307.97
     },
     {
       "name": "M1",
-      "amplitude": 0.00016601132551515789,
-      "phase": 125.56045628757528
+      "amplitude": 0,
+      "phase": 125.56
     },
     {
       "name": "M4",
-      "amplitude": 0.0017834578440899219,
-      "phase": 183.3988827405834
+      "amplitude": 0.002,
+      "phase": 183.4
     },
     {
       "name": "MM",
-      "amplitude": 0.011464944308080961,
-      "phase": 291.5012115026515
+      "amplitude": 0.011,
+      "phase": 291.5
     },
     {
       "name": "MF",
-      "amplitude": 0.010135478043639413,
-      "phase": 249.0120159476295
+      "amplitude": 0.01,
+      "phase": 249.01
     },
     {
       "name": "SA",
-      "amplitude": 0.03446383486245829,
-      "phase": 182.87249480402838
+      "amplitude": 0.034,
+      "phase": 182.87
     },
     {
       "name": "SSA",
-      "amplitude": 0.015860479168677985,
-      "phase": 279.30263665745133
+      "amplitude": 0.016,
+      "phase": 279.3
     },
     {
       "name": "T2",
-      "amplitude": 0.0009124482439891846,
-      "phase": 48.52271699013596
+      "amplitude": 0.001,
+      "phase": 48.52
     },
     {
       "name": "J1",
-      "amplitude": 0.0011911166311226542,
-      "phase": 133.8898025251109
+      "amplitude": 0.001,
+      "phase": 133.89
     },
     {
       "name": "L2",
-      "amplitude": 0.004656334348978155,
-      "phase": 209.19585188294465
+      "amplitude": 0.005,
+      "phase": 209.2
     },
     {
       "name": "R2",
-      "amplitude": 0.0010839008199682151,
-      "phase": 121.29451448453204
+      "amplitude": 0.001,
+      "phase": 121.29
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0015004871111473376,
-      "phase": 274.2035952043935
+      "amplitude": 0.002,
+      "phase": 274.2
     },
     {
       "name": "MSF",
-      "amplitude": 0.0023990308417559565,
-      "phase": 229.87399817143498
+      "amplitude": 0.002,
+      "phase": 229.87
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004560404740684584,
-      "phase": 216.5732981128987
+      "amplitude": 0.005,
+      "phase": 216.57
     },
     {
       "name": "EP2",
-      "amplitude": 0.0028739259568362633,
-      "phase": 238.49722060614886
+      "amplitude": 0.003,
+      "phase": 238.5
     },
     {
       "name": "M3",
-      "amplitude": 0.0003914827772354132,
-      "phase": 330.66053701266725
+      "amplitude": 0,
+      "phase": 330.66
     },
     {
       "name": "MU2",
-      "amplitude": 0.011871077363354602,
-      "phase": 278.49847247618345
+      "amplitude": 0.012,
+      "phase": 278.5
     },
     {
       "name": "MTM",
-      "amplitude": 0.003934568153751144,
-      "phase": 336.6385174981105
+      "amplitude": 0.004,
+      "phase": 336.64
     },
     {
       "name": "NU2",
-      "amplitude": 0.0050120550550657806,
-      "phase": 95.19588071934356
+      "amplitude": 0.005,
+      "phase": 95.2
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.002622048565112042,
-      "phase": 202.35626146583076
+      "amplitude": 0.003,
+      "phase": 202.36
     },
     {
       "name": "MN4",
-      "amplitude": 0.0005433687235431521,
-      "phase": 123.80408377571484
+      "amplitude": 0.001,
+      "phase": 123.8
     },
     {
       "name": "MS4",
-      "amplitude": 0.00039157783132856225,
-      "phase": 320.54334644524
+      "amplitude": 0,
+      "phase": 320.54
     },
     {
       "name": "N4",
-      "amplitude": 0.00015835256224058046,
-      "phase": 100.15479518793632
+      "amplitude": 0,
+      "phase": 100.15
     },
     {
       "name": "M6",
-      "amplitude": 0.00011161491076492255,
-      "phase": 240.547942342168
+      "amplitude": 0,
+      "phase": 240.55
     },
     {
       "name": "M8",
-      "amplitude": 0.00001358206401472715,
-      "phase": 345.4324052792734
+      "amplitude": 0,
+      "phase": 345.43
     },
     {
       "name": "S4",
-      "amplitude": 0.00013228356869883688,
-      "phase": 271.7087176183079
+      "amplitude": 0,
+      "phase": 271.71
     },
     {
       "name": "OO1",
-      "amplitude": 0.0016660922323459436,
-      "phase": 123.84074313102411
+      "amplitude": 0.002,
+      "phase": 123.84
     },
     {
       "name": "S3",
-      "amplitude": 0.00021339542419531132,
-      "phase": 199.61194862900007
+      "amplitude": 0,
+      "phase": 199.61
     },
     {
       "name": "MA2",
-      "amplitude": 0.006571631279214371,
-      "phase": 98.87078467950238
+      "amplitude": 0.007,
+      "phase": 98.87
     },
     {
       "name": "MB2",
-      "amplitude": 0.007193407418836491,
-      "phase": 262.04148348822747
+      "amplitude": 0.007,
+      "phase": 262.04
     },
     {
       "name": "T3",
-      "amplitude": 0.00009070907111006926,
-      "phase": 121.35401965345818
+      "amplitude": 0,
+      "phase": 121.35
     },
     {
       "name": "R3",
-      "amplitude": 0.00014719287636705088,
-      "phase": 243.4603467710807
+      "amplitude": 0,
+      "phase": 243.46
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0007295818972712473,
-      "phase": 260.5249530237244
+      "amplitude": 0.001,
+      "phase": 260.52
     },
     {
       "name": "SGM",
-      "amplitude": 0.003094281956490612,
-      "phase": 216.35385120631733
+      "amplitude": 0.003,
+      "phase": 216.35
     },
     {
       "name": "3L2",
-      "amplitude": 0.00046953334932595543,
-      "phase": 351.24365847871525
+      "amplitude": 0,
+      "phase": 351.24
     },
     {
       "name": "3N2",
-      "amplitude": 0.0015496534783852268,
-      "phase": 16.66186981449107
+      "amplitude": 0.002,
+      "phase": 16.66
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0018052905409301524,
-      "phase": 167.25881536039878
+      "amplitude": 0.002,
+      "phase": 167.26
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00013815812083906213,
-      "phase": 293.6839952763368
+      "amplitude": 0,
+      "phase": 293.68
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000058046190279214354,
-      "phase": 123.62777912496739
+      "amplitude": 0,
+      "phase": 123.63
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00011393724626128319,
-      "phase": 192.52173297716368
+      "amplitude": 0,
+      "phase": 192.52
     }
   ],
   "epoch": {

--- a/data/ticon/schoonhoven-schoonhvn-nld-rws.json
+++ b/data/ticon/schoonhoven-schoonhvn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.45677531000000005,
-      "phase": 156.72354100000007
+      "amplitude": 0.468,
+      "phase": 145.04
     },
     {
       "name": "N2",
-      "amplitude": 0.06469515,
-      "phase": 131.24782700000003
+      "amplitude": 0.066,
+      "phase": 119.71
     },
     {
       "name": "S2",
-      "amplitude": 0.10905595,
-      "phase": 220.621327
+      "amplitude": 0.117,
+      "phase": 211.29
     },
     {
       "name": "K2",
-      "amplitude": 0.03364403,
-      "phase": 225.103877
+      "amplitude": 0.035,
+      "phase": 211.62
     },
     {
       "name": "2N2",
-      "amplitude": 0.01038484,
-      "phase": 99.80009799999999
+      "amplitude": 0.012,
+      "phase": 90.51
     },
     {
       "name": "S1",
-      "amplitude": 0.00603567,
-      "phase": 0.22613200000000688
+      "amplitude": 0.015,
+      "phase": 323.01
     },
     {
       "name": "K1",
-      "amplitude": 0.03324913,
-      "phase": 31.45181100000002
+      "amplitude": 0.033,
+      "phase": 24.1
     },
     {
       "name": "P1",
-      "amplitude": 0.02006797,
-      "phase": 40.880967999999996
+      "amplitude": 0.02,
+      "phase": 35.43
     },
     {
       "name": "O1",
-      "amplitude": 0.056861129999999996,
-      "phase": 225.659937
+      "amplitude": 0.057,
+      "phase": 220.44
     },
     {
       "name": "Q1",
-      "amplitude": 0.02081955,
-      "phase": 174.493791
+      "amplitude": 0.021,
+      "phase": 168.66
     },
     {
       "name": "M1",
-      "amplitude": 0.0016194800000000002,
-      "phase": 152.85676899999999
+      "amplitude": 0.002,
+      "phase": 56.88
     },
     {
       "name": "M4",
-      "amplitude": 0.08259876000000001,
-      "phase": 257.66868999999997
+      "amplitude": 0.095,
+      "phase": 234.93
     },
     {
       "name": "MM",
-      "amplitude": 0.012197290000000001,
-      "phase": 57.37934799999999
+      "amplitude": 0.01,
+      "phase": 60.73
     },
     {
       "name": "MF",
-      "amplitude": 0.0050291699999999995,
-      "phase": 94.60756400000002
+      "amplitude": 0.005,
+      "phase": 88.55
     },
     {
       "name": "SA",
-      "amplitude": 0.13442074,
-      "phase": 311.404457
+      "amplitude": 0.134,
+      "phase": 316.33
     },
     {
       "name": "SSA",
-      "amplitude": 0.0830212,
-      "phase": 210.8346
+      "amplitude": 0.086,
+      "phase": 215.48
     },
     {
       "name": "T2",
-      "amplitude": 0.01798389,
-      "phase": 146.411749
+      "amplitude": 0.007,
+      "phase": 177.87
     },
     {
       "name": "J1",
-      "amplitude": 0.00071236,
-      "phase": 30.347249999999974
+      "amplitude": 0.001,
+      "phase": 27.35
     },
     {
       "name": "L2",
-      "amplitude": 0.041722279999999994,
-      "phase": 179.51405499999998
+      "amplitude": 0.043,
+      "phase": 168.59
     },
     {
       "name": "R2",
-      "amplitude": 0.00904932,
-      "phase": 319.33657
+      "amplitude": 0.002,
+      "phase": 223.64
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00382179,
-      "phase": 113.36403899999999
+      "amplitude": 0.004,
+      "phase": 108.58
     },
     {
       "name": "MSF",
-      "amplitude": 0.03455535,
-      "phase": 63.01315099999999
+      "amplitude": 0.035,
+      "phase": 60.11
     },
     {
       "name": "MSQM",
-      "amplitude": 0.002827,
-      "phase": 294.86920299999997
+      "amplitude": 0.003,
+      "phase": 297.23
     },
     {
       "name": "EP2",
-      "amplitude": 0.01113548,
-      "phase": 247.368131
+      "amplitude": 0.011,
+      "phase": 236.6
     },
     {
       "name": "M3",
-      "amplitude": 0.00118018,
-      "phase": 289.102269
+      "amplitude": 0.001,
+      "phase": 84.31
     },
     {
       "name": "MU2",
-      "amplitude": 0.05950818,
-      "phase": 264.354347
+      "amplitude": 0.06,
+      "phase": 252.51
     },
     {
       "name": "MTM",
-      "amplitude": 0.00868904,
-      "phase": 264.304434
+      "amplitude": 0.008,
+      "phase": 258.82
     },
     {
       "name": "NU2",
-      "amplitude": 0.03127771,
-      "phase": 125.33930700000002
+      "amplitude": 0.032,
+      "phase": 110.63
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02044673,
-      "phase": 177.941371
+      "amplitude": 0.021,
+      "phase": 167.1
     },
     {
       "name": "MN4",
-      "amplitude": 0.02565912,
-      "phase": 233.338975
+      "amplitude": 0.03,
+      "phase": 211.15
     },
     {
       "name": "MS4",
-      "amplitude": 0.045339090000000005,
-      "phase": 317.766518
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.01069226,
-      "phase": 261.72855400000003
+      "amplitude": 0.051,
+      "phase": 294.31
     },
     {
       "name": "N4",
-      "amplitude": 0.00713633,
-      "phase": 205.587139
+      "amplitude": 0.009,
+      "phase": 185.31
     },
     {
       "name": "M6",
-      "amplitude": 0.01822855,
-      "phase": 318.279819
+      "amplitude": 0.024,
+      "phase": 284.88
     },
     {
       "name": "M8",
-      "amplitude": 0.00358134,
-      "phase": 21.974491
+      "amplitude": 0.007,
+      "phase": 339.84
     },
     {
       "name": "S4",
-      "amplitude": 0.007904989999999999,
-      "phase": 67.85728499999999
+      "amplitude": 0.014,
+      "phase": 91.3
     },
     {
       "name": "OO1",
-      "amplitude": 0.0014954200000000001,
-      "phase": 232.693403
+      "amplitude": 0.002,
+      "phase": 223.27
     },
     {
       "name": "S3",
-      "amplitude": 0.0053342500000000004,
-      "phase": 133.781365
+      "amplitude": 0.011,
+      "phase": 344.31
     },
     {
       "name": "MA2",
-      "amplitude": 0.052636909999999995,
-      "phase": 139.63218
+      "amplitude": 0.003,
+      "phase": 45.89
     },
     {
       "name": "MB2",
-      "amplitude": 0.06296361,
-      "phase": 339.557748
+      "amplitude": 0.017,
+      "phase": 279.92
     },
     {
       "name": "T3",
-      "amplitude": 0.00134824,
-      "phase": 302.426601
+      "amplitude": 0.001,
+      "phase": 170.05
     },
     {
       "name": "R3",
-      "amplitude": 0.00300313,
-      "phase": 336.77227
+      "amplitude": 0.004,
+      "phase": 72.02
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0044101800000000005,
-      "phase": 160.69943999999998
+      "amplitude": 0.004,
+      "phase": 156.28
     },
     {
       "name": "SGM",
-      "amplitude": 0.0020094799999999997,
-      "phase": 119.07508899999999
+      "amplitude": 0.002,
+      "phase": 288.24
     },
     {
       "name": "3L2",
-      "amplitude": 0.0006312,
-      "phase": 339.259282
+      "amplitude": 0.002,
+      "phase": 160.53
     },
     {
       "name": "3N2",
-      "amplitude": 0.00028774000000000003,
-      "phase": 55.32982099999998
+      "amplitude": 0.003,
+      "phase": 234.51
     },
     {
       "name": "2SM2",
-      "amplitude": 0.01645826,
-      "phase": 89.95483899999999
+      "amplitude": 0.015,
+      "phase": 90.65
     },
     {
       "name": "2MS6",
-      "amplitude": 0.016388009999999998,
-      "phase": 16.230267000000026
+      "amplitude": 0.021,
+      "phase": 340.83
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0027034900000000002,
-      "phase": 30.98968100000002
+      "amplitude": 0.003,
+      "phase": 87.27
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0035144399999999998,
-      "phase": 53.283304999999984
+      "amplitude": 0.004,
+      "phase": 299.67
     }
   ],
   "epoch": {

--- a/data/ticon/schulau-5950090-deu-wsv.json
+++ b/data/ticon/schulau-5950090-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.446449583593393,
-      "phase": 71.14654492333199
+      "amplitude": 1.446,
+      "phase": 71.15
     },
     {
       "name": "N2",
-      "amplitude": 0.21741537284654475,
-      "phase": 44.67569195934374
+      "amplitude": 0.217,
+      "phase": 44.68
     },
     {
       "name": "S2",
-      "amplitude": 0.33179499793872264,
-      "phase": 147.52314223212318
+      "amplitude": 0.332,
+      "phase": 147.52
     },
     {
       "name": "K2",
-      "amplitude": 0.09981854795345095,
-      "phase": 145.83197743881647
+      "amplitude": 0.1,
+      "phase": 145.83
     },
     {
       "name": "2N2",
-      "amplitude": 0.022488179446488846,
-      "phase": 23.063826864761495
+      "amplitude": 0.022,
+      "phase": 23.06
     },
     {
       "name": "S1",
-      "amplitude": 0.019330183078467903,
-      "phase": 93.76095678091144
+      "amplitude": 0.019,
+      "phase": 93.76
     },
     {
       "name": "K1",
-      "amplitude": 0.07149810630922455,
-      "phase": 92.91600952926791
+      "amplitude": 0.071,
+      "phase": 92.92
     },
     {
       "name": "P1",
-      "amplitude": 0.030823770848663324,
-      "phase": 90.85130993214682
+      "amplitude": 0.031,
+      "phase": 90.85
     },
     {
       "name": "O1",
-      "amplitude": 0.08985909141644621,
-      "phase": 298.52979464386533
+      "amplitude": 0.09,
+      "phase": 298.53
     },
     {
       "name": "Q1",
-      "amplitude": 0.02596168506739939,
-      "phase": 239.2257738855304
+      "amplitude": 0.026,
+      "phase": 239.23
     },
     {
       "name": "M1",
-      "amplitude": 0.002315187838348206,
-      "phase": 151.77654416870013
+      "amplitude": 0.002,
+      "phase": 151.78
     },
     {
       "name": "M4",
-      "amplitude": 0.10133370652963157,
-      "phase": 26.72081448875474
+      "amplitude": 0.101,
+      "phase": 26.72
     },
     {
       "name": "MM",
-      "amplitude": 0.01708003598531995,
-      "phase": 145.9780225075827
+      "amplitude": 0.017,
+      "phase": 145.98
     },
     {
       "name": "MF",
-      "amplitude": 0.01429566289767265,
-      "phase": 109.87931002964172
+      "amplitude": 0.014,
+      "phase": 109.88
     },
     {
       "name": "SA",
-      "amplitude": 0.0677037761026257,
-      "phase": 241.17108682082787
+      "amplitude": 0.068,
+      "phase": 241.17
     },
     {
       "name": "SSA",
-      "amplitude": 0.047248657988171495,
-      "phase": 224.38626922992725
+      "amplitude": 0.047,
+      "phase": 224.39
     },
     {
       "name": "T2",
-      "amplitude": 0.02097822935804973,
-      "phase": 123.266151373659
+      "amplitude": 0.021,
+      "phase": 123.27
     },
     {
       "name": "J1",
-      "amplitude": 0.005428754786438921,
-      "phase": 224.81221625623485
+      "amplitude": 0.005,
+      "phase": 224.81
     },
     {
       "name": "L2",
-      "amplitude": 0.13110124344653717,
-      "phase": 91.16210046620506
+      "amplitude": 0.131,
+      "phase": 91.16
     },
     {
       "name": "R2",
-      "amplitude": 0.0035265447201967633,
-      "phase": 53.144521801950134
+      "amplitude": 0.004,
+      "phase": 53.14
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005798762220000855,
-      "phase": 174.7946779594863
+      "amplitude": 0.006,
+      "phase": 174.79
     },
     {
       "name": "MSF",
-      "amplitude": 0.05438082359636455,
-      "phase": 63.550249389880946
+      "amplitude": 0.054,
+      "phase": 63.55
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009727191984769793,
-      "phase": 49.90127246383105
+      "amplitude": 0.01,
+      "phase": 49.9
     },
     {
       "name": "EP2",
-      "amplitude": 0.03983410224932194,
-      "phase": 135.73085831278127
+      "amplitude": 0.04,
+      "phase": 135.73
     },
     {
       "name": "M3",
-      "amplitude": 0.0026971387670019884,
-      "phase": 134.21650646453367
+      "amplitude": 0.003,
+      "phase": 134.22
     },
     {
       "name": "MU2",
-      "amplitude": 0.19609527524711046,
-      "phase": 161.80530941370364
+      "amplitude": 0.196,
+      "phase": 161.81
     },
     {
       "name": "MTM",
-      "amplitude": 0.0039876142874895205,
-      "phase": 233.75813030382892
+      "amplitude": 0.004,
+      "phase": 233.76
     },
     {
       "name": "NU2",
-      "amplitude": 0.09928238935039851,
-      "phase": 27.488012416040476
+      "amplitude": 0.099,
+      "phase": 27.49
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05867319710916182,
-      "phase": 89.01206321495977
+      "amplitude": 0.059,
+      "phase": 89.01
     },
     {
       "name": "MN4",
-      "amplitude": 0.03431949454494315,
-      "phase": 2.0122759223312983
+      "amplitude": 0.034,
+      "phase": 2.01
     },
     {
       "name": "MS4",
-      "amplitude": 0.05665115208893941,
-      "phase": 98.05826265176057
+      "amplitude": 0.057,
+      "phase": 98.06
     },
     {
       "name": "N4",
-      "amplitude": 0.007063280245980722,
-      "phase": 340.4524426909005
+      "amplitude": 0.007,
+      "phase": 340.45
     },
     {
       "name": "M6",
-      "amplitude": 0.07013398924584864,
-      "phase": 270.444435830304
+      "amplitude": 0.07,
+      "phase": 270.44
     },
     {
       "name": "M8",
-      "amplitude": 0.022532385043234945,
-      "phase": 214.21152056504948
+      "amplitude": 0.023,
+      "phase": 214.21
     },
     {
       "name": "S4",
-      "amplitude": 0.005263049791368848,
-      "phase": 227.67193510283875
+      "amplitude": 0.005,
+      "phase": 227.67
     },
     {
       "name": "OO1",
-      "amplitude": 0.0030591893811490203,
-      "phase": 233.2893676726529
+      "amplitude": 0.003,
+      "phase": 233.29
     },
     {
       "name": "S3",
-      "amplitude": 0.0009284199746072306,
-      "phase": 11.461026602672575
+      "amplitude": 0.001,
+      "phase": 11.46
     },
     {
       "name": "MA2",
-      "amplitude": 0.04657559746723694,
-      "phase": 39.68142662009848
+      "amplitude": 0.047,
+      "phase": 39.68
     },
     {
       "name": "MB2",
-      "amplitude": 0.014254982414320452,
-      "phase": 96.86887344728848
+      "amplitude": 0.014,
+      "phase": 96.87
     },
     {
       "name": "T3",
-      "amplitude": 0.0009928986716534578,
-      "phase": 142.36588285695615
+      "amplitude": 0.001,
+      "phase": 142.37
     },
     {
       "name": "R3",
-      "amplitude": 0.00469457295130003,
-      "phase": 147.20301264696877
+      "amplitude": 0.005,
+      "phase": 147.2
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005761508656929061,
-      "phase": 242.52695043047254
+      "amplitude": 0.006,
+      "phase": 242.53
     },
     {
       "name": "SGM",
-      "amplitude": 0.0038026112867657635,
-      "phase": 74.29197192734534
+      "amplitude": 0.004,
+      "phase": 74.29
     },
     {
       "name": "3L2",
-      "amplitude": 0.003134671439546631,
-      "phase": 336.08205895732874
+      "amplitude": 0.003,
+      "phase": 336.08
     },
     {
       "name": "3N2",
-      "amplitude": 0.015302137450953223,
-      "phase": 230.1007792979598
+      "amplitude": 0.015,
+      "phase": 230.1
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03554752452627194,
-      "phase": 18.29781095340377
+      "amplitude": 0.036,
+      "phase": 18.3
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06395789062643739,
-      "phase": 340.23574827547327
+      "amplitude": 0.064,
+      "phase": 340.24
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005784697289415549,
-      "phase": 266.6306434933931
+      "amplitude": 0.006,
+      "phase": 266.63
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004584567879041798,
-      "phase": 126.7470709531948
+      "amplitude": 0.005,
+      "phase": 126.75
     }
   ],
   "epoch": {

--- a/data/ticon/sint_annaland_haven_steiger-sintanlhvsgr-nld-rws.json
+++ b/data/ticon/sint_annaland_haven_steiger-sintanlhvsgr-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.34886194,
-      "phase": 81.11173600000001
+      "amplitude": 1.396,
+      "phase": 63.78
     },
     {
       "name": "N2",
-      "amplitude": 0.19484108,
-      "phase": 58.08817799999997
+      "amplitude": 0.211,
+      "phase": 38.38
     },
     {
       "name": "S2",
-      "amplitude": 0.35150428,
-      "phase": 145.396768
+      "amplitude": 0.358,
+      "phase": 127.36
     },
     {
       "name": "K2",
-      "amplitude": 0.10074101,
-      "phase": 152.421469
+      "amplitude": 0.106,
+      "phase": 128.15
     },
     {
       "name": "2N2",
-      "amplitude": 0.05567352,
-      "phase": 48.953036999999995
+      "amplitude": 0.061,
+      "phase": 34.06
     },
     {
       "name": "S1",
-      "amplitude": 0.00720844,
-      "phase": 32.30458399999998
+      "amplitude": 0.009,
+      "phase": 316.58
     },
     {
       "name": "K1",
-      "amplitude": 0.06964838000000001,
-      "phase": 22.46883600000001
+      "amplitude": 0.07,
+      "phase": 13.44
     },
     {
       "name": "P1",
-      "amplitude": 0.03829384,
-      "phase": 5.396623999999974
+      "amplitude": 0.039,
+      "phase": 359.05
     },
     {
       "name": "O1",
-      "amplitude": 0.09985391,
-      "phase": 207.681978
+      "amplitude": 0.1,
+      "phase": 198.49
     },
     {
       "name": "Q1",
-      "amplitude": 0.04036433,
-      "phase": 149.358516
+      "amplitude": 0.04,
+      "phase": 140.5
     },
     {
       "name": "M1",
-      "amplitude": 0.00898107,
-      "phase": 274.812435
+      "amplitude": 0.003,
+      "phase": 22.96
     },
     {
       "name": "M4",
-      "amplitude": 0.08031566,
-      "phase": 181.602925
+      "amplitude": 0.094,
+      "phase": 147.2
     },
     {
       "name": "MM",
-      "amplitude": 0.02808579,
-      "phase": 40.66492499999998
+      "amplitude": 0.03,
+      "phase": 41.2
     },
     {
       "name": "MF",
-      "amplitude": 0.01417908,
-      "phase": 96.31454500000001
+      "amplitude": 0.014,
+      "phase": 95.96
     },
     {
       "name": "SA",
-      "amplitude": 0.10232680999999999,
-      "phase": 235.551391
+      "amplitude": 0.114,
+      "phase": 229.66
     },
     {
       "name": "SSA",
-      "amplitude": 0.02605772,
-      "phase": 217.899298
+      "amplitude": 0.025,
+      "phase": 199.57
     },
     {
       "name": "T2",
-      "amplitude": 0.06234908,
-      "phase": 64.446169
+      "amplitude": 0.025,
+      "phase": 115.26
     },
     {
       "name": "J1",
-      "amplitude": 0.00685774,
-      "phase": 161.435875
+      "amplitude": 0.007,
+      "phase": 152.26
     },
     {
       "name": "L2",
-      "amplitude": 0.13770863,
-      "phase": 93.89935200000002
+      "amplitude": 0.153,
+      "phase": 78.21
     },
     {
       "name": "R2",
-      "amplitude": 0.04591209,
-      "phase": 250.141345
+      "amplitude": 0.006,
+      "phase": 177.46
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00924707,
-      "phase": 93.26312200000001
+      "amplitude": 0.009,
+      "phase": 91.86
     },
     {
       "name": "MSF",
-      "amplitude": 0.044745520000000004,
-      "phase": 51.28492499999999
+      "amplitude": 0.046,
+      "phase": 52.01
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00429164,
-      "phase": 234.565023
+      "amplitude": 0.004,
+      "phase": 232.41
     },
     {
       "name": "EP2",
-      "amplitude": 0.024168440000000003,
-      "phase": 158.20877700000005
+      "amplitude": 0.023,
+      "phase": 132.01
     },
     {
       "name": "M3",
-      "amplitude": 0.00705046,
-      "phase": 194.608853
+      "amplitude": 0.007,
+      "phase": 352.52
     },
     {
       "name": "MU2",
-      "amplitude": 0.14464579,
-      "phase": 183.768291
+      "amplitude": 0.149,
+      "phase": 165.34
     },
     {
       "name": "MTM",
-      "amplitude": 0.00947225,
-      "phase": 254.279955
+      "amplitude": 0.01,
+      "phase": 250.27
     },
     {
       "name": "NU2",
-      "amplitude": 0.08793619,
-      "phase": 47.280910000000006
+      "amplitude": 0.087,
+      "phase": 26.63
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05292375,
-      "phase": 101.949592
+      "amplitude": 0.057,
+      "phase": 82.57
     },
     {
       "name": "MN4",
-      "amplitude": 0.02566496,
-      "phase": 152.172412
+      "amplitude": 0.031,
+      "phase": 121
     },
     {
       "name": "MS4",
-      "amplitude": 0.0511606,
-      "phase": 237.96073
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.06907082,
-      "phase": 215.552624
+      "amplitude": 0.059,
+      "phase": 201.73
     },
     {
       "name": "N4",
-      "amplitude": 0.00965292,
-      "phase": 151.935585
+      "amplitude": 0.012,
+      "phase": 112.85
     },
     {
       "name": "M6",
-      "amplitude": 0.02694598,
-      "phase": 202.671131
+      "amplitude": 0.041,
+      "phase": 145.5
     },
     {
       "name": "M8",
-      "amplitude": 0.00618592,
-      "phase": 153.78513099999998
+      "amplitude": 0.013,
+      "phase": 74.69
     },
     {
       "name": "S4",
-      "amplitude": 0.0036822,
-      "phase": 325.037176
+      "amplitude": 0.004,
+      "phase": 295.07
     },
     {
       "name": "OO1",
-      "amplitude": 0.00635661,
-      "phase": 179.40493100000003
+      "amplitude": 0.005,
+      "phase": 152.33
     },
     {
       "name": "S3",
-      "amplitude": 0.00156102,
-      "phase": 161.79208800000004
+      "amplitude": 0.001,
+      "phase": 53.03
     },
     {
       "name": "MA2",
-      "amplitude": 0.23351479,
-      "phase": 59.34873700000003
+      "amplitude": 0.021,
+      "phase": 55.39
     },
     {
       "name": "MB2",
-      "amplitude": 0.23245838,
-      "phase": 274.346415
+      "amplitude": 0.025,
+      "phase": 216.98
     },
     {
       "name": "T3",
-      "amplitude": 0.00274584,
-      "phase": 102.43696899999998
+      "amplitude": 0.003,
+      "phase": 283.45
     },
     {
       "name": "R3",
-      "amplitude": 0.0061428,
-      "phase": 337.443768
+      "amplitude": 0.006,
+      "phase": 35.73
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00849955,
-      "phase": 133.411794
+      "amplitude": 0.008,
+      "phase": 133.5
     },
     {
       "name": "SGM",
-      "amplitude": 0.00231637,
-      "phase": 44.596637999999984
+      "amplitude": 0.003,
+      "phase": 225.16
     },
     {
       "name": "3L2",
-      "amplitude": 0.05483009,
-      "phase": 252.863538
+      "amplitude": 0.062,
+      "phase": 349.26
     },
     {
       "name": "3N2",
-      "amplitude": 0.01086745,
-      "phase": 152.05468199999996
+      "amplitude": 0.012,
+      "phase": 203.63
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03859769,
-      "phase": 8.373634999999979
+      "amplitude": 0.039,
+      "phase": 350.17
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02425679,
-      "phase": 253.231526
+      "amplitude": 0.035,
+      "phase": 195.22
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00358612,
-      "phase": 168.249102
+      "amplitude": 0.004,
+      "phase": 202.23
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00203497,
-      "phase": 109.56425999999999
+      "amplitude": 0.002,
+      "phase": 342.84
     }
   ],
   "epoch": {

--- a/data/ticon/spiekeroog-9410010-deu-wsv.json
+++ b/data/ticon/spiekeroog-9410010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2322231054672028,
-      "phase": 301.4741651781163
+      "amplitude": 1.232,
+      "phase": 301.47
     },
     {
       "name": "N2",
-      "amplitude": 0.19753999623121402,
-      "phase": 276.5285039772563
+      "amplitude": 0.198,
+      "phase": 276.53
     },
     {
       "name": "S2",
-      "amplitude": 0.3278004411176775,
-      "phase": 9.582872654988591
+      "amplitude": 0.328,
+      "phase": 9.58
     },
     {
       "name": "K2",
-      "amplitude": 0.0982156276168592,
-      "phase": 7.584085459899541
+      "amplitude": 0.098,
+      "phase": 7.58
     },
     {
       "name": "2N2",
-      "amplitude": 0.023633930037891628,
-      "phase": 260.7327990945006
+      "amplitude": 0.024,
+      "phase": 260.73
     },
     {
       "name": "S1",
-      "amplitude": 0.010583215047048813,
-      "phase": 18.457916448216906
+      "amplitude": 0.011,
+      "phase": 18.46
     },
     {
       "name": "K1",
-      "amplitude": 0.06900229206086092,
-      "phase": 18.8824805062751
+      "amplitude": 0.069,
+      "phase": 18.88
     },
     {
       "name": "P1",
-      "amplitude": 0.0288290467753699,
-      "phase": 26.19911379233804
+      "amplitude": 0.029,
+      "phase": 26.2
     },
     {
       "name": "O1",
-      "amplitude": 0.08873309173762399,
-      "phase": 229.1018991884816
+      "amplitude": 0.089,
+      "phase": 229.1
     },
     {
       "name": "Q1",
-      "amplitude": 0.028735733659843315,
-      "phase": 171.08372333470004
+      "amplitude": 0.029,
+      "phase": 171.08
     },
     {
       "name": "M1",
-      "amplitude": 0.0017378229971392045,
-      "phase": 74.48472327359082
+      "amplitude": 0.002,
+      "phase": 74.48
     },
     {
       "name": "M4",
-      "amplitude": 0.020846536689868186,
-      "phase": 108.81174819443675
+      "amplitude": 0.021,
+      "phase": 108.81
     },
     {
       "name": "MM",
-      "amplitude": 0.023124360650425887,
-      "phase": 175.0338032472181
+      "amplitude": 0.023,
+      "phase": 175.03
     },
     {
       "name": "MF",
-      "amplitude": 0.008730480043957049,
-      "phase": 177.11908913428056
+      "amplitude": 0.009,
+      "phase": 177.12
     },
     {
       "name": "SA",
-      "amplitude": 0.10856129316443903,
-      "phase": 224.94795238027433
+      "amplitude": 0.109,
+      "phase": 224.95
     },
     {
       "name": "SSA",
-      "amplitude": 0.03458886625485132,
-      "phase": 212.73426883578153
+      "amplitude": 0.035,
+      "phase": 212.73
     },
     {
       "name": "T2",
-      "amplitude": 0.01686040247750227,
-      "phase": 346.9188227293721
+      "amplitude": 0.017,
+      "phase": 346.92
     },
     {
       "name": "J1",
-      "amplitude": 0.001383787734394468,
-      "phase": 133.08357114634987
+      "amplitude": 0.001,
+      "phase": 133.08
     },
     {
       "name": "L2",
-      "amplitude": 0.09539146605071272,
-      "phase": 318.5185224935065
+      "amplitude": 0.095,
+      "phase": 318.52
     },
     {
       "name": "R2",
-      "amplitude": 0.0025623964909776576,
-      "phase": 350.4804943546459
+      "amplitude": 0.003,
+      "phase": 350.48
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005520747580547374,
-      "phase": 120.10687509420563
+      "amplitude": 0.006,
+      "phase": 120.11
     },
     {
       "name": "MSF",
-      "amplitude": 0.003996126220670923,
-      "phase": 54.96802846338625
+      "amplitude": 0.004,
+      "phase": 54.97
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00829817035017046,
-      "phase": 57.90847247058991
+      "amplitude": 0.008,
+      "phase": 57.91
     },
     {
       "name": "EP2",
-      "amplitude": 0.026838407635439456,
-      "phase": 6.2007739270739535
+      "amplitude": 0.027,
+      "phase": 6.2
     },
     {
       "name": "M3",
-      "amplitude": 0.004023201364609383,
-      "phase": 300.79707468932855
+      "amplitude": 0.004,
+      "phase": 300.8
     },
     {
       "name": "MU2",
-      "amplitude": 0.11704193622450045,
-      "phase": 30.09040684886679
+      "amplitude": 0.117,
+      "phase": 30.09
     },
     {
       "name": "MTM",
-      "amplitude": 0.005969461308043947,
-      "phase": 229.02743044597665
+      "amplitude": 0.006,
+      "phase": 229.03
     },
     {
       "name": "NU2",
-      "amplitude": 0.06973139682932104,
-      "phase": 261.53270219383785
+      "amplitude": 0.07,
+      "phase": 261.53
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04550133832211124,
-      "phase": 311.9866352828205
+      "amplitude": 0.046,
+      "phase": 311.99
     },
     {
       "name": "MN4",
-      "amplitude": 0.00825429416365234,
-      "phase": 103.50096522171253
+      "amplitude": 0.008,
+      "phase": 103.5
     },
     {
       "name": "MS4",
-      "amplitude": 0.024239356481650976,
-      "phase": 157.42353198703518
+      "amplitude": 0.024,
+      "phase": 157.42
     },
     {
       "name": "N4",
-      "amplitude": 0.002219296645872359,
-      "phase": 79.24890087404412
+      "amplitude": 0.002,
+      "phase": 79.25
     },
     {
       "name": "M6",
-      "amplitude": 0.048762199482237846,
-      "phase": 245.14281731461247
+      "amplitude": 0.049,
+      "phase": 245.14
     },
     {
       "name": "M8",
-      "amplitude": 0.013250080980349811,
-      "phase": 112.65873555796531
+      "amplitude": 0.013,
+      "phase": 112.66
     },
     {
       "name": "S4",
-      "amplitude": 0.004920465887701446,
-      "phase": 268.2846099016337
+      "amplitude": 0.005,
+      "phase": 268.28
     },
     {
       "name": "OO1",
-      "amplitude": 0.002446811859612363,
-      "phase": 184.0802933159152
+      "amplitude": 0.002,
+      "phase": 184.08
     },
     {
       "name": "S3",
-      "amplitude": 0.0004530789311751058,
-      "phase": 93.83905752113935
+      "amplitude": 0,
+      "phase": 93.84
     },
     {
       "name": "MA2",
-      "amplitude": 0.04034036181715413,
-      "phase": 247.195635678136
+      "amplitude": 0.04,
+      "phase": 247.2
     },
     {
       "name": "MB2",
-      "amplitude": 0.022525549170209314,
-      "phase": 26.300703028217868
+      "amplitude": 0.023,
+      "phase": 26.3
     },
     {
       "name": "T3",
-      "amplitude": 0.000455659509799043,
-      "phase": 352.1315337063963
+      "amplitude": 0,
+      "phase": 352.13
     },
     {
       "name": "R3",
-      "amplitude": 0.0025691171623432683,
-      "phase": 349.24308328911263
+      "amplitude": 0.003,
+      "phase": 349.24
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005788268533085228,
-      "phase": 175.17242952783727
+      "amplitude": 0.006,
+      "phase": 175.17
     },
     {
       "name": "SGM",
-      "amplitude": 0.002114160365647809,
-      "phase": 37.78787481750487
+      "amplitude": 0.002,
+      "phase": 37.79
     },
     {
       "name": "3L2",
-      "amplitude": 0.0033282752238369268,
-      "phase": 213.9153126911189
+      "amplitude": 0.003,
+      "phase": 213.92
     },
     {
       "name": "3N2",
-      "amplitude": 0.014103551579722318,
-      "phase": 99.17490313177825
+      "amplitude": 0.014,
+      "phase": 99.17
     },
     {
       "name": "2SM2",
-      "amplitude": 0.030591140535760456,
-      "phase": 228.53219731058925
+      "amplitude": 0.031,
+      "phase": 228.53
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05043756997507843,
-      "phase": 308.06336385781333
+      "amplitude": 0.05,
+      "phase": 308.06
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00508915767279295,
-      "phase": 241.07491907010888
+      "amplitude": 0.005,
+      "phase": 241.07
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0021092768917221017,
-      "phase": 65.00666242803788
+      "amplitude": 0.002,
+      "phase": 65.01
     }
   ],
   "epoch": {

--- a/data/ticon/spijkenisse-spijknse-nld-rws.json
+++ b/data/ticon/spijkenisse-spijknse-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.65310074,
-      "phase": 95.36433999999997
+      "amplitude": 0.673,
+      "phase": 83.76
     },
     {
       "name": "N2",
-      "amplitude": 0.09401393000000001,
-      "phase": 67.813422
+      "amplitude": 0.097,
+      "phase": 56.41
     },
     {
       "name": "S2",
-      "amplitude": 0.15525840000000002,
-      "phase": 155.69263999999998
+      "amplitude": 0.159,
+      "phase": 143.87
     },
     {
       "name": "K2",
-      "amplitude": 0.048512440000000004,
-      "phase": 159.781971
+      "amplitude": 0.05,
+      "phase": 145.63
     },
     {
       "name": "2N2",
-      "amplitude": 0.01401176,
-      "phase": 34.04066599999999
+      "amplitude": 0.016,
+      "phase": 25.81
     },
     {
       "name": "S1",
-      "amplitude": 0.00459545,
-      "phase": 345.22097
+      "amplitude": 0.008,
+      "phase": 301.28
     },
     {
       "name": "K1",
-      "amplitude": 0.05732915,
-      "phase": 7.534447
+      "amplitude": 0.057,
+      "phase": 1.31
     },
     {
       "name": "P1",
-      "amplitude": 0.02735116,
-      "phase": 356.25104699999997
+      "amplitude": 0.027,
+      "phase": 351.04
     },
     {
       "name": "O1",
-      "amplitude": 0.0847061,
-      "phase": 195.985003
+      "amplitude": 0.085,
+      "phase": 190.22
     },
     {
       "name": "Q1",
-      "amplitude": 0.03022806,
-      "phase": 141.929527
+      "amplitude": 0.03,
+      "phase": 135.75
     },
     {
       "name": "M1",
-      "amplitude": 0.00054925,
-      "phase": 199.096158
+      "amplitude": 0.002,
+      "phase": 11.4
     },
     {
       "name": "M4",
-      "amplitude": 0.12321764,
-      "phase": 177.79521899999997
+      "amplitude": 0.141,
+      "phase": 154.63
     },
     {
       "name": "MM",
-      "amplitude": 0.00580272,
-      "phase": 119.46896500000003
+      "amplitude": 0.006,
+      "phase": 112.79
     },
     {
       "name": "MF",
-      "amplitude": 0.0065910199999999995,
-      "phase": 157.61706500000003
+      "amplitude": 0.007,
+      "phase": 161.4
     },
     {
       "name": "SA",
-      "amplitude": 0.07976673,
-      "phase": 233.033042
+      "amplitude": 0.085,
+      "phase": 232.51
     },
     {
       "name": "SSA",
-      "amplitude": 0.03199673,
-      "phase": 166.45043499999997
+      "amplitude": 0.034,
+      "phase": 160.67
     },
     {
       "name": "T2",
-      "amplitude": 0.02494901,
-      "phase": 88.797957
+      "amplitude": 0.01,
+      "phase": 127.48
     },
     {
       "name": "J1",
-      "amplitude": 0.002793,
-      "phase": 118.69756899999999
+      "amplitude": 0.003,
+      "phase": 110.34
     },
     {
       "name": "L2",
-      "amplitude": 0.05586983,
-      "phase": 120.55348500000002
+      "amplitude": 0.058,
+      "phase": 108.97
     },
     {
       "name": "R2",
-      "amplitude": 0.011110580000000002,
-      "phase": 251.757719
+      "amplitude": 0.003,
+      "phase": 102.71
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005737379999999999,
-      "phase": 81.73721899999998
+      "amplitude": 0.006,
+      "phase": 78.75
     },
     {
       "name": "MSF",
-      "amplitude": 0.03157402,
-      "phase": 55.678147000000024
+      "amplitude": 0.032,
+      "phase": 55.13
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00404335,
-      "phase": 327.981838
+      "amplitude": 0.004,
+      "phase": 326.98
     },
     {
       "name": "EP2",
-      "amplitude": 0.01347373,
-      "phase": 195.642846
+      "amplitude": 0.013,
+      "phase": 184.55
     },
     {
       "name": "M3",
-      "amplitude": 0.00083829,
-      "phase": 250.874447
+      "amplitude": 0.001,
+      "phase": 60.82
     },
     {
       "name": "MU2",
-      "amplitude": 0.07638836,
-      "phase": 214.398811
+      "amplitude": 0.078,
+      "phase": 203.13
     },
     {
       "name": "MTM",
-      "amplitude": 0.006275429999999999,
-      "phase": 250.210016
+      "amplitude": 0.006,
+      "phase": 239.69
     },
     {
       "name": "NU2",
-      "amplitude": 0.041723590000000005,
-      "phase": 66.37211000000002
+      "amplitude": 0.044,
+      "phase": 51.91
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.027651500000000002,
-      "phase": 116.345846
+      "amplitude": 0.029,
+      "phase": 105.91
     },
     {
       "name": "MN4",
-      "amplitude": 0.04302066,
-      "phase": 154.05031600000007
+      "amplitude": 0.049,
+      "phase": 131.46
     },
     {
       "name": "MS4",
-      "amplitude": 0.07759069,
-      "phase": 234.782114
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.0104048,
-      "phase": 249.631461
+      "amplitude": 0.088,
+      "phase": 212.52
     },
     {
       "name": "N4",
-      "amplitude": 0.011294390000000001,
-      "phase": 125.33227499999998
+      "amplitude": 0.014,
+      "phase": 103.22
     },
     {
       "name": "M6",
-      "amplitude": 0.02444238,
-      "phase": 166.90209900000002
+      "amplitude": 0.034,
+      "phase": 133.33
     },
     {
       "name": "M8",
-      "amplitude": 0.00486142,
-      "phase": 239.59171700000002
+      "amplitude": 0.01,
+      "phase": 196.9
     },
     {
       "name": "S4",
-      "amplitude": 0.0080017,
-      "phase": 326.136985
+      "amplitude": 0.009,
+      "phase": 300.46
     },
     {
       "name": "OO1",
-      "amplitude": 0.00225859,
-      "phase": 149.687924
+      "amplitude": 0.002,
+      "phase": 137.92
     },
     {
       "name": "S3",
-      "amplitude": 0.0011829199999999998,
-      "phase": 63.47497099999998
+      "amplitude": 0,
+      "phase": 174.43
     },
     {
       "name": "MA2",
-      "amplitude": 0.08949665,
-      "phase": 87.511392
+      "amplitude": 0.015,
+      "phase": 96.2
     },
     {
       "name": "MB2",
-      "amplitude": 0.07124787,
-      "phase": 283.509464
+      "amplitude": 0.014,
+      "phase": 155.85
     },
     {
       "name": "T3",
-      "amplitude": 0.00124288,
-      "phase": 54.08407599999998
+      "amplitude": 0.001,
+      "phase": 225.42
     },
     {
       "name": "R3",
-      "amplitude": 0.00409804,
-      "phase": 273.62719
+      "amplitude": 0.004,
+      "phase": 343.23
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00555665,
-      "phase": 137.066641
+      "amplitude": 0.006,
+      "phase": 132.62
     },
     {
       "name": "SGM",
-      "amplitude": 0.00132328,
-      "phase": 205.536979
+      "amplitude": 0,
+      "phase": 4.38
     },
     {
       "name": "3L2",
-      "amplitude": 0.00153776,
-      "phase": 276.93593799999996
+      "amplitude": 0.004,
+      "phase": 80.68
     },
     {
       "name": "3N2",
-      "amplitude": 0.00165503,
-      "phase": 94.955828
+      "amplitude": 0.005,
+      "phase": 301.65
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02151831,
-      "phase": 26.697046999999998
+      "amplitude": 0.022,
+      "phase": 16.86
     },
     {
       "name": "2MS6",
-      "amplitude": 0.022045759999999998,
-      "phase": 223.341046
+      "amplitude": 0.029,
+      "phase": 189.39
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00723313,
-      "phase": 317.160806
+      "amplitude": 0.009,
+      "phase": 15.63
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00844691,
-      "phase": 323.650025
+      "amplitude": 0.01,
+      "phase": 208.86
     }
   ],
   "epoch": {

--- a/data/ticon/stadersand-5970013-deu-wsv.json
+++ b/data/ticon/stadersand-5970013-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3223284506961046,
-      "phase": 60.98284357566729
+      "amplitude": 1.322,
+      "phase": 60.98
     },
     {
       "name": "N2",
-      "amplitude": 0.1999723974619297,
-      "phase": 34.4708364755877
+      "amplitude": 0.2,
+      "phase": 34.47
     },
     {
       "name": "S2",
-      "amplitude": 0.30194970061225396,
-      "phase": 135.76911111682585
+      "amplitude": 0.302,
+      "phase": 135.77
     },
     {
       "name": "K2",
-      "amplitude": 0.09106363318095086,
-      "phase": 134.2226850889465
+      "amplitude": 0.091,
+      "phase": 134.22
     },
     {
       "name": "2N2",
-      "amplitude": 0.02063981803434763,
-      "phase": 12.463466081692616
+      "amplitude": 0.021,
+      "phase": 12.46
     },
     {
       "name": "S1",
-      "amplitude": 0.018236653050563472,
-      "phase": 89.92212709197014
+      "amplitude": 0.018,
+      "phase": 89.92
     },
     {
       "name": "K1",
-      "amplitude": 0.07090098292991678,
-      "phase": 88.39221470505834
+      "amplitude": 0.071,
+      "phase": 88.39
     },
     {
       "name": "P1",
-      "amplitude": 0.030333334901179804,
-      "phase": 85.53670095941385
+      "amplitude": 0.03,
+      "phase": 85.54
     },
     {
       "name": "O1",
-      "amplitude": 0.08913642829030416,
-      "phase": 293.88348237993216
+      "amplitude": 0.089,
+      "phase": 293.88
     },
     {
       "name": "Q1",
-      "amplitude": 0.025923665637828806,
-      "phase": 234.09077925546055
+      "amplitude": 0.026,
+      "phase": 234.09
     },
     {
       "name": "M1",
-      "amplitude": 0.002220581983028248,
-      "phase": 143.9097223467444
+      "amplitude": 0.002,
+      "phase": 143.91
     },
     {
       "name": "M4",
-      "amplitude": 0.10276425486245688,
-      "phase": 349.33544358317175
+      "amplitude": 0.103,
+      "phase": 349.34
     },
     {
       "name": "MM",
-      "amplitude": 0.016795187886119535,
-      "phase": 143.33248122420025
+      "amplitude": 0.017,
+      "phase": 143.33
     },
     {
       "name": "MF",
-      "amplitude": 0.014437667976964032,
-      "phase": 108.18671052483899
+      "amplitude": 0.014,
+      "phase": 108.19
     },
     {
       "name": "SA",
-      "amplitude": 0.0676127387647387,
-      "phase": 235.8261892065767
+      "amplitude": 0.068,
+      "phase": 235.83
     },
     {
       "name": "SSA",
-      "amplitude": 0.047302305662798694,
-      "phase": 222.04200221973338
+      "amplitude": 0.047,
+      "phase": 222.04
     },
     {
       "name": "T2",
-      "amplitude": 0.018758819018602456,
-      "phase": 112.54848733751402
+      "amplitude": 0.019,
+      "phase": 112.55
     },
     {
       "name": "J1",
-      "amplitude": 0.0054147450951619784,
-      "phase": 218.23838179978952
+      "amplitude": 0.005,
+      "phase": 218.24
     },
     {
       "name": "L2",
-      "amplitude": 0.11834448330892744,
-      "phase": 81.3888447329137
+      "amplitude": 0.118,
+      "phase": 81.39
     },
     {
       "name": "R2",
-      "amplitude": 0.004017871597560286,
-      "phase": 38.9906429543999
+      "amplitude": 0.004,
+      "phase": 38.99
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0057733647261287695,
-      "phase": 170.88834812980895
+      "amplitude": 0.006,
+      "phase": 170.89
     },
     {
       "name": "MSF",
-      "amplitude": 0.05630600203332195,
-      "phase": 63.25388845587241
+      "amplitude": 0.056,
+      "phase": 63.25
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009506190321887407,
-      "phase": 47.114384512688844
+      "amplitude": 0.01,
+      "phase": 47.11
     },
     {
       "name": "EP2",
-      "amplitude": 0.036088495277085846,
-      "phase": 126.82730120033705
+      "amplitude": 0.036,
+      "phase": 126.83
     },
     {
       "name": "M3",
-      "amplitude": 0.002370217395149973,
-      "phase": 105.36488132688788
+      "amplitude": 0.002,
+      "phase": 105.36
     },
     {
       "name": "MU2",
-      "amplitude": 0.17565522083601964,
-      "phase": 152.93751947488067
+      "amplitude": 0.176,
+      "phase": 152.94
     },
     {
       "name": "MTM",
-      "amplitude": 0.004075017570924109,
-      "phase": 229.31526674804851
+      "amplitude": 0.004,
+      "phase": 229.32
     },
     {
       "name": "NU2",
-      "amplitude": 0.08993002428395816,
-      "phase": 18.168746995114873
+      "amplitude": 0.09,
+      "phase": 18.17
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05246738035133906,
-      "phase": 78.71261335171522
+      "amplitude": 0.052,
+      "phase": 78.71
     },
     {
       "name": "MN4",
-      "amplitude": 0.03451833055375832,
-      "phase": 325.28208695360274
+      "amplitude": 0.035,
+      "phase": 325.28
     },
     {
       "name": "MS4",
-      "amplitude": 0.0589236597164101,
-      "phase": 59.741225242367534
+      "amplitude": 0.059,
+      "phase": 59.74
     },
     {
       "name": "N4",
-      "amplitude": 0.007007211449422267,
-      "phase": 304.0548295089027
+      "amplitude": 0.007,
+      "phase": 304.05
     },
     {
       "name": "M6",
-      "amplitude": 0.07913269319044856,
-      "phase": 228.01277255208214
+      "amplitude": 0.079,
+      "phase": 228.01
     },
     {
       "name": "M8",
-      "amplitude": 0.026707527911442312,
-      "phase": 185.0800054121317
+      "amplitude": 0.027,
+      "phase": 185.08
     },
     {
       "name": "S4",
-      "amplitude": 0.005395505164923081,
-      "phase": 190.97835611816217
+      "amplitude": 0.005,
+      "phase": 190.98
     },
     {
       "name": "OO1",
-      "amplitude": 0.002931458625184759,
-      "phase": 228.28162103895679
+      "amplitude": 0.003,
+      "phase": 228.28
     },
     {
       "name": "S3",
-      "amplitude": 0.0008301158802135896,
-      "phase": 336.7540989396107
+      "amplitude": 0.001,
+      "phase": 336.75
     },
     {
       "name": "MA2",
-      "amplitude": 0.04207356399542344,
-      "phase": 26.89757845243497
+      "amplitude": 0.042,
+      "phase": 26.9
     },
     {
       "name": "MB2",
-      "amplitude": 0.017950468429237827,
-      "phase": 77.94751096519349
+      "amplitude": 0.018,
+      "phase": 77.95
     },
     {
       "name": "T3",
-      "amplitude": 0.0007138703522806373,
-      "phase": 115.6305576621902
+      "amplitude": 0.001,
+      "phase": 115.63
     },
     {
       "name": "R3",
-      "amplitude": 0.003977444903792283,
-      "phase": 129.5742018454377
+      "amplitude": 0.004,
+      "phase": 129.57
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005516113144604729,
-      "phase": 237.49639277802254
+      "amplitude": 0.006,
+      "phase": 237.5
     },
     {
       "name": "SGM",
-      "amplitude": 0.0037106578582762175,
-      "phase": 73.72322245875534
+      "amplitude": 0.004,
+      "phase": 73.72
     },
     {
       "name": "3L2",
-      "amplitude": 0.0033487148100209293,
-      "phase": 324.0674536364904
+      "amplitude": 0.003,
+      "phase": 324.07
     },
     {
       "name": "3N2",
-      "amplitude": 0.013767349353405933,
-      "phase": 215.9764717236892
+      "amplitude": 0.014,
+      "phase": 215.98
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03168608265020653,
-      "phase": 6.539031390036996
+      "amplitude": 0.032,
+      "phase": 6.54
     },
     {
       "name": "2MS6",
-      "amplitude": 0.07474813129837005,
-      "phase": 298.26413276099277
+      "amplitude": 0.075,
+      "phase": 298.26
     },
     {
       "name": "2MK5",
-      "amplitude": 0.005030343848122493,
-      "phase": 232.4612744325798
+      "amplitude": 0.005,
+      "phase": 232.46
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004269506444206012,
-      "phase": 104.13958936964576
+      "amplitude": 0.004,
+      "phase": 104.14
     }
   ],
   "epoch": {

--- a/data/ticon/stahlbrode-9650070-deu-wsv.json
+++ b/data/ticon/stahlbrode-9650070-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.014373563638041022,
-      "phase": 318.0009924357544
+      "amplitude": 0.014,
+      "phase": 318
     },
     {
       "name": "N2",
-      "amplitude": 0.0042325646107584216,
-      "phase": 274.8751008288434
+      "amplitude": 0.004,
+      "phase": 274.88
     },
     {
       "name": "S2",
-      "amplitude": 0.003723023147039338,
-      "phase": 268.45316036045665
+      "amplitude": 0.004,
+      "phase": 268.45
     },
     {
       "name": "K2",
-      "amplitude": 0.0016943295411806106,
-      "phase": 257.5640204673404
+      "amplitude": 0.002,
+      "phase": 257.56
     },
     {
       "name": "2N2",
-      "amplitude": 0.000703719419662729,
-      "phase": 297.1959309029169
+      "amplitude": 0.001,
+      "phase": 297.2
     },
     {
       "name": "S1",
-      "amplitude": 0.007565450310989401,
-      "phase": 52.784808188775116
+      "amplitude": 0.008,
+      "phase": 52.78
     },
     {
       "name": "K1",
-      "amplitude": 0.008355221185214017,
-      "phase": 157.64737966442226
+      "amplitude": 0.008,
+      "phase": 157.65
     },
     {
       "name": "P1",
-      "amplitude": 0.0017584427162834042,
-      "phase": 131.61197001649407
+      "amplitude": 0.002,
+      "phase": 131.61
     },
     {
       "name": "O1",
-      "amplitude": 0.013955793599533462,
-      "phase": 151.57148719110103
+      "amplitude": 0.014,
+      "phase": 151.57
     },
     {
       "name": "Q1",
-      "amplitude": 0.0021810782176646996,
-      "phase": 108.53729191411071
+      "amplitude": 0.002,
+      "phase": 108.54
     },
     {
       "name": "M1",
-      "amplitude": 0.0005943656904593536,
-      "phase": 52.1155444412081
+      "amplitude": 0.001,
+      "phase": 52.12
     },
     {
       "name": "M4",
-      "amplitude": 0.0015180937817856298,
-      "phase": 13.599720270662544
+      "amplitude": 0.002,
+      "phase": 13.6
     },
     {
       "name": "MM",
-      "amplitude": 0.012379225046041581,
-      "phase": 288.0324139395474
+      "amplitude": 0.012,
+      "phase": 288.03
     },
     {
       "name": "MF",
-      "amplitude": 0.009414627532337017,
-      "phase": 275.05734840878154
+      "amplitude": 0.009,
+      "phase": 275.06
     },
     {
       "name": "SA",
-      "amplitude": 0.038966291370577284,
-      "phase": 192.52451415583576
+      "amplitude": 0.039,
+      "phase": 192.52
     },
     {
       "name": "SSA",
-      "amplitude": 0.030019419624572417,
-      "phase": 249.93050238103217
+      "amplitude": 0.03,
+      "phase": 249.93
     },
     {
       "name": "T2",
-      "amplitude": 0.00099413661500913,
-      "phase": 245.13005887226626
+      "amplitude": 0.001,
+      "phase": 245.13
     },
     {
       "name": "J1",
-      "amplitude": 0.0008204703710793698,
-      "phase": 209.2551444433948
+      "amplitude": 0.001,
+      "phase": 209.26
     },
     {
       "name": "L2",
-      "amplitude": 0.0015117559058314834,
-      "phase": 75.13394552974546
+      "amplitude": 0.002,
+      "phase": 75.13
     },
     {
       "name": "R2",
-      "amplitude": 0.0007354428865895321,
-      "phase": 37.65038780084933
+      "amplitude": 0.001,
+      "phase": 37.65
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00021357224936923512,
-      "phase": 217.87834554844312
+      "amplitude": 0,
+      "phase": 217.88
     },
     {
       "name": "MSF",
-      "amplitude": 0.001043543463979576,
-      "phase": 230.10556554033408
+      "amplitude": 0.001,
+      "phase": 230.11
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004422129437868075,
-      "phase": 203.96775904308967
+      "amplitude": 0.004,
+      "phase": 203.97
     },
     {
       "name": "EP2",
-      "amplitude": 0.0006159417083891754,
-      "phase": 89.21425668668684
+      "amplitude": 0.001,
+      "phase": 89.21
     },
     {
       "name": "M3",
-      "amplitude": 0.0006440262089732173,
-      "phase": 309.6258011530958
+      "amplitude": 0.001,
+      "phase": 309.63
     },
     {
       "name": "MU2",
-      "amplitude": 0.0025714351744952203,
-      "phase": 139.91576103282932
+      "amplitude": 0.003,
+      "phase": 139.92
     },
     {
       "name": "MTM",
-      "amplitude": 0.003936733823039306,
-      "phase": 347.7226591911321
+      "amplitude": 0.004,
+      "phase": 347.72
     },
     {
       "name": "NU2",
-      "amplitude": 0.0012350521744426053,
-      "phase": 321.1070410861123
+      "amplitude": 0.001,
+      "phase": 321.11
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0005849168134489455,
-      "phase": 66.19207248074986
+      "amplitude": 0.001,
+      "phase": 66.19
     },
     {
       "name": "MN4",
-      "amplitude": 0.0006035163741162568,
-      "phase": 310.1681939334312
+      "amplitude": 0.001,
+      "phase": 310.17
     },
     {
       "name": "MS4",
-      "amplitude": 0.0006934340503404614,
-      "phase": 176.30373474167595
+      "amplitude": 0.001,
+      "phase": 176.3
     },
     {
       "name": "N4",
-      "amplitude": 0.0001216296709074307,
-      "phase": 248.1147392568982
+      "amplitude": 0,
+      "phase": 248.11
     },
     {
       "name": "M6",
-      "amplitude": 0.00022563573874888836,
-      "phase": 201.43921024543388
+      "amplitude": 0,
+      "phase": 201.44
     },
     {
       "name": "M8",
-      "amplitude": 0.000030714847052459184,
-      "phase": 110.59787917950302
+      "amplitude": 0,
+      "phase": 110.6
     },
     {
       "name": "S4",
-      "amplitude": 0.00010492184578049182,
-      "phase": 101.8760636593073
+      "amplitude": 0,
+      "phase": 101.88
     },
     {
       "name": "OO1",
-      "amplitude": 0.00047042979466793385,
-      "phase": 94.80243119369663
+      "amplitude": 0,
+      "phase": 94.8
     },
     {
       "name": "S3",
-      "amplitude": 0.0008337172244515269,
-      "phase": 16.72710124818809
+      "amplitude": 0.001,
+      "phase": 16.73
     },
     {
       "name": "MA2",
-      "amplitude": 0.0009964575257721262,
-      "phase": 329.7962142010901
+      "amplitude": 0.001,
+      "phase": 329.8
     },
     {
       "name": "MB2",
-      "amplitude": 0.001724462851916635,
-      "phase": 89.79819436626212
+      "amplitude": 0.002,
+      "phase": 89.8
     },
     {
       "name": "T3",
-      "amplitude": 0.0007687808123317673,
-      "phase": 271.37215681433327
+      "amplitude": 0.001,
+      "phase": 271.37
     },
     {
       "name": "R3",
-      "amplitude": 0.0009006184508592717,
-      "phase": 24.895310934128304
+      "amplitude": 0.001,
+      "phase": 24.9
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0001832302217235109,
-      "phase": 303.3261287153177
+      "amplitude": 0,
+      "phase": 303.33
     },
     {
       "name": "SGM",
-      "amplitude": 0.001127157881850232,
-      "phase": 242.7795896704764
+      "amplitude": 0.001,
+      "phase": 242.78
     },
     {
       "name": "3L2",
-      "amplitude": 0.0002667076167725175,
-      "phase": 241.26888339719585
+      "amplitude": 0,
+      "phase": 241.27
     },
     {
       "name": "3N2",
-      "amplitude": 0.00040027247692279533,
-      "phase": 200.04951421896058
+      "amplitude": 0,
+      "phase": 200.05
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0007831957515110976,
-      "phase": 57.56286836420469
+      "amplitude": 0.001,
+      "phase": 57.56
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00019058889859414188,
-      "phase": 285.4862102589964
+      "amplitude": 0,
+      "phase": 285.49
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00007623148802587589,
-      "phase": 41.45131278989311
+      "amplitude": 0,
+      "phase": 41.45
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00007767534447912492,
-      "phase": 256.1023418116333
+      "amplitude": 0,
+      "phase": 256.1
     }
   ],
   "epoch": {

--- a/data/ticon/stavenisse-stavnse-nld-rws.json
+++ b/data/ticon/stavenisse-stavnse-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.40512938,
-      "phase": 72.30555700000002
+      "amplitude": 1.453,
+      "phase": 60.91
     },
     {
       "name": "N2",
-      "amplitude": 0.2210311,
-      "phase": 47.571000000000026
+      "amplitude": 0.227,
+      "phase": 37.26
     },
     {
       "name": "S2",
-      "amplitude": 0.35422913,
-      "phase": 134.25777700000003
+      "amplitude": 0.364,
+      "phase": 122.73
     },
     {
       "name": "K2",
-      "amplitude": 0.09979421000000001,
-      "phase": 136.05858999999998
+      "amplitude": 0.104,
+      "phase": 121.91
     },
     {
       "name": "2N2",
-      "amplitude": 0.029536760000000002,
-      "phase": 15.893591000000015
+      "amplitude": 0.033,
+      "phase": 6.6
     },
     {
       "name": "S1",
-      "amplitude": 0.00624617,
-      "phase": 6.556163000000026
+      "amplitude": 0.009,
+      "phase": 316.89
     },
     {
       "name": "K1",
-      "amplitude": 0.06755247,
-      "phase": 14.182859000000008
+      "amplitude": 0.068,
+      "phase": 8.12
     },
     {
       "name": "P1",
-      "amplitude": 0.03567018,
-      "phase": 357.657064
+      "amplitude": 0.036,
+      "phase": 352.22
     },
     {
       "name": "O1",
-      "amplitude": 0.10256671,
-      "phase": 197.301004
+      "amplitude": 0.103,
+      "phase": 191.52
     },
     {
       "name": "Q1",
-      "amplitude": 0.03577322,
-      "phase": 144.405511
+      "amplitude": 0.036,
+      "phase": 137.98
     },
     {
       "name": "M1",
-      "amplitude": 0.0009442200000000001,
-      "phase": 230.578435
+      "amplitude": 0.003,
+      "phase": 7.38
     },
     {
       "name": "M4",
-      "amplitude": 0.049948490000000005,
-      "phase": 171.21624700000007
+      "amplitude": 0.058,
+      "phase": 145.84
     },
     {
       "name": "MM",
-      "amplitude": 0.01019808,
-      "phase": 69.64548400000001
+      "amplitude": 0.01,
+      "phase": 66.14
     },
     {
       "name": "MF",
-      "amplitude": 0.00758003,
-      "phase": 103.72934800000002
+      "amplitude": 0.007,
+      "phase": 106.86
     },
     {
       "name": "SA",
-      "amplitude": 0.08424009,
-      "phase": 215.467579
+      "amplitude": 0.088,
+      "phase": 215.91
     },
     {
       "name": "SSA",
-      "amplitude": 0.024824799999999998,
-      "phase": 156.51669000000004
+      "amplitude": 0.026,
+      "phase": 151.12
     },
     {
       "name": "T2",
-      "amplitude": 0.0542867,
-      "phase": 62.048765
+      "amplitude": 0.018,
+      "phase": 102.75
     },
     {
       "name": "J1",
-      "amplitude": 0.00464193,
-      "phase": 122.59153300000003
+      "amplitude": 0.005,
+      "phase": 115.2
     },
     {
       "name": "L2",
-      "amplitude": 0.10993399999999999,
-      "phase": 89.94300199999998
+      "amplitude": 0.114,
+      "phase": 78.79
     },
     {
       "name": "R2",
-      "amplitude": 0.02733464,
-      "phase": 240.972687
+      "amplitude": 0.002,
+      "phase": 26.42
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00601788,
-      "phase": 80.83150899999998
+      "amplitude": 0.007,
+      "phase": 77.13
     },
     {
       "name": "MSF",
-      "amplitude": 0.05830952,
-      "phase": 49.515777000000014
+      "amplitude": 0.059,
+      "phase": 49.35
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00714684,
-      "phase": 325.501171
+      "amplitude": 0.007,
+      "phase": 325.57
     },
     {
       "name": "EP2",
-      "amplitude": 0.025873789999999997,
-      "phase": 160.61668299999997
+      "amplitude": 0.026,
+      "phase": 148.04
     },
     {
       "name": "M3",
-      "amplitude": 0.00434162,
-      "phase": 192.481234
+      "amplitude": 0.004,
+      "phase": 351.64
     },
     {
       "name": "MU2",
-      "amplitude": 0.1420233,
-      "phase": 176.43590500000005
+      "amplitude": 0.146,
+      "phase": 164.9
     },
     {
       "name": "MTM",
-      "amplitude": 0.0066731099999999995,
-      "phase": 232.474436
+      "amplitude": 0.006,
+      "phase": 221.84
     },
     {
       "name": "NU2",
-      "amplitude": 0.08321764,
-      "phase": 36.40351700000002
+      "amplitude": 0.088,
+      "phase": 23.44
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.053281999999999996,
-      "phase": 85.252137
+      "amplitude": 0.056,
+      "phase": 75.36
     },
     {
       "name": "MN4",
-      "amplitude": 0.01650279,
-      "phase": 144.35290599999996
+      "amplitude": 0.019,
+      "phase": 119.72
     },
     {
       "name": "MS4",
-      "amplitude": 0.033969559999999996,
-      "phase": 216.209486
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.036618620000000004,
-      "phase": 236.15296899999998
+      "amplitude": 0.039,
+      "phase": 192.85
     },
     {
       "name": "N4",
-      "amplitude": 0.00494961,
-      "phase": 120.77234099999998
+      "amplitude": 0.006,
+      "phase": 98.63
     },
     {
       "name": "M6",
-      "amplitude": 0.01661867,
-      "phase": 138.448553
+      "amplitude": 0.027,
+      "phase": 105.63
     },
     {
       "name": "M8",
-      "amplitude": 0.00756298,
-      "phase": 90.73167799999999
+      "amplitude": 0.014,
+      "phase": 59.68
     },
     {
       "name": "S4",
-      "amplitude": 0.0032566099999999996,
-      "phase": 286.278433
+      "amplitude": 0.004,
+      "phase": 264.27
     },
     {
       "name": "OO1",
-      "amplitude": 0.0021657,
-      "phase": 162.66745300000002
+      "amplitude": 0.002,
+      "phase": 157.36
     },
     {
       "name": "S3",
-      "amplitude": 0.00112907,
-      "phase": 115.78900199999998
+      "amplitude": 0,
+      "phase": 95.96
     },
     {
       "name": "MA2",
-      "amplitude": 0.18799713,
-      "phase": 56.496774000000016
+      "amplitude": 0.029,
+      "phase": 23.29
     },
     {
       "name": "MB2",
-      "amplitude": 0.1578636,
-      "phase": 265.178397
+      "amplitude": 0.016,
+      "phase": 143.12
     },
     {
       "name": "T3",
-      "amplitude": 0.00211965,
-      "phase": 85.23616800000002
+      "amplitude": 0.002,
+      "phase": 257.41
     },
     {
       "name": "R3",
-      "amplitude": 0.00559936,
-      "phase": 301.966045
+      "amplitude": 0.006,
+      "phase": 12.92
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00719405,
-      "phase": 123.75787000000003
+      "amplitude": 0.008,
+      "phase": 121.46
     },
     {
       "name": "SGM",
-      "amplitude": 0.0014329,
-      "phase": 149.256872
+      "amplitude": 0.001,
+      "phase": 275.6
     },
     {
       "name": "3L2",
-      "amplitude": 0.01232426,
-      "phase": 231.396797
+      "amplitude": 0.009,
+      "phase": 347.32
     },
     {
       "name": "3N2",
-      "amplitude": 0.01846593,
-      "phase": 11.959503999999981
+      "amplitude": 0.019,
+      "phase": 251.83
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03763973,
-      "phase": 359.207812
+      "amplitude": 0.038,
+      "phase": 349.23
     },
     {
       "name": "2MS6",
-      "amplitude": 0.01583317,
-      "phase": 182.198863
+      "amplitude": 0.026,
+      "phase": 151.24
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00215475,
-      "phase": 161.480997
+      "amplitude": 0.003,
+      "phase": 216.37
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00030007,
-      "phase": 102.01530200000002
+      "amplitude": 0,
+      "phase": 0.24
     }
   ],
   "epoch": {

--- a/data/ticon/stellendam_buiten-stelldbtn-nld-rws.json
+++ b/data/ticon/stellendam_buiten-stelldbtn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.91071656,
-      "phase": 67.40640000000002
+      "amplitude": 0.939,
+      "phase": 50.4
     },
     {
       "name": "N2",
-      "amplitude": 0.13814903,
-      "phase": 41.95377500000001
+      "amplitude": 0.142,
+      "phase": 23.02
     },
     {
       "name": "S2",
-      "amplitude": 0.23076781000000002,
-      "phase": 125.98141299999997
+      "amplitude": 0.237,
+      "phase": 108.48
     },
     {
       "name": "K2",
-      "amplitude": 0.06858826999999999,
-      "phase": 131.992864
+      "amplitude": 0.074,
+      "phase": 109.34
     },
     {
       "name": "2N2",
-      "amplitude": 0.017082379999999998,
-      "phase": 14.040733999999986
+      "amplitude": 0.019,
+      "phase": 356.8
     },
     {
       "name": "S1",
-      "amplitude": 0.0111726,
-      "phase": 4.677273000000014
+      "amplitude": 0.012,
+      "phase": 312.87
     },
     {
       "name": "K1",
-      "amplitude": 0.075098,
-      "phase": 356.043324
+      "amplitude": 0.075,
+      "phase": 347.12
     },
     {
       "name": "P1",
-      "amplitude": 0.03457798,
-      "phase": 346.931771
+      "amplitude": 0.035,
+      "phase": 339.2
     },
     {
       "name": "O1",
-      "amplitude": 0.10805075,
-      "phase": 186.828587
+      "amplitude": 0.108,
+      "phase": 178.24
     },
     {
       "name": "Q1",
-      "amplitude": 0.04037248,
-      "phase": 135.30245000000002
+      "amplitude": 0.04,
+      "phase": 127
     },
     {
       "name": "M1",
-      "amplitude": 0.004683339999999999,
-      "phase": 303.608128
+      "amplitude": 0.002,
+      "phase": 55.39
     },
     {
       "name": "M4",
-      "amplitude": 0.16739338,
-      "phase": 129.14493400000003
+      "amplitude": 0.198,
+      "phase": 92.29
     },
     {
       "name": "MM",
-      "amplitude": 0.027440060000000002,
-      "phase": 29.542809999999974
+      "amplitude": 0.028,
+      "phase": 29.23
     },
     {
       "name": "MF",
-      "amplitude": 0.00925557,
-      "phase": 85.36704299999997
+      "amplitude": 0.009,
+      "phase": 86.41
     },
     {
       "name": "SA",
-      "amplitude": 0.09987499,
-      "phase": 243.47791
+      "amplitude": 0.1,
+      "phase": 243.56
     },
     {
       "name": "SSA",
-      "amplitude": 0.02713464,
-      "phase": 222.760802
+      "amplitude": 0.028,
+      "phase": 222.79
     },
     {
       "name": "T2",
-      "amplitude": 0.041609179999999996,
-      "phase": 46.239773000000014
+      "amplitude": 0.017,
+      "phase": 98.67
     },
     {
       "name": "J1",
-      "amplitude": 0.0040691699999999996,
-      "phase": 131.59193200000004
+      "amplitude": 0.004,
+      "phase": 115.53
     },
     {
       "name": "L2",
-      "amplitude": 0.07736066,
-      "phase": 86.042936
+      "amplitude": 0.076,
+      "phase": 68.12
     },
     {
       "name": "R2",
-      "amplitude": 0.02845312,
-      "phase": 224.797011
+      "amplitude": 0.004,
+      "phase": 113.22
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00712692,
-      "phase": 96.60116099999999
+      "amplitude": 0.008,
+      "phase": 92.08
     },
     {
       "name": "MSF",
-      "amplitude": 0.02242887,
-      "phase": 85.664154
+      "amplitude": 0.022,
+      "phase": 87.18
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0076611399999999994,
-      "phase": 207.610826
+      "amplitude": 0.008,
+      "phase": 205.4
     },
     {
       "name": "EP2",
-      "amplitude": 0.017657350000000002,
-      "phase": 162.632606
+      "amplitude": 0.018,
+      "phase": 145.42
     },
     {
       "name": "M3",
-      "amplitude": 0.00029899,
-      "phase": 49.75354199999998
+      "amplitude": 0,
+      "phase": 309.13
     },
     {
       "name": "MU2",
-      "amplitude": 0.08771898,
-      "phase": 187.250162
+      "amplitude": 0.09,
+      "phase": 170.13
     },
     {
       "name": "MTM",
-      "amplitude": 0.01029631,
-      "phase": 230.553711
+      "amplitude": 0.011,
+      "phase": 221.42
     },
     {
       "name": "NU2",
-      "amplitude": 0.05623818,
-      "phase": 41.99167
+      "amplitude": 0.057,
+      "phase": 22.2
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.030220470000000003,
-      "phase": 85.96605399999999
+      "amplitude": 0.034,
+      "phase": 71.85
     },
     {
       "name": "MN4",
-      "amplitude": 0.05762736,
-      "phase": 103.456122
+      "amplitude": 0.068,
+      "phase": 66.23
     },
     {
       "name": "MS4",
-      "amplitude": 0.10794556,
-      "phase": 183.199453
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03625804,
-      "phase": 207.576812
+      "amplitude": 0.126,
+      "phase": 148.52
     },
     {
       "name": "N4",
-      "amplitude": 0.011676269999999999,
-      "phase": 84.70109100000002
+      "amplitude": 0.015,
+      "phase": 47.03
     },
     {
       "name": "M6",
-      "amplitude": 0.07220093,
-      "phase": 106.604691
+      "amplitude": 0.097,
+      "phase": 48.9
     },
     {
       "name": "M8",
-      "amplitude": 0.016184920000000002,
-      "phase": 173.29991500000006
+      "amplitude": 0.033,
+      "phase": 93.78
     },
     {
       "name": "S4",
-      "amplitude": 0.00960138,
-      "phase": 276.807464
+      "amplitude": 0.011,
+      "phase": 238.66
     },
     {
       "name": "OO1",
-      "amplitude": 0.00644429,
-      "phase": 129.87327400000004
+      "amplitude": 0.006,
+      "phase": 109.04
     },
     {
       "name": "S3",
-      "amplitude": 0.00305544,
-      "phase": 63.253089999999986
+      "amplitude": 0.001,
+      "phase": 264.32
     },
     {
       "name": "MA2",
-      "amplitude": 0.15093402,
-      "phase": 42.785203000000024
+      "amplitude": 0.011,
+      "phase": 336.73
     },
     {
       "name": "MB2",
-      "amplitude": 0.14175583,
-      "phase": 254.604478
+      "amplitude": 0.025,
+      "phase": 143.65
     },
     {
       "name": "T3",
-      "amplitude": 0.00182258,
-      "phase": 356.532445
+      "amplitude": 0.002,
+      "phase": 185.94
     },
     {
       "name": "R3",
-      "amplitude": 0.007436819999999999,
-      "phase": 257.507458
+      "amplitude": 0.008,
+      "phase": 315.72
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00640446,
-      "phase": 121.29466500000001
+      "amplitude": 0.007,
+      "phase": 121.24
     },
     {
       "name": "SGM",
-      "amplitude": 0.00256393,
-      "phase": 68.76141100000001
+      "amplitude": 0.003,
+      "phase": 238.56
     },
     {
       "name": "3L2",
-      "amplitude": 0.01576491,
-      "phase": 211.350997
+      "amplitude": 0.015,
+      "phase": 290.01
     },
     {
       "name": "3N2",
-      "amplitude": 0.00654409,
-      "phase": 98.64691900000003
+      "amplitude": 0.004,
+      "phase": 219.01
     },
     {
       "name": "2SM2",
-      "amplitude": 0.026281099999999998,
-      "phase": 358.250015
+      "amplitude": 0.027,
+      "phase": 341.51
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06603427,
-      "phase": 159.821323
+      "amplitude": 0.089,
+      "phase": 102.67
     },
     {
       "name": "2MK5",
-      "amplitude": 0.009149899999999999,
-      "phase": 269.941847
+      "amplitude": 0.012,
+      "phase": 310.37
     },
     {
       "name": "2MO5",
-      "amplitude": 0.01121591,
-      "phase": 276.836819
+      "amplitude": 0.015,
+      "phase": 147.43
     }
   ],
   "epoch": {

--- a/data/ticon/stralsund-9650043-deu-wsv.json
+++ b/data/ticon/stralsund-9650043-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.011769616154973907,
-      "phase": 340.7555533976254
+      "amplitude": 0.012,
+      "phase": 340.76
     },
     {
       "name": "N2",
-      "amplitude": 0.003651957189871306,
-      "phase": 302.30702945599455
+      "amplitude": 0.004,
+      "phase": 302.31
     },
     {
       "name": "S2",
-      "amplitude": 0.00389303508723788,
-      "phase": 295.17571267223826
+      "amplitude": 0.004,
+      "phase": 295.18
     },
     {
       "name": "K2",
-      "amplitude": 0.0015254882795040245,
-      "phase": 285.70211890017583
+      "amplitude": 0.002,
+      "phase": 285.7
     },
     {
       "name": "2N2",
-      "amplitude": 0.0006153351235729137,
-      "phase": 324.3449316599041
+      "amplitude": 0.001,
+      "phase": 324.34
     },
     {
       "name": "S1",
-      "amplitude": 0.006635487896807222,
-      "phase": 67.78464745752541
+      "amplitude": 0.007,
+      "phase": 67.78
     },
     {
       "name": "K1",
-      "amplitude": 0.009507279926284003,
-      "phase": 173.35512461607982
+      "amplitude": 0.01,
+      "phase": 173.36
     },
     {
       "name": "P1",
-      "amplitude": 0.0018569169028141987,
-      "phase": 160.44139551161356
+      "amplitude": 0.002,
+      "phase": 160.44
     },
     {
       "name": "O1",
-      "amplitude": 0.014987245737572612,
-      "phase": 161.42085539863115
+      "amplitude": 0.015,
+      "phase": 161.42
     },
     {
       "name": "Q1",
-      "amplitude": 0.002049941779530986,
-      "phase": 114.11870533416425
+      "amplitude": 0.002,
+      "phase": 114.12
     },
     {
       "name": "M1",
-      "amplitude": 0.0005724741248346768,
-      "phase": 62.3561761788269
+      "amplitude": 0.001,
+      "phase": 62.36
     },
     {
       "name": "M4",
-      "amplitude": 0.0005188387142634969,
-      "phase": 88.19536078700963
+      "amplitude": 0.001,
+      "phase": 88.2
     },
     {
       "name": "MM",
-      "amplitude": 0.01244894106469662,
-      "phase": 288.5963732097582
+      "amplitude": 0.012,
+      "phase": 288.6
     },
     {
       "name": "MF",
-      "amplitude": 0.009699425768732636,
-      "phase": 274.8217803971554
+      "amplitude": 0.01,
+      "phase": 274.82
     },
     {
       "name": "SA",
-      "amplitude": 0.040517707198057994,
-      "phase": 192.28441159764785
+      "amplitude": 0.041,
+      "phase": 192.28
     },
     {
       "name": "SSA",
-      "amplitude": 0.028580916638348924,
-      "phase": 249.30885137830197
+      "amplitude": 0.029,
+      "phase": 249.31
     },
     {
       "name": "T2",
-      "amplitude": 0.000995644861240678,
-      "phase": 264.17501543237046
+      "amplitude": 0.001,
+      "phase": 264.18
     },
     {
       "name": "J1",
-      "amplitude": 0.0009553982763221277,
-      "phase": 219.58362384716207
+      "amplitude": 0.001,
+      "phase": 219.58
     },
     {
       "name": "L2",
-      "amplitude": 0.0011051216407568524,
-      "phase": 112.11017308484253
+      "amplitude": 0.001,
+      "phase": 112.11
     },
     {
       "name": "R2",
-      "amplitude": 0.0008058982945299706,
-      "phase": 45.01750599566964
+      "amplitude": 0.001,
+      "phase": 45.02
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00027633498191864447,
-      "phase": 233.0803188782056
+      "amplitude": 0,
+      "phase": 233.08
     },
     {
       "name": "MSF",
-      "amplitude": 0.0009962374992354309,
-      "phase": 237.09742577763768
+      "amplitude": 0.001,
+      "phase": 237.1
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00427017366389864,
-      "phase": 205.83906031010895
+      "amplitude": 0.004,
+      "phase": 205.84
     },
     {
       "name": "EP2",
-      "amplitude": 0.00043953934413877197,
-      "phase": 123.95291575767942
+      "amplitude": 0,
+      "phase": 123.95
     },
     {
       "name": "M3",
-      "amplitude": 0.0003104217699862729,
-      "phase": 6.601966931679044
+      "amplitude": 0,
+      "phase": 6.6
     },
     {
       "name": "MU2",
-      "amplitude": 0.0022192074191234473,
-      "phase": 174.05583746208094
+      "amplitude": 0.002,
+      "phase": 174.06
     },
     {
       "name": "MTM",
-      "amplitude": 0.0039406063768612195,
-      "phase": 347.1051464678019
+      "amplitude": 0.004,
+      "phase": 347.11
     },
     {
       "name": "NU2",
-      "amplitude": 0.0009684771527948547,
-      "phase": 340.7827112504323
+      "amplitude": 0.001,
+      "phase": 340.78
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0004911429254703307,
-      "phase": 102.95989930242524
+      "amplitude": 0,
+      "phase": 102.96
     },
     {
       "name": "MN4",
-      "amplitude": 0.0002142367661900454,
-      "phase": 32.32610124360491
+      "amplitude": 0,
+      "phase": 32.33
     },
     {
       "name": "MS4",
-      "amplitude": 0.00020717901548238557,
-      "phase": 233.69119131850573
+      "amplitude": 0,
+      "phase": 233.69
     },
     {
       "name": "N4",
-      "amplitude": 0.00003247357735110276,
-      "phase": 310.9378732401784
+      "amplitude": 0,
+      "phase": 310.94
     },
     {
       "name": "M6",
-      "amplitude": 0.00011053382602487513,
-      "phase": 214.83735611806358
+      "amplitude": 0,
+      "phase": 214.84
     },
     {
       "name": "M8",
-      "amplitude": 0.00003542040619669253,
-      "phase": 149.6609969951117
+      "amplitude": 0,
+      "phase": 149.66
     },
     {
       "name": "S4",
-      "amplitude": 0.00002374592446065143,
-      "phase": 169.00214980061548
+      "amplitude": 0,
+      "phase": 169
     },
     {
       "name": "OO1",
-      "amplitude": 0.0005325538946226357,
-      "phase": 110.05507540985695
+      "amplitude": 0.001,
+      "phase": 110.06
     },
     {
       "name": "S3",
-      "amplitude": 0.0004179351275316936,
-      "phase": 47.75255271405928
+      "amplitude": 0,
+      "phase": 47.75
     },
     {
       "name": "MA2",
-      "amplitude": 0.0008961344750764598,
-      "phase": 343.47864881573855
+      "amplitude": 0.001,
+      "phase": 343.48
     },
     {
       "name": "MB2",
-      "amplitude": 0.0017513035642436972,
-      "phase": 126.51677654570005
+      "amplitude": 0.002,
+      "phase": 126.52
     },
     {
       "name": "T3",
-      "amplitude": 0.00046702532479472116,
-      "phase": 329.0334903603662
+      "amplitude": 0,
+      "phase": 329.03
     },
     {
       "name": "R3",
-      "amplitude": 0.0005389685168993415,
-      "phase": 69.94502920038695
+      "amplitude": 0.001,
+      "phase": 69.95
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00027098934198615745,
-      "phase": 326.2430277380621
+      "amplitude": 0,
+      "phase": 326.24
     },
     {
       "name": "SGM",
-      "amplitude": 0.0012158816993240087,
-      "phase": 251.06743964657312
+      "amplitude": 0.001,
+      "phase": 251.07
     },
     {
       "name": "3L2",
-      "amplitude": 0.0002784012593287172,
-      "phase": 265.4533469096034
+      "amplitude": 0,
+      "phase": 265.45
     },
     {
       "name": "3N2",
-      "amplitude": 0.0003140547371405477,
-      "phase": 244.48432090685327
+      "amplitude": 0,
+      "phase": 244.48
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0006518638079744775,
-      "phase": 84.76837622633235
+      "amplitude": 0.001,
+      "phase": 84.77
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00008155343744735603,
-      "phase": 340.21231310284753
+      "amplitude": 0,
+      "phase": 340.21
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000004128452611377664,
-      "phase": 22.532276426098065
+      "amplitude": 0,
+      "phase": 22.53
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00006277512663811695,
-      "phase": 275.5434566196826
+      "amplitude": 0,
+      "phase": 275.54
     }
   ],
   "epoch": {

--- a/data/ticon/suurhofbrug_noordzijde-suurhbnzde-nld-rws.json
+++ b/data/ticon/suurhofbrug_noordzijde-suurhbnzde-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.73896545,
-      "phase": 65.53930400000002
+      "amplitude": 0.763,
+      "phase": 48.59
     },
     {
       "name": "N2",
-      "amplitude": 0.12074460999999999,
-      "phase": 39.150611000000026
+      "amplitude": 0.116,
+      "phase": 23.12
     },
     {
       "name": "S2",
-      "amplitude": 0.1802832,
-      "phase": 125.59323999999998
+      "amplitude": 0.185,
+      "phase": 107.97
     },
     {
       "name": "K2",
-      "amplitude": 0.052032230000000006,
-      "phase": 132.230978
+      "amplitude": 0.057,
+      "phase": 107.78
     },
     {
       "name": "2N2",
-      "amplitude": 0.0096045,
-      "phase": 10.998622000000012
+      "amplitude": 0.007,
+      "phase": 358.43
     },
     {
       "name": "S1",
-      "amplitude": 0.00545652,
-      "phase": 340.922137
+      "amplitude": 0.01,
+      "phase": 273.52
     },
     {
       "name": "K1",
-      "amplitude": 0.07355888000000001,
-      "phase": 350.301998
+      "amplitude": 0.074,
+      "phase": 341.51
     },
     {
       "name": "P1",
-      "amplitude": 0.03323175,
-      "phase": 334.84414
+      "amplitude": 0.033,
+      "phase": 328.9
     },
     {
       "name": "O1",
-      "amplitude": 0.10313172,
-      "phase": 180.218919
+      "amplitude": 0.103,
+      "phase": 171.82
     },
     {
       "name": "Q1",
-      "amplitude": 0.0329766,
-      "phase": 118.14682099999999
+      "amplitude": 0.033,
+      "phase": 110.05
     },
     {
       "name": "M1",
-      "amplitude": 0.0075425,
-      "phase": 56.44212900000002
+      "amplitude": 0.004,
+      "phase": 20.21
     },
     {
       "name": "M4",
-      "amplitude": 0.1372598,
-      "phase": 124.74044100000003
+      "amplitude": 0.161,
+      "phase": 87.92
     },
     {
       "name": "MM",
-      "amplitude": 0.013228150000000001,
-      "phase": 271.653911
+      "amplitude": 0.013,
+      "phase": 269.28
     },
     {
       "name": "MF",
-      "amplitude": 0.0077649500000000005,
-      "phase": 232.721903
+      "amplitude": 0.008,
+      "phase": 233.24
     },
     {
       "name": "SA",
-      "amplitude": 0.07885516,
-      "phase": 238.01201
+      "amplitude": 0.079,
+      "phase": 238.03
     },
     {
       "name": "SSA",
-      "amplitude": 0.02138509,
-      "phase": 247.623299
+      "amplitude": 0.021,
+      "phase": 247.3
     },
     {
       "name": "T2",
-      "amplitude": 0.03148669,
-      "phase": 46.31767300000001
+      "amplitude": 0.014,
+      "phase": 99.4
     },
     {
       "name": "J1",
-      "amplitude": 0.00261799,
-      "phase": 150.855867
+      "amplitude": 0.003,
+      "phase": 142.81
     },
     {
       "name": "L2",
-      "amplitude": 0.052226369999999994,
-      "phase": 91.773596
+      "amplitude": 0.053,
+      "phase": 72.7
     },
     {
       "name": "R2",
-      "amplitude": 0.021969910000000002,
-      "phase": 232.058311
+      "amplitude": 0.002,
+      "phase": 48.89
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00436035,
-      "phase": 54.356194000000016
+      "amplitude": 0.004,
+      "phase": 51.41
     },
     {
       "name": "MSF",
-      "amplitude": 0.00698667,
-      "phase": 38.55326400000001
+      "amplitude": 0.007,
+      "phase": 37.61
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00858739,
-      "phase": 10.050314000000014
+      "amplitude": 0.009,
+      "phase": 10.65
     },
     {
       "name": "EP2",
-      "amplitude": 0.01840645,
-      "phase": 168.234739
+      "amplitude": 0.019,
+      "phase": 153.37
     },
     {
       "name": "M3",
-      "amplitude": 0.0019882,
-      "phase": 188.771543
+      "amplitude": 0.002,
+      "phase": 341.1
     },
     {
       "name": "MU2",
-      "amplitude": 0.07855454,
-      "phase": 185.034364
+      "amplitude": 0.082,
+      "phase": 168.75
     },
     {
       "name": "MTM",
-      "amplitude": 0.0025919,
-      "phase": 41.54387800000001
+      "amplitude": 0.003,
+      "phase": 32.87
     },
     {
       "name": "NU2",
-      "amplitude": 0.048506850000000004,
-      "phase": 33.010514
+      "amplitude": 0.047,
+      "phase": 19.12
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.030633780000000003,
-      "phase": 82.26221399999997
+      "amplitude": 0.03,
+      "phase": 63.78
     },
     {
       "name": "MN4",
-      "amplitude": 0.04975503,
-      "phase": 98.81226900000001
+      "amplitude": 0.059,
+      "phase": 63.83
     },
     {
       "name": "MS4",
-      "amplitude": 0.08517744000000001,
-      "phase": 176.95668899999998
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03875743,
-      "phase": 211.245612
+      "amplitude": 0.098,
+      "phase": 142
     },
     {
       "name": "N4",
-      "amplitude": 0.0097484,
-      "phase": 78.71080899999998
+      "amplitude": 0.009,
+      "phase": 50.35
     },
     {
       "name": "M6",
-      "amplitude": 0.01934502,
-      "phase": 79.81461100000001
+      "amplitude": 0.026,
+      "phase": 25.39
     },
     {
       "name": "M8",
-      "amplitude": 0.005386999999999999,
-      "phase": 176.97290299999997
+      "amplitude": 0.011,
+      "phase": 97.45
     },
     {
       "name": "S4",
-      "amplitude": 0.00667605,
-      "phase": 247.036978
+      "amplitude": 0.007,
+      "phase": 220.42
     },
     {
       "name": "OO1",
-      "amplitude": 0.0051868999999999995,
-      "phase": 150.159517
+      "amplitude": 0.005,
+      "phase": 111.66
     },
     {
       "name": "S3",
-      "amplitude": 0.0014899000000000002,
-      "phase": 41.912600999999995
+      "amplitude": 0,
+      "phase": 309.13
     },
     {
       "name": "MA2",
-      "amplitude": 0.12850169,
-      "phase": 44.12773600000003
+      "amplitude": 0.01,
+      "phase": 44.12
     },
     {
       "name": "MB2",
-      "amplitude": 0.11292371,
-      "phase": 260.365794
+      "amplitude": 0.008,
+      "phase": 115.7
     },
     {
       "name": "T3",
-      "amplitude": 0.00110636,
-      "phase": 28.55000100000001
+      "amplitude": 0.001,
+      "phase": 203.51
     },
     {
       "name": "R3",
-      "amplitude": 0.00469258,
-      "phase": 242.574843
+      "amplitude": 0.005,
+      "phase": 298.15
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00435253,
-      "phase": 119.70928300000003
+      "amplitude": 0.005,
+      "phase": 117.31
     },
     {
       "name": "SGM",
-      "amplitude": 0.00299716,
-      "phase": 73.558696
+      "amplitude": 0.003,
+      "phase": 254.5
     },
     {
       "name": "3L2",
-      "amplitude": 0.02700281,
-      "phase": 350.183538
+      "amplitude": 0.025,
+      "phase": 66.32
     },
     {
       "name": "3N2",
-      "amplitude": 0.01464283,
-      "phase": 133.46801600000003
+      "amplitude": 0.012,
+      "phase": 206.01
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0226388,
-      "phase": 358.728192
+      "amplitude": 0.023,
+      "phase": 342.91
     },
     {
       "name": "2MS6",
-      "amplitude": 0.015601799999999999,
-      "phase": 135.146368
+      "amplitude": 0.021,
+      "phase": 80.19
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00812275,
-      "phase": 246.543815
+      "amplitude": 0.01,
+      "phase": 283.91
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00903111,
-      "phase": 252.602513
+      "amplitude": 0.011,
+      "phase": 120.77
     }
   ],
   "epoch": {

--- a/data/ticon/terborg-3910020-deu-wsv.json
+++ b/data/ticon/terborg-3910020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.47459818367074,
-      "phase": 328.63520335501096
+      "amplitude": 1.475,
+      "phase": 328.64
     },
     {
       "name": "N2",
-      "amplitude": 0.22836654001979761,
-      "phase": 306.5284498377585
+      "amplitude": 0.228,
+      "phase": 306.53
     },
     {
       "name": "S2",
-      "amplitude": 0.3597693418726163,
-      "phase": 45.66202855877316
+      "amplitude": 0.36,
+      "phase": 45.66
     },
     {
       "name": "K2",
-      "amplitude": 0.10585950610552244,
-      "phase": 43.09481154355393
+      "amplitude": 0.106,
+      "phase": 43.09
     },
     {
       "name": "2N2",
-      "amplitude": 0.022755356797160436,
-      "phase": 291.787653690958
+      "amplitude": 0.023,
+      "phase": 291.79
     },
     {
       "name": "S1",
-      "amplitude": 0.017496719683591722,
-      "phase": 64.71785100153596
+      "amplitude": 0.017,
+      "phase": 64.72
     },
     {
       "name": "K1",
-      "amplitude": 0.07356431907403291,
-      "phase": 44.653353578586575
+      "amplitude": 0.074,
+      "phase": 44.65
     },
     {
       "name": "P1",
-      "amplitude": 0.0334448576997407,
-      "phase": 43.350708306282115
+      "amplitude": 0.033,
+      "phase": 43.35
     },
     {
       "name": "O1",
-      "amplitude": 0.08885864670977336,
-      "phase": 249.43497262423165
+      "amplitude": 0.089,
+      "phase": 249.43
     },
     {
       "name": "Q1",
-      "amplitude": 0.026060297337468005,
-      "phase": 187.5791428926339
+      "amplitude": 0.026,
+      "phase": 187.58
     },
     {
       "name": "M1",
-      "amplitude": 0.0024509029680517946,
-      "phase": 104.91923350473093
+      "amplitude": 0.002,
+      "phase": 104.92
     },
     {
       "name": "M4",
-      "amplitude": 0.14657571421640242,
-      "phase": 144.77011138745138
+      "amplitude": 0.147,
+      "phase": 144.77
     },
     {
       "name": "MM",
-      "amplitude": 0.014025841403101124,
-      "phase": 103.9514568943822
+      "amplitude": 0.014,
+      "phase": 103.95
     },
     {
       "name": "MF",
-      "amplitude": 0.005240015245496796,
-      "phase": 77.7748282590311
+      "amplitude": 0.005,
+      "phase": 77.77
     },
     {
       "name": "SA",
-      "amplitude": 0.0758234991891552,
-      "phase": 229.89719154208555
+      "amplitude": 0.076,
+      "phase": 229.9
     },
     {
       "name": "SSA",
-      "amplitude": 0.03356582732050609,
-      "phase": 232.76482686278368
+      "amplitude": 0.034,
+      "phase": 232.76
     },
     {
       "name": "T2",
-      "amplitude": 0.023047095322195323,
-      "phase": 353.3816205029332
+      "amplitude": 0.023,
+      "phase": 353.38
     },
     {
       "name": "J1",
-      "amplitude": 0.004419017882945411,
-      "phase": 168.55996235189127
+      "amplitude": 0.004,
+      "phase": 168.56
     },
     {
       "name": "L2",
-      "amplitude": 0.13476966231775883,
-      "phase": 341.3575794791108
+      "amplitude": 0.135,
+      "phase": 341.36
     },
     {
       "name": "R2",
-      "amplitude": 0.013981054059707015,
-      "phase": 217.69193606337058
+      "amplitude": 0.014,
+      "phase": 217.69
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004159514480150307,
-      "phase": 129.46190961512934
+      "amplitude": 0.004,
+      "phase": 129.46
     },
     {
       "name": "MSF",
-      "amplitude": 0.04091782024528521,
-      "phase": 39.239493752991564
+      "amplitude": 0.041,
+      "phase": 39.24
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00692534332212237,
-      "phase": 51.05713203498465
+      "amplitude": 0.007,
+      "phase": 51.06
     },
     {
       "name": "EP2",
-      "amplitude": 0.03930130694754344,
-      "phase": 37.05837808243621
+      "amplitude": 0.039,
+      "phase": 37.06
     },
     {
       "name": "M3",
-      "amplitude": 0.003519428032194137,
-      "phase": 18.34632635801546
+      "amplitude": 0.004,
+      "phase": 18.35
     },
     {
       "name": "MU2",
-      "amplitude": 0.1883216421462005,
-      "phase": 51.097892372604576
+      "amplitude": 0.188,
+      "phase": 51.1
     },
     {
       "name": "MTM",
-      "amplitude": 0.005192677759274401,
-      "phase": 358.7574872568386
+      "amplitude": 0.005,
+      "phase": 358.76
     },
     {
       "name": "NU2",
-      "amplitude": 0.09505807244752124,
-      "phase": 280.7178182565318
+      "amplitude": 0.095,
+      "phase": 280.72
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06274527044285881,
-      "phase": 341.4901013767994
+      "amplitude": 0.063,
+      "phase": 341.49
     },
     {
       "name": "MN4",
-      "amplitude": 0.04681729259420858,
-      "phase": 120.61894139586957
+      "amplitude": 0.047,
+      "phase": 120.62
     },
     {
       "name": "MS4",
-      "amplitude": 0.08620484283671126,
-      "phase": 226.3102777500958
+      "amplitude": 0.086,
+      "phase": 226.31
     },
     {
       "name": "N4",
-      "amplitude": 0.009503015939906129,
-      "phase": 103.91655490118728
+      "amplitude": 0.01,
+      "phase": 103.92
     },
     {
       "name": "M6",
-      "amplitude": 0.09309014138581151,
-      "phase": 343.11632362794967
+      "amplitude": 0.093,
+      "phase": 343.12
     },
     {
       "name": "M8",
-      "amplitude": 0.021804245668935105,
-      "phase": 172.77623944528193
+      "amplitude": 0.022,
+      "phase": 172.78
     },
     {
       "name": "S4",
-      "amplitude": 0.008848505284893836,
-      "phase": 24.93864185488718
+      "amplitude": 0.009,
+      "phase": 24.94
     },
     {
       "name": "OO1",
-      "amplitude": 0.0033882981404872495,
-      "phase": 194.42675968571186
+      "amplitude": 0.003,
+      "phase": 194.43
     },
     {
       "name": "S3",
-      "amplitude": 0.0003760327860615494,
-      "phase": 284.61520433630915
+      "amplitude": 0,
+      "phase": 284.62
     },
     {
       "name": "MA2",
-      "amplitude": 0.08548547980731774,
-      "phase": 292.49123892874144
+      "amplitude": 0.085,
+      "phase": 292.49
     },
     {
       "name": "MB2",
-      "amplitude": 0.029997560791363013,
-      "phase": 201.9754554311928
+      "amplitude": 0.03,
+      "phase": 201.98
     },
     {
       "name": "T3",
-      "amplitude": 0.0007265857293035695,
-      "phase": 13.579221964196165
+      "amplitude": 0.001,
+      "phase": 13.58
     },
     {
       "name": "R3",
-      "amplitude": 0.004826793046377799,
-      "phase": 15.057101798069482
+      "amplitude": 0.005,
+      "phase": 15.06
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005674027032743657,
-      "phase": 215.7883103286884
+      "amplitude": 0.006,
+      "phase": 215.79
     },
     {
       "name": "SGM",
-      "amplitude": 0.004943200171728441,
-      "phase": 41.54804486294489
+      "amplitude": 0.005,
+      "phase": 41.55
     },
     {
       "name": "3L2",
-      "amplitude": 0.0019084621589147803,
-      "phase": 217.55585351751768
+      "amplitude": 0.002,
+      "phase": 217.56
     },
     {
       "name": "3N2",
-      "amplitude": 0.022957158175124247,
-      "phase": 137.7416833391287
+      "amplitude": 0.023,
+      "phase": 137.74
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03901785355714004,
-      "phase": 266.45354989442956
+      "amplitude": 0.039,
+      "phase": 266.45
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08755793187731725,
-      "phase": 52.85524312958199
+      "amplitude": 0.088,
+      "phase": 52.86
     },
     {
       "name": "2MK5",
-      "amplitude": 0.011570498738343883,
-      "phase": 19.93774577284273
+      "amplitude": 0.012,
+      "phase": 19.94
     },
     {
       "name": "2MO5",
-      "amplitude": 0.008781664029363104,
-      "phase": 224.8535550577416
+      "amplitude": 0.009,
+      "phase": 224.85
     }
   ],
   "epoch": {

--- a/data/ticon/terneuzen-ternzn-nld-rws.json
+++ b/data/ticon/terneuzen-ternzn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.79847132,
-      "phase": 50.53072300000002
+      "amplitude": 1.855,
+      "phase": 40.74
     },
     {
       "name": "N2",
-      "amplitude": 0.29129865,
-      "phase": 26.206961999999976
+      "amplitude": 0.301,
+      "phase": 16.94
     },
     {
       "name": "S2",
-      "amplitude": 0.48517676000000004,
-      "phase": 108.81877600000001
+      "amplitude": 0.5,
+      "phase": 99.13
     },
     {
       "name": "K2",
-      "amplitude": 0.14191008,
-      "phase": 109.16056200000003
+      "amplitude": 0.148,
+      "phase": 98.84
     },
     {
       "name": "2N2",
-      "amplitude": 0.03474898,
-      "phase": 2.339459999999974
+      "amplitude": 0.037,
+      "phase": 352.18
     },
     {
       "name": "S1",
-      "amplitude": 0.00697213,
-      "phase": 17.87136700000002
+      "amplitude": 0.007,
+      "phase": 332.35
     },
     {
       "name": "K1",
-      "amplitude": 0.06560135,
-      "phase": 9.107152999999983
+      "amplitude": 0.066,
+      "phase": 4.01
     },
     {
       "name": "P1",
-      "amplitude": 0.03427315,
-      "phase": 350.877681
+      "amplitude": 0.034,
+      "phase": 346.02
     },
     {
       "name": "O1",
-      "amplitude": 0.10332034999999999,
-      "phase": 189.727934
+      "amplitude": 0.103,
+      "phase": 184.99
     },
     {
       "name": "Q1",
-      "amplitude": 0.03641114,
-      "phase": 134.53456600000004
+      "amplitude": 0.036,
+      "phase": 129.5
     },
     {
       "name": "M1",
-      "amplitude": 0.00149736,
-      "phase": 127.94786999999997
+      "amplitude": 0.003,
+      "phase": 354.8
     },
     {
       "name": "M4",
-      "amplitude": 0.099816,
-      "phase": 97.77312
+      "amplitude": 0.114,
+      "phase": 77.83
     },
     {
       "name": "MM",
-      "amplitude": 0.01254495,
-      "phase": 83.3632
+      "amplitude": 0.013,
+      "phase": 79.69
     },
     {
       "name": "MF",
-      "amplitude": 0.00329548,
-      "phase": 81.150668
+      "amplitude": 0.003,
+      "phase": 93.34
     },
     {
       "name": "SA",
-      "amplitude": 0.07518041,
-      "phase": 216.258134
+      "amplitude": 0.08,
+      "phase": 216.62
     },
     {
       "name": "SSA",
-      "amplitude": 0.02153721,
-      "phase": 165.075967
+      "amplitude": 0.023,
+      "phase": 157.29
     },
     {
       "name": "T2",
-      "amplitude": 0.06634013,
-      "phase": 42.96366899999998
+      "amplitude": 0.027,
+      "phase": 83.19
     },
     {
       "name": "J1",
-      "amplitude": 0.00401545,
-      "phase": 123.98753799999997
+      "amplitude": 0.004,
+      "phase": 117.53
     },
     {
       "name": "L2",
-      "amplitude": 0.13236444,
-      "phase": 66.73877199999998
+      "amplitude": 0.136,
+      "phase": 57.71
     },
     {
       "name": "R2",
-      "amplitude": 0.03989017,
-      "phase": 206.953529
+      "amplitude": 0.006,
+      "phase": 143.21
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00635685,
-      "phase": 82.92695400000002
+      "amplitude": 0.007,
+      "phase": 76.75
     },
     {
       "name": "MSF",
-      "amplitude": 0.05739775,
-      "phase": 47.73743999999999
+      "amplitude": 0.058,
+      "phase": 47.12
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00392551,
-      "phase": 281.791643
+      "amplitude": 0.004,
+      "phase": 281.44
     },
     {
       "name": "EP2",
-      "amplitude": 0.032129439999999995,
-      "phase": 133.23753
+      "amplitude": 0.033,
+      "phase": 124.09
     },
     {
       "name": "M3",
-      "amplitude": 0.00968627,
-      "phase": 150.63829499999997
+      "amplitude": 0.01,
+      "phase": 311.85
     },
     {
       "name": "MU2",
-      "amplitude": 0.15096788,
-      "phase": 153.585284
+      "amplitude": 0.155,
+      "phase": 143.12
     },
     {
       "name": "MTM",
-      "amplitude": 0.00215,
-      "phase": 234.576387
+      "amplitude": 0.002,
+      "phase": 212.47
     },
     {
       "name": "NU2",
-      "amplitude": 0.09851799,
-      "phase": 15.469385999999986
+      "amplitude": 0.106,
+      "phase": 6.66
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.060345380000000004,
-      "phase": 60.49731400000002
+      "amplitude": 0.064,
+      "phase": 53.6
     },
     {
       "name": "MN4",
-      "amplitude": 0.03208177,
-      "phase": 72.49718100000001
+      "amplitude": 0.037,
+      "phase": 53.1
     },
     {
       "name": "MS4",
-      "amplitude": 0.06364035,
-      "phase": 157.42937400000005
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03453229,
-      "phase": 206.312357
+      "amplitude": 0.073,
+      "phase": 139.04
     },
     {
       "name": "N4",
-      "amplitude": 0.00618345,
-      "phase": 49.55775
+      "amplitude": 0.008,
+      "phase": 23.94
     },
     {
       "name": "M6",
-      "amplitude": 0.06457039,
-      "phase": 94.84627799999998
+      "amplitude": 0.088,
+      "phase": 66.65
     },
     {
       "name": "M8",
-      "amplitude": 0.02061016,
-      "phase": 70.82035000000002
+      "amplitude": 0.038,
+      "phase": 36.67
     },
     {
       "name": "S4",
-      "amplitude": 0.00375445,
-      "phase": 280.975137
+      "amplitude": 0.004,
+      "phase": 254.24
     },
     {
       "name": "OO1",
-      "amplitude": 0.00347973,
-      "phase": 135.550023
+      "amplitude": 0.003,
+      "phase": 142.25
     },
     {
       "name": "S3",
-      "amplitude": 0.00192305,
-      "phase": 84.36581999999999
+      "amplitude": 0,
+      "phase": 232.05
     },
     {
       "name": "MA2",
-      "amplitude": 0.20529482999999998,
-      "phase": 38.00493
+      "amplitude": 0.029,
+      "phase": 5.36
     },
     {
       "name": "MB2",
-      "amplitude": 0.1803793,
-      "phase": 241.351252
+      "amplitude": 0.021,
+      "phase": 148.88
     },
     {
       "name": "T3",
-      "amplitude": 0.0023086400000000003,
-      "phase": 49.96609599999999
+      "amplitude": 0.003,
+      "phase": 224.3
     },
     {
       "name": "R3",
-      "amplitude": 0.008858669999999999,
-      "phase": 275.414784
+      "amplitude": 0.01,
+      "phase": 348.91
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00730154,
-      "phase": 119.29800699999998
+      "amplitude": 0.008,
+      "phase": 116.9
     },
     {
       "name": "SGM",
-      "amplitude": 0.00061052,
-      "phase": 139.62451799999997
+      "amplitude": 0.001,
+      "phase": 249.55
     },
     {
       "name": "3L2",
-      "amplitude": 0.00744146,
-      "phase": 220.366236
+      "amplitude": 0.01,
+      "phase": 352.43
     },
     {
       "name": "3N2",
-      "amplitude": 0.01188283,
-      "phase": 338.38161
+      "amplitude": 0.015,
+      "phase": 210.4
     },
     {
       "name": "2SM2",
-      "amplitude": 0.046983,
-      "phase": 335.581051
+      "amplitude": 0.048,
+      "phase": 326.68
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06350562,
-      "phase": 143.478412
+      "amplitude": 0.088,
+      "phase": 115.58
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00882336,
-      "phase": 124.438763
+      "amplitude": 0.011,
+      "phase": 190.42
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00551682,
-      "phase": 152.77002200000004
+      "amplitude": 0.007,
+      "phase": 42.61
     }
   ],
   "epoch": {

--- a/data/ticon/terschelling_noordzee-terslnze-nld-rws.json
+++ b/data/ticon/terschelling_noordzee-terslnze-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.8537195599999999,
-      "phase": 221.15994
+      "amplitude": 0.889,
+      "phase": 203.66
     },
     {
       "name": "N2",
-      "amplitude": 0.12319876,
-      "phase": 199.202668
+      "amplitude": 0.146,
+      "phase": 180.56
     },
     {
       "name": "S2",
-      "amplitude": 0.2501257,
-      "phase": 283.08480199999997
+      "amplitude": 0.253,
+      "phase": 264.42
     },
     {
       "name": "K2",
-      "amplitude": 0.07484779,
-      "phase": 288.31248
+      "amplitude": 0.075,
+      "phase": 263.17
     },
     {
       "name": "2N2",
-      "amplitude": 0.02744587,
-      "phase": 156.66699600000004
+      "amplitude": 0.03,
+      "phase": 151.5
     },
     {
       "name": "S1",
-      "amplitude": 0.00793187,
-      "phase": 345.776903
+      "amplitude": 0.012,
+      "phase": 295.93
     },
     {
       "name": "K1",
-      "amplitude": 0.07132404,
-      "phase": 354.048422
+      "amplitude": 0.07,
+      "phase": 345.32
     },
     {
       "name": "P1",
-      "amplitude": 0.02790355,
-      "phase": 345.941193
+      "amplitude": 0.029,
+      "phase": 340.78
     },
     {
       "name": "O1",
-      "amplitude": 0.09224933,
-      "phase": 198.38917
+      "amplitude": 0.093,
+      "phase": 191.37
     },
     {
       "name": "Q1",
-      "amplitude": 0.03203781,
-      "phase": 146.413499
+      "amplitude": 0.032,
+      "phase": 139.05
     },
     {
       "name": "M1",
-      "amplitude": 0.00469449,
-      "phase": 184.579462
+      "amplitude": 0.003,
+      "phase": 335.62
     },
     {
       "name": "M4",
-      "amplitude": 0.07123656,
-      "phase": 296.662842
+      "amplitude": 0.086,
+      "phase": 267.42
     },
     {
       "name": "MM",
-      "amplitude": 0.01901067,
-      "phase": 105.32660799999996
+      "amplitude": 0.019,
+      "phase": 109.29
     },
     {
       "name": "MF",
-      "amplitude": 0.0040901999999999996,
-      "phase": 285.598242
+      "amplitude": 0.004,
+      "phase": 286.86
     },
     {
       "name": "SA",
-      "amplitude": 0.11365064,
-      "phase": 242.249503
+      "amplitude": 0.111,
+      "phase": 242.33
     },
     {
       "name": "SSA",
-      "amplitude": 0.054302029999999994,
-      "phase": 229.47838
+      "amplitude": 0.056,
+      "phase": 231.12
     },
     {
       "name": "T2",
-      "amplitude": 0.04654065,
-      "phase": 188.288793
+      "amplitude": 0.009,
+      "phase": 239.54
     },
     {
       "name": "J1",
-      "amplitude": 0.00378583,
-      "phase": 86.36145299999998
+      "amplitude": 0.004,
+      "phase": 84.99
     },
     {
       "name": "L2",
-      "amplitude": 0.0541831,
-      "phase": 238.123555
+      "amplitude": 0.067,
+      "phase": 221.97
     },
     {
       "name": "R2",
-      "amplitude": 0.0261919,
-      "phase": 35.21063400000003
+      "amplitude": 0.003,
+      "phase": 188.4
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0076113,
-      "phase": 73.72754399999997
+      "amplitude": 0.008,
+      "phase": 79.23
     },
     {
       "name": "MSF",
-      "amplitude": 0.01748372,
-      "phase": 66.93766099999999
+      "amplitude": 0.018,
+      "phase": 69.67
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00922345,
-      "phase": 359.633645
+      "amplitude": 0.01,
+      "phase": 0.11
     },
     {
       "name": "EP2",
-      "amplitude": 0.0101153,
-      "phase": 291.402295
+      "amplitude": 0.01,
+      "phase": 267.04
     },
     {
       "name": "M3",
-      "amplitude": 0.00739062,
-      "phase": 343.140781
+      "amplitude": 0.008,
+      "phase": 141.34
     },
     {
       "name": "MU2",
-      "amplitude": 0.0671338,
-      "phase": 317.455956
+      "amplitude": 0.064,
+      "phase": 300.42
     },
     {
       "name": "MTM",
-      "amplitude": 0.0224065,
-      "phase": 228.122983
+      "amplitude": 0.024,
+      "phase": 218.36
     },
     {
       "name": "NU2",
-      "amplitude": 0.03991712,
-      "phase": 200.586435
+      "amplitude": 0.044,
+      "phase": 168.54
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02010474,
-      "phase": 219.830733
+      "amplitude": 0.03,
+      "phase": 207.68
     },
     {
       "name": "MN4",
-      "amplitude": 0.02228912,
-      "phase": 269.130477
+      "amplitude": 0.028,
+      "phase": 240.4
     },
     {
       "name": "MS4",
-      "amplitude": 0.04489979,
-      "phase": 6.018858000000023
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.042420309999999996,
-      "phase": 348.70917
+      "amplitude": 0.053,
+      "phase": 335.42
     },
     {
       "name": "N4",
-      "amplitude": 0.009494820000000001,
-      "phase": 258.367923
+      "amplitude": 0.012,
+      "phase": 229.88
     },
     {
       "name": "M6",
-      "amplitude": 0.03284967,
-      "phase": 15.814105999999981
+      "amplitude": 0.051,
+      "phase": 331.7
     },
     {
       "name": "M8",
-      "amplitude": 0.00176883,
-      "phase": 169.05586199999993
+      "amplitude": 0.005,
+      "phase": 88.54
     },
     {
       "name": "S4",
-      "amplitude": 0.00626525,
-      "phase": 134.183647
+      "amplitude": 0.005,
+      "phase": 102.69
     },
     {
       "name": "OO1",
-      "amplitude": 0.00217864,
-      "phase": 92.78314599999999
+      "amplitude": 0.003,
+      "phase": 77.99
     },
     {
       "name": "S3",
-      "amplitude": 0.00107925,
-      "phase": 302.639866
+      "amplitude": 0.001,
+      "phase": 102.1
     },
     {
       "name": "MA2",
-      "amplitude": 0.16964086,
-      "phase": 191.337167
+      "amplitude": 0.027,
+      "phase": 160.96
     },
     {
       "name": "MB2",
-      "amplitude": 0.13792314,
-      "phase": 57.17437100000001
+      "amplitude": 0.007,
+      "phase": 259.51
     },
     {
       "name": "T3",
-      "amplitude": 0.00156009,
-      "phase": 133.40526
+      "amplitude": 0.002,
+      "phase": 295.98
     },
     {
       "name": "R3",
-      "amplitude": 0.00360341,
-      "phase": 161.43268899999998
+      "amplitude": 0.003,
+      "phase": 215.72
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00705367,
-      "phase": 102.91603800000001
+      "amplitude": 0.006,
+      "phase": 102.41
     },
     {
       "name": "SGM",
-      "amplitude": 0.00564273,
-      "phase": 267.570404
+      "amplitude": 0.005,
+      "phase": 97.83
     },
     {
       "name": "3L2",
-      "amplitude": 0.00841439,
-      "phase": 79.287824
+      "amplitude": 0.018,
+      "phase": 143.32
     },
     {
       "name": "3N2",
-      "amplitude": 0.013357699999999998,
-      "phase": 2.9703440000000114
+      "amplitude": 0.006,
+      "phase": 41.89
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0201071,
-      "phase": 117.29127199999999
+      "amplitude": 0.02,
+      "phase": 107.53
     },
     {
       "name": "2MS6",
-      "amplitude": 0.03172583,
-      "phase": 76.83491700000002
+      "amplitude": 0.046,
+      "phase": 27.12
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0042552499999999995,
-      "phase": 349.587668
+      "amplitude": 0.005,
+      "phase": 33.53
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00065854,
-      "phase": 156.39644799999996
+      "amplitude": 0.001,
+      "phase": 12.93
     }
   ],
   "epoch": {

--- a/data/ticon/texel_noordzee-texnze-nld-rws.json
+++ b/data/ticon/texel_noordzee-texnze-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.7370895000000001,
-      "phase": 178.117528
+      "amplitude": 0.767,
+      "phase": 160.83
     },
     {
       "name": "N2",
-      "amplitude": 0.10249007,
-      "phase": 161.09783200000004
+      "amplitude": 0.119,
+      "phase": 142.83
     },
     {
       "name": "S2",
-      "amplitude": 0.22033214999999998,
-      "phase": 243.171443
+      "amplitude": 0.224,
+      "phase": 225
     },
     {
       "name": "K2",
-      "amplitude": 0.06494181,
-      "phase": 246.34017799999998
+      "amplitude": 0.066,
+      "phase": 222.14
     },
     {
       "name": "2N2",
-      "amplitude": 0.023937689999999998,
-      "phase": 116.35833100000002
+      "amplitude": 0.027,
+      "phase": 112.72
     },
     {
       "name": "S1",
-      "amplitude": 0.00800041,
-      "phase": 324.740437
+      "amplitude": 0.013,
+      "phase": 282.33
     },
     {
       "name": "K1",
-      "amplitude": 0.06885945,
-      "phase": 349.404786
+      "amplitude": 0.068,
+      "phase": 340.31
     },
     {
       "name": "P1",
-      "amplitude": 0.03230853,
-      "phase": 344.650243
+      "amplitude": 0.033,
+      "phase": 338.53
     },
     {
       "name": "O1",
-      "amplitude": 0.09502682,
-      "phase": 189.517947
+      "amplitude": 0.096,
+      "phase": 181.66
     },
     {
       "name": "Q1",
-      "amplitude": 0.03646532,
-      "phase": 134.836653
+      "amplitude": 0.037,
+      "phase": 127.09
     },
     {
       "name": "M1",
-      "amplitude": 0.0054443,
-      "phase": 171.38412300000005
+      "amplitude": 0.005,
+      "phase": 336.15
     },
     {
       "name": "M4",
-      "amplitude": 0.08315616,
-      "phase": 200.220099
+      "amplitude": 0.099,
+      "phase": 168.74
     },
     {
       "name": "MM",
-      "amplitude": 0.00966176,
-      "phase": 20.813515999999993
+      "amplitude": 0.009,
+      "phase": 15.34
     },
     {
       "name": "MF",
-      "amplitude": 0.00460755,
-      "phase": 50.756260999999995
+      "amplitude": 0.005,
+      "phase": 48.21
     },
     {
       "name": "SA",
-      "amplitude": 0.11672189,
-      "phase": 240.848184
+      "amplitude": 0.116,
+      "phase": 240.77
     },
     {
       "name": "SSA",
-      "amplitude": 0.03509131,
-      "phase": 233.836716
+      "amplitude": 0.035,
+      "phase": 234.34
     },
     {
       "name": "T2",
-      "amplitude": 0.043815400000000004,
-      "phase": 152.28785700000003
+      "amplitude": 0.011,
+      "phase": 194.52
     },
     {
       "name": "J1",
-      "amplitude": 0.00481537,
-      "phase": 78.05270999999999
+      "amplitude": 0.005,
+      "phase": 73.28
     },
     {
       "name": "L2",
-      "amplitude": 0.05437554000000001,
-      "phase": 192.825593
+      "amplitude": 0.067,
+      "phase": 178.49
     },
     {
       "name": "R2",
-      "amplitude": 0.023688289999999997,
-      "phase": 1.9830479999999966
+      "amplitude": 0.003,
+      "phase": 90.33
     },
     {
       "name": "2Q1",
-      "amplitude": 0.01224052,
-      "phase": 63.250811999999996
+      "amplitude": 0.011,
+      "phase": 63.42
     },
     {
       "name": "MSF",
-      "amplitude": 0.02950625,
-      "phase": 47.94544400000001
+      "amplitude": 0.03,
+      "phase": 48.56
     },
     {
       "name": "MSQM",
-      "amplitude": 0.01358612,
-      "phase": 313.154791
+      "amplitude": 0.014,
+      "phase": 312.46
     },
     {
       "name": "EP2",
-      "amplitude": 0.00919465,
-      "phase": 250.090308
+      "amplitude": 0.01,
+      "phase": 223.38
     },
     {
       "name": "M3",
-      "amplitude": 0.00745787,
-      "phase": 311.974966
+      "amplitude": 0.008,
+      "phase": 106.76
     },
     {
       "name": "MU2",
-      "amplitude": 0.07760064,
-      "phase": 269.10659
+      "amplitude": 0.077,
+      "phase": 250.69
     },
     {
       "name": "MTM",
-      "amplitude": 0.02291861,
-      "phase": 263.486132
+      "amplitude": 0.023,
+      "phase": 258.28
     },
     {
       "name": "NU2",
-      "amplitude": 0.03601919,
-      "phase": 151.13815599999998
+      "amplitude": 0.041,
+      "phase": 121.69
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02666259,
-      "phase": 184.303756
+      "amplitude": 0.033,
+      "phase": 164.79
     },
     {
       "name": "MN4",
-      "amplitude": 0.02578818,
-      "phase": 175.41400799999997
+      "amplitude": 0.032,
+      "phase": 144.18
     },
     {
       "name": "MS4",
-      "amplitude": 0.044457290000000003,
-      "phase": 264.105717
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.03584466,
-      "phase": 314.081358
+      "amplitude": 0.052,
+      "phase": 232.25
     },
     {
       "name": "N4",
-      "amplitude": 0.00994605,
-      "phase": 156.47218199999998
+      "amplitude": 0.014,
+      "phase": 124.41
     },
     {
       "name": "M6",
-      "amplitude": 0.05356588,
-      "phase": 310.03987
+      "amplitude": 0.082,
+      "phase": 258.05
     },
     {
       "name": "M8",
-      "amplitude": 0.0090835,
-      "phase": 342.897424
+      "amplitude": 0.021,
+      "phase": 281.06
     },
     {
       "name": "S4",
-      "amplitude": 0.00539466,
-      "phase": 24.014309000000026
+      "amplitude": 0.004,
+      "phase": 340.93
     },
     {
       "name": "OO1",
-      "amplitude": 0.0042153600000000005,
-      "phase": 106.68260700000002
+      "amplitude": 0.004,
+      "phase": 82.2
     },
     {
       "name": "S3",
-      "amplitude": 0.00132775,
-      "phase": 318.003071
+      "amplitude": 0.001,
+      "phase": 119.15
     },
     {
       "name": "MA2",
-      "amplitude": 0.14880886999999998,
-      "phase": 150.567202
+      "amplitude": 0.029,
+      "phase": 126.19
     },
     {
       "name": "MB2",
-      "amplitude": 0.11596387,
-      "phase": 17.36520200000001
+      "amplitude": 0.007,
+      "phase": 152.41
     },
     {
       "name": "T3",
-      "amplitude": 0.00151812,
-      "phase": 123.56622199999998
+      "amplitude": 0.001,
+      "phase": 285.13
     },
     {
       "name": "R3",
-      "amplitude": 0.00236033,
-      "phase": 126.53309899999999
+      "amplitude": 0.003,
+      "phase": 184.1
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00782393,
-      "phase": 92.719063
+      "amplitude": 0.007,
+      "phase": 94.53
     },
     {
       "name": "SGM",
-      "amplitude": 0.007423959999999999,
-      "phase": 262.898812
+      "amplitude": 0.006,
+      "phase": 95.27
     },
     {
       "name": "3L2",
-      "amplitude": 0.009036800000000001,
-      "phase": 31.26903600000003
+      "amplitude": 0.021,
+      "phase": 113.61
     },
     {
       "name": "3N2",
-      "amplitude": 0.009735200000000001,
-      "phase": 338.551969
+      "amplitude": 0.006,
+      "phase": 356.41
     },
     {
       "name": "2SM2",
-      "amplitude": 0.02367619,
-      "phase": 71.47393699999998
+      "amplitude": 0.023,
+      "phase": 58.33
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05422968,
-      "phase": 6.701958999999988
+      "amplitude": 0.078,
+      "phase": 312.09
     },
     {
       "name": "2MK5",
-      "amplitude": 0.01166258,
-      "phase": 315.919318
+      "amplitude": 0.014,
+      "phase": 355.6
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0070352,
-      "phase": 327.084942
+      "amplitude": 0.009,
+      "phase": 205.24
     }
   ],
   "epoch": {

--- a/data/ticon/thiessow-9670067-deu-wsv.json
+++ b/data/ticon/thiessow-9670067-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.014575848380742802,
-      "phase": 302.05534367676916
+      "amplitude": 0.015,
+      "phase": 302.06
     },
     {
       "name": "N2",
-      "amplitude": 0.004365541194704019,
-      "phase": 260.53320167881844
+      "amplitude": 0.004,
+      "phase": 260.53
     },
     {
       "name": "S2",
-      "amplitude": 0.0037890568679370177,
-      "phase": 264.0783355832353
+      "amplitude": 0.004,
+      "phase": 264.08
     },
     {
       "name": "K2",
-      "amplitude": 0.0015523455312893234,
-      "phase": 244.69461731341386
+      "amplitude": 0.002,
+      "phase": 244.69
     },
     {
       "name": "2N2",
-      "amplitude": 0.0006656468068128996,
-      "phase": 270.64635587538817
+      "amplitude": 0.001,
+      "phase": 270.65
     },
     {
       "name": "S1",
-      "amplitude": 0.0063190426724438285,
-      "phase": 22.744651632797513
+      "amplitude": 0.006,
+      "phase": 22.74
     },
     {
       "name": "K1",
-      "amplitude": 0.00765525781879055,
-      "phase": 154.06640804426252
+      "amplitude": 0.008,
+      "phase": 154.07
     },
     {
       "name": "P1",
-      "amplitude": 0.0013201041275751335,
-      "phase": 148.03730427884238
+      "amplitude": 0.001,
+      "phase": 148.04
     },
     {
       "name": "O1",
-      "amplitude": 0.013159531322711785,
-      "phase": 145.42143916991176
+      "amplitude": 0.013,
+      "phase": 145.42
     },
     {
       "name": "Q1",
-      "amplitude": 0.0019180364864829916,
-      "phase": 103.49752986968048
+      "amplitude": 0.002,
+      "phase": 103.5
     },
     {
       "name": "M1",
-      "amplitude": 0.0005934094163080798,
-      "phase": 42.43158775313532
+      "amplitude": 0.001,
+      "phase": 42.43
     },
     {
       "name": "M4",
-      "amplitude": 0.0013120482769496849,
-      "phase": 349.0251169371244
+      "amplitude": 0.001,
+      "phase": 349.03
     },
     {
       "name": "MM",
-      "amplitude": 0.01107232331662962,
-      "phase": 277.50964964346974
+      "amplitude": 0.011,
+      "phase": 277.51
     },
     {
       "name": "MF",
-      "amplitude": 0.007981405328875976,
-      "phase": 275.1267130351961
+      "amplitude": 0.008,
+      "phase": 275.13
     },
     {
       "name": "SA",
-      "amplitude": 0.04229159028494146,
-      "phase": 199.64860660992468
+      "amplitude": 0.042,
+      "phase": 199.65
     },
     {
       "name": "SSA",
-      "amplitude": 0.0362705036018861,
-      "phase": 243.88350214435036
+      "amplitude": 0.036,
+      "phase": 243.88
     },
     {
       "name": "T2",
-      "amplitude": 0.0009429293386807982,
-      "phase": 258.941988897254
+      "amplitude": 0.001,
+      "phase": 258.94
     },
     {
       "name": "J1",
-      "amplitude": 0.0005725867431286231,
-      "phase": 223.11411660136676
+      "amplitude": 0.001,
+      "phase": 223.11
     },
     {
       "name": "L2",
-      "amplitude": 0.00147297717674045,
-      "phase": 60.773559131780985
+      "amplitude": 0.001,
+      "phase": 60.77
     },
     {
       "name": "R2",
-      "amplitude": 0.0005015597239507076,
-      "phase": 43.98994937484906
+      "amplitude": 0.001,
+      "phase": 43.99
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00005062242584278257,
-      "phase": 159.40707595777337
+      "amplitude": 0,
+      "phase": 159.41
     },
     {
       "name": "MSF",
-      "amplitude": 0.0012666219401734804,
-      "phase": 258.0956134095479
+      "amplitude": 0.001,
+      "phase": 258.1
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0034680118696718185,
-      "phase": 188.5867313395196
+      "amplitude": 0.003,
+      "phase": 188.59
     },
     {
       "name": "EP2",
-      "amplitude": 0.0007209726780160549,
-      "phase": 74.9492614531099
+      "amplitude": 0.001,
+      "phase": 74.95
     },
     {
       "name": "M3",
-      "amplitude": 0.0007045910957449379,
-      "phase": 304.6322317261528
+      "amplitude": 0.001,
+      "phase": 304.63
     },
     {
       "name": "MU2",
-      "amplitude": 0.0028971865605601646,
-      "phase": 125.49430737632923
+      "amplitude": 0.003,
+      "phase": 125.49
     },
     {
       "name": "MTM",
-      "amplitude": 0.0032269416459867477,
-      "phase": 338.5241372665327
+      "amplitude": 0.003,
+      "phase": 338.52
     },
     {
       "name": "NU2",
-      "amplitude": 0.0014475297027022585,
-      "phase": 305.14220552597953
+      "amplitude": 0.001,
+      "phase": 305.14
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.000787413552188465,
-      "phase": 47.72877644806607
+      "amplitude": 0.001,
+      "phase": 47.73
     },
     {
       "name": "MN4",
-      "amplitude": 0.000533379679035338,
-      "phase": 284.9256540852763
+      "amplitude": 0.001,
+      "phase": 284.93
     },
     {
       "name": "MS4",
-      "amplitude": 0.0006287456415273651,
-      "phase": 165.70474928262206
+      "amplitude": 0.001,
+      "phase": 165.7
     },
     {
       "name": "N4",
-      "amplitude": 0.00011181468851189521,
-      "phase": 178.39216600841905
+      "amplitude": 0,
+      "phase": 178.39
     },
     {
       "name": "M6",
-      "amplitude": 0.00010661096925469319,
-      "phase": 171.44706818382895
+      "amplitude": 0,
+      "phase": 171.45
     },
     {
       "name": "M8",
-      "amplitude": 0.00005284307787270828,
-      "phase": 194.29016707632857
+      "amplitude": 0,
+      "phase": 194.29
     },
     {
       "name": "S4",
-      "amplitude": 0.00012632461534902277,
-      "phase": 140.7358698191196
+      "amplitude": 0,
+      "phase": 140.74
     },
     {
       "name": "OO1",
-      "amplitude": 0.00034601590263917974,
-      "phase": 115.5949669888779
+      "amplitude": 0,
+      "phase": 115.59
     },
     {
       "name": "S3",
-      "amplitude": 0.0007115715027270081,
-      "phase": 342.65858472914346
+      "amplitude": 0.001,
+      "phase": 342.66
     },
     {
       "name": "MA2",
-      "amplitude": 0.0013775865134950987,
-      "phase": 325.25434051485945
+      "amplitude": 0.001,
+      "phase": 325.25
     },
     {
       "name": "MB2",
-      "amplitude": 0.0017235896043597927,
-      "phase": 84.41465244907101
+      "amplitude": 0.002,
+      "phase": 84.41
     },
     {
       "name": "T3",
-      "amplitude": 0.0005036765173173944,
-      "phase": 243.03450934648282
+      "amplitude": 0.001,
+      "phase": 243.03
     },
     {
       "name": "R3",
-      "amplitude": 0.0004641478762937618,
-      "phase": 6.902085391087837
+      "amplitude": 0,
+      "phase": 6.9
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00011763602410476053,
-      "phase": 106.66574063491436
+      "amplitude": 0,
+      "phase": 106.67
     },
     {
       "name": "SGM",
-      "amplitude": 0.00107758980270959,
-      "phase": 242.080476891832
+      "amplitude": 0.001,
+      "phase": 242.08
     },
     {
       "name": "3L2",
-      "amplitude": 0.00016893810649849575,
-      "phase": 175.0198347367209
+      "amplitude": 0,
+      "phase": 175.02
     },
     {
       "name": "3N2",
-      "amplitude": 0.000578116057500284,
-      "phase": 229.65092128883768
+      "amplitude": 0.001,
+      "phase": 229.65
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0006814599604567866,
-      "phase": 39.717614990459936
+      "amplitude": 0.001,
+      "phase": 39.72
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00009055335746914729,
-      "phase": 246.39255430287858
+      "amplitude": 0,
+      "phase": 246.39
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00005068455699476202,
-      "phase": 42.08141272085703
+      "amplitude": 0,
+      "phase": 42.08
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00001696206771402634,
-      "phase": 235.80990365949137
+      "amplitude": 0,
+      "phase": 235.81
     }
   ],
   "epoch": {

--- a/data/ticon/timmendorfpoel-9630007-deu-wsv.json
+++ b/data/ticon/timmendorfpoel-9630007-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.0581611186015756,
-      "phase": 162.04504703729845
+      "amplitude": 0.058,
+      "phase": 162.05
     },
     {
       "name": "N2",
-      "amplitude": 0.012881550314391005,
-      "phase": 100.97221263630865
+      "amplitude": 0.013,
+      "phase": 100.97
     },
     {
       "name": "S2",
-      "amplitude": 0.01040942415768547,
-      "phase": 142.35322999863354
+      "amplitude": 0.01,
+      "phase": 142.35
     },
     {
       "name": "K2",
-      "amplitude": 0.0026073010344093523,
-      "phase": 132.8197560749593
+      "amplitude": 0.003,
+      "phase": 132.82
     },
     {
       "name": "2N2",
-      "amplitude": 0.0014956526050958889,
-      "phase": 58.29002326177425
+      "amplitude": 0.001,
+      "phase": 58.29
     },
     {
       "name": "S1",
-      "amplitude": 0.0034183583256610314,
-      "phase": 109.95280351289233
+      "amplitude": 0.003,
+      "phase": 109.95
     },
     {
       "name": "K1",
-      "amplitude": 0.01431961094501166,
-      "phase": 193.4258627249764
+      "amplitude": 0.014,
+      "phase": 193.43
     },
     {
       "name": "P1",
-      "amplitude": 0.0035940436809396062,
-      "phase": 234.48143544131585
+      "amplitude": 0.004,
+      "phase": 234.48
     },
     {
       "name": "O1",
-      "amplitude": 0.017458831903753944,
-      "phase": 119.66385736324645
+      "amplitude": 0.017,
+      "phase": 119.66
     },
     {
       "name": "Q1",
-      "amplitude": 0.0024317667287345945,
-      "phase": 335.6898930215981
+      "amplitude": 0.002,
+      "phase": 335.69
     },
     {
       "name": "M1",
-      "amplitude": 0.00039873572914690735,
-      "phase": 27.020518532995254
+      "amplitude": 0,
+      "phase": 27.02
     },
     {
       "name": "M4",
-      "amplitude": 0.001189171433958249,
-      "phase": 330.97457760351625
+      "amplitude": 0.001,
+      "phase": 330.97
     },
     {
       "name": "MM",
-      "amplitude": 0.01090017389248287,
-      "phase": 292.26469447879776
+      "amplitude": 0.011,
+      "phase": 292.26
     },
     {
       "name": "MF",
-      "amplitude": 0.009379272195815982,
-      "phase": 258.55854121382504
+      "amplitude": 0.009,
+      "phase": 258.56
     },
     {
       "name": "SA",
-      "amplitude": 0.03850686409950777,
-      "phase": 154.78124589517176
+      "amplitude": 0.039,
+      "phase": 154.78
     },
     {
       "name": "SSA",
-      "amplitude": 0.02143705499434378,
-      "phase": 260.13167201430906
+      "amplitude": 0.021,
+      "phase": 260.13
     },
     {
       "name": "T2",
-      "amplitude": 0.0011414815983394832,
-      "phase": 99.18766087203932
+      "amplitude": 0.001,
+      "phase": 99.19
     },
     {
       "name": "J1",
-      "amplitude": 0.0009479347004656526,
-      "phase": 163.72049098726245
+      "amplitude": 0.001,
+      "phase": 163.72
     },
     {
       "name": "L2",
-      "amplitude": 0.005486112672336368,
-      "phase": 252.06520653787777
+      "amplitude": 0.005,
+      "phase": 252.07
     },
     {
       "name": "R2",
-      "amplitude": 0.0011257784530301163,
-      "phase": 197.65574513603642
+      "amplitude": 0.001,
+      "phase": 197.66
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0006731468486461152,
-      "phase": 260.3525466911972
+      "amplitude": 0.001,
+      "phase": 260.35
     },
     {
       "name": "MSF",
-      "amplitude": 0.00269048943402283,
-      "phase": 244.7096422926067
+      "amplitude": 0.003,
+      "phase": 244.71
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0036061011567777536,
-      "phase": 201.39740820425783
+      "amplitude": 0.004,
+      "phase": 201.4
     },
     {
       "name": "EP2",
-      "amplitude": 0.0028007925388607267,
-      "phase": 261.949544796095
+      "amplitude": 0.003,
+      "phase": 261.95
     },
     {
       "name": "M3",
-      "amplitude": 0.0005001916848915862,
-      "phase": 336.962248527349
+      "amplitude": 0.001,
+      "phase": 336.96
     },
     {
       "name": "MU2",
-      "amplitude": 0.01099650463641412,
-      "phase": 306.9527104512382
+      "amplitude": 0.011,
+      "phase": 306.95
     },
     {
       "name": "MTM",
-      "amplitude": 0.0034757098680216663,
-      "phase": 348.4946411258491
+      "amplitude": 0.003,
+      "phase": 348.49
     },
     {
       "name": "NU2",
-      "amplitude": 0.0042387375589040205,
-      "phase": 139.0116458322724
+      "amplitude": 0.004,
+      "phase": 139.01
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0028162231979142007,
-      "phase": 249.45162533787186
+      "amplitude": 0.003,
+      "phase": 249.45
     },
     {
       "name": "MN4",
-      "amplitude": 0.00038263290692778845,
-      "phase": 264.07079732508123
+      "amplitude": 0,
+      "phase": 264.07
     },
     {
       "name": "MS4",
-      "amplitude": 0.0005017561322459615,
-      "phase": 120.21028577362131
+      "amplitude": 0.001,
+      "phase": 120.21
     },
     {
       "name": "N4",
-      "amplitude": 0.00005805878065601209,
-      "phase": 152.3448407451558
+      "amplitude": 0,
+      "phase": 152.34
     },
     {
       "name": "M6",
-      "amplitude": 0.000635262512090954,
-      "phase": 212.00315842437902
+      "amplitude": 0.001,
+      "phase": 212
     },
     {
       "name": "M8",
-      "amplitude": 0.00008099477767507972,
-      "phase": 173.66532444591223
+      "amplitude": 0,
+      "phase": 173.67
     },
     {
       "name": "S4",
-      "amplitude": 0.00016899710576072938,
-      "phase": 12.082620432619592
+      "amplitude": 0,
+      "phase": 12.08
     },
     {
       "name": "OO1",
-      "amplitude": 0.0013554747135065587,
-      "phase": 139.95876613349196
+      "amplitude": 0.001,
+      "phase": 139.96
     },
     {
       "name": "S3",
-      "amplitude": 0.00048772903352493934,
-      "phase": 20.189938445549785
+      "amplitude": 0,
+      "phase": 20.19
     },
     {
       "name": "MA2",
-      "amplitude": 0.005770855563992585,
-      "phase": 123.98139625847375
+      "amplitude": 0.006,
+      "phase": 123.98
     },
     {
       "name": "MB2",
-      "amplitude": 0.006475814330947928,
-      "phase": 288.1418659835803
+      "amplitude": 0.006,
+      "phase": 288.14
     },
     {
       "name": "T3",
-      "amplitude": 0.0007578843930997166,
-      "phase": 281.3716104762412
+      "amplitude": 0.001,
+      "phase": 281.37
     },
     {
       "name": "R3",
-      "amplitude": 0.0007461593955214054,
-      "phase": 24.878884559809308
+      "amplitude": 0.001,
+      "phase": 24.88
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0003733210749075025,
-      "phase": 290.42483772619676
+      "amplitude": 0,
+      "phase": 290.42
     },
     {
       "name": "SGM",
-      "amplitude": 0.0024327564279433066,
-      "phase": 222.83648281136215
+      "amplitude": 0.002,
+      "phase": 222.84
     },
     {
       "name": "3L2",
-      "amplitude": 0.00026636129874913075,
-      "phase": 58.62102178084422
+      "amplitude": 0,
+      "phase": 58.62
     },
     {
       "name": "3N2",
-      "amplitude": 0.001302378420621543,
-      "phase": 49.72731625121503
+      "amplitude": 0.001,
+      "phase": 49.73
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0017045264662753064,
-      "phase": 252.79556101277547
+      "amplitude": 0.002,
+      "phase": 252.8
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0004840264661114372,
-      "phase": 285.3111875563532
+      "amplitude": 0,
+      "phase": 285.31
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00011115012308334264,
-      "phase": 299.74180476304804
+      "amplitude": 0,
+      "phase": 299.74
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00020791338021297504,
-      "phase": 160.511227875514
+      "amplitude": 0,
+      "phase": 160.51
     }
   ],
   "epoch": {

--- a/data/ticon/tnning-9520070-deu-wsv.json
+++ b/data/ticon/tnning-9520070-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.0241188174679505,
-      "phase": 19.170197745171777
+      "amplitude": 1.024,
+      "phase": 19.17
     },
     {
       "name": "N2",
-      "amplitude": 0.1616437764796196,
-      "phase": 355.3541602180254
+      "amplitude": 0.162,
+      "phase": 355.35
     },
     {
       "name": "S2",
-      "amplitude": 0.2666717456617517,
-      "phase": 97.94272964943434
+      "amplitude": 0.267,
+      "phase": 97.94
     },
     {
       "name": "K2",
-      "amplitude": 0.08241780892347939,
-      "phase": 97.03345453627043
+      "amplitude": 0.082,
+      "phase": 97.03
     },
     {
       "name": "2N2",
-      "amplitude": 0.0213895538352633,
-      "phase": 346.3084209893159
+      "amplitude": 0.021,
+      "phase": 346.31
     },
     {
       "name": "S1",
-      "amplitude": 0.02088805306823775,
-      "phase": 309.57471539941724
+      "amplitude": 0.021,
+      "phase": 309.57
     },
     {
       "name": "K1",
-      "amplitude": 0.06086554708779032,
-      "phase": 55.970907174801084
+      "amplitude": 0.061,
+      "phase": 55.97
     },
     {
       "name": "P1",
-      "amplitude": 0.02866058277872351,
-      "phase": 41.568015542198225
+      "amplitude": 0.029,
+      "phase": 41.57
     },
     {
       "name": "O1",
-      "amplitude": 0.07708678129345989,
-      "phase": 271.6622860367358
+      "amplitude": 0.077,
+      "phase": 271.66
     },
     {
       "name": "Q1",
-      "amplitude": 0.020920564637044108,
-      "phase": 218.70642448467655
+      "amplitude": 0.021,
+      "phase": 218.71
     },
     {
       "name": "M1",
-      "amplitude": 0.0010603929748211928,
-      "phase": 128.0496651576002
+      "amplitude": 0.001,
+      "phase": 128.05
     },
     {
       "name": "M4",
-      "amplitude": 0.08005777992219179,
-      "phase": 243.86817296582876
+      "amplitude": 0.08,
+      "phase": 243.87
     },
     {
       "name": "MM",
-      "amplitude": 0.024954929143277987,
-      "phase": 133.62359812724844
+      "amplitude": 0.025,
+      "phase": 133.62
     },
     {
       "name": "MF",
-      "amplitude": 0.012224828339235083,
-      "phase": 136.9409688490631
+      "amplitude": 0.012,
+      "phase": 136.94
     },
     {
       "name": "SA",
-      "amplitude": 0.12720361130267205,
-      "phase": 132.34989188478812
+      "amplitude": 0.127,
+      "phase": 132.35
     },
     {
       "name": "SSA",
-      "amplitude": 0.008497766965732194,
-      "phase": 31.28390009860567
+      "amplitude": 0.008,
+      "phase": 31.28
     },
     {
       "name": "T2",
-      "amplitude": 0.006765165909345201,
-      "phase": 53.9949022917678
+      "amplitude": 0.007,
+      "phase": 53.99
     },
     {
       "name": "J1",
-      "amplitude": 0.005361116504900879,
-      "phase": 182.59441223500525
+      "amplitude": 0.005,
+      "phase": 182.59
     },
     {
       "name": "L2",
-      "amplitude": 0.08897779924935595,
-      "phase": 30.733850585697496
+      "amplitude": 0.089,
+      "phase": 30.73
     },
     {
       "name": "R2",
-      "amplitude": 0.005592636298445732,
-      "phase": 77.4717147802026
+      "amplitude": 0.006,
+      "phase": 77.47
     },
     {
       "name": "2Q1",
-      "amplitude": 0.007454749416732691,
-      "phase": 182.97134809559893
+      "amplitude": 0.007,
+      "phase": 182.97
     },
     {
       "name": "MSF",
-      "amplitude": 0.04223604452895949,
-      "phase": 96.42938369952532
+      "amplitude": 0.042,
+      "phase": 96.43
     },
     {
       "name": "MSQM",
-      "amplitude": 0.000530168534181492,
-      "phase": 155.77572374647616
+      "amplitude": 0.001,
+      "phase": 155.78
     },
     {
       "name": "EP2",
-      "amplitude": 0.03635276048355875,
-      "phase": 85.85939540477688
+      "amplitude": 0.036,
+      "phase": 85.86
     },
     {
       "name": "M3",
-      "amplitude": 0.001126745360990258,
-      "phase": 125.54659157413403
+      "amplitude": 0.001,
+      "phase": 125.55
     },
     {
       "name": "MU2",
-      "amplitude": 0.12864709722385925,
-      "phase": 98.3305680516304
+      "amplitude": 0.129,
+      "phase": 98.33
     },
     {
       "name": "MTM",
-      "amplitude": 0.010741719645037447,
-      "phase": 100.04023107357028
+      "amplitude": 0.011,
+      "phase": 100.04
     },
     {
       "name": "NU2",
-      "amplitude": 0.06411973319384091,
-      "phase": 339.28747055113826
+      "amplitude": 0.064,
+      "phase": 339.29
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.039536148824106575,
-      "phase": 40.68427627212833
+      "amplitude": 0.04,
+      "phase": 40.68
     },
     {
       "name": "MN4",
-      "amplitude": 0.02464477318586167,
-      "phase": 220.76933530986085
+      "amplitude": 0.025,
+      "phase": 220.77
     },
     {
       "name": "MS4",
-      "amplitude": 0.05091638052532778,
-      "phase": 319.6751794770202
+      "amplitude": 0.051,
+      "phase": 319.68
     },
     {
       "name": "N4",
-      "amplitude": 0.004600416843973931,
-      "phase": 204.62424667252208
+      "amplitude": 0.005,
+      "phase": 204.62
     },
     {
       "name": "M6",
-      "amplitude": 0.028056218498826575,
-      "phase": 142.17868776333296
+      "amplitude": 0.028,
+      "phase": 142.18
     },
     {
       "name": "M8",
-      "amplitude": 0.014146855158083409,
-      "phase": 34.247834767817665
+      "amplitude": 0.014,
+      "phase": 34.25
     },
     {
       "name": "S4",
-      "amplitude": 0.005595059897850541,
-      "phase": 112.45725308502301
+      "amplitude": 0.006,
+      "phase": 112.46
     },
     {
       "name": "OO1",
-      "amplitude": 0.003706368333006211,
-      "phase": 354.42900618124537
+      "amplitude": 0.004,
+      "phase": 354.43
     },
     {
       "name": "S3",
-      "amplitude": 0.00522060444126412,
-      "phase": 88.97519729177338
+      "amplitude": 0.005,
+      "phase": 88.98
     },
     {
       "name": "MA2",
-      "amplitude": 0.06857661294683569,
-      "phase": 293.747008179886
+      "amplitude": 0.069,
+      "phase": 293.75
     },
     {
       "name": "MB2",
-      "amplitude": 0.06540483700794716,
-      "phase": 112.9889230906245
+      "amplitude": 0.065,
+      "phase": 112.99
     },
     {
       "name": "T3",
-      "amplitude": 0.0012573202270195988,
-      "phase": 287.8578965186764
+      "amplitude": 0.001,
+      "phase": 287.86
     },
     {
       "name": "R3",
-      "amplitude": 0.0038760226024296923,
-      "phase": 356.3212504808269
+      "amplitude": 0.004,
+      "phase": 356.32
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004984471576033058,
-      "phase": 210.01992035927728
+      "amplitude": 0.005,
+      "phase": 210.02
     },
     {
       "name": "SGM",
-      "amplitude": 0.010332691626580607,
-      "phase": 86.64772420154509
+      "amplitude": 0.01,
+      "phase": 86.65
     },
     {
       "name": "3L2",
-      "amplitude": 0.007946207310517508,
-      "phase": 300.63517021010176
+      "amplitude": 0.008,
+      "phase": 300.64
     },
     {
       "name": "3N2",
-      "amplitude": 0.0035721242214809996,
-      "phase": 125.38176523350899
+      "amplitude": 0.004,
+      "phase": 125.38
     },
     {
       "name": "2SM2",
-      "amplitude": 0.029525750796863776,
-      "phase": 314.50002003347436
+      "amplitude": 0.03,
+      "phase": 314.5
     },
     {
       "name": "2MS6",
-      "amplitude": 0.030423702950605598,
-      "phase": 212.71206902442
+      "amplitude": 0.03,
+      "phase": 212.71
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0009482588722195903,
-      "phase": 140.49442558373778
+      "amplitude": 0.001,
+      "phase": 140.49
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0026260810805697346,
-      "phase": 80.42099887267256
+      "amplitude": 0.003,
+      "phase": 80.42
     }
   ],
   "epoch": {

--- a/data/ticon/travemnde-9620085-deu-wsv.json
+++ b/data/ticon/travemnde-9620085-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.06164087753911779,
-      "phase": 161.70624200516409
+      "amplitude": 0.062,
+      "phase": 161.71
     },
     {
       "name": "N2",
-      "amplitude": 0.013794215028244681,
-      "phase": 101.19957924352832
+      "amplitude": 0.014,
+      "phase": 101.2
     },
     {
       "name": "S2",
-      "amplitude": 0.01180678796594837,
-      "phase": 143.51143707233268
+      "amplitude": 0.012,
+      "phase": 143.51
     },
     {
       "name": "K2",
-      "amplitude": 0.0028627823216407005,
-      "phase": 132.93864886011107
+      "amplitude": 0.003,
+      "phase": 132.94
     },
     {
       "name": "2N2",
-      "amplitude": 0.0015715680976099572,
-      "phase": 62.461672625963445
+      "amplitude": 0.002,
+      "phase": 62.46
     },
     {
       "name": "S1",
-      "amplitude": 0.0037143934544013636,
-      "phase": 115.82326325838198
+      "amplitude": 0.004,
+      "phase": 115.82
     },
     {
       "name": "K1",
-      "amplitude": 0.0141196285240805,
-      "phase": 191.22007245767523
+      "amplitude": 0.014,
+      "phase": 191.22
     },
     {
       "name": "P1",
-      "amplitude": 0.003276322330470163,
-      "phase": 230.58115697755926
+      "amplitude": 0.003,
+      "phase": 230.58
     },
     {
       "name": "O1",
-      "amplitude": 0.01835119017026157,
-      "phase": 118.39106582117455
+      "amplitude": 0.018,
+      "phase": 118.39
     },
     {
       "name": "Q1",
-      "amplitude": 0.0023065866176008166,
-      "phase": 335.5113747330334
+      "amplitude": 0.002,
+      "phase": 335.51
     },
     {
       "name": "M1",
-      "amplitude": 0.0003487155863121615,
-      "phase": 29.25667512294973
+      "amplitude": 0,
+      "phase": 29.26
     },
     {
       "name": "M4",
-      "amplitude": 0.0021216417422416324,
-      "phase": 328.56346361031535
+      "amplitude": 0.002,
+      "phase": 328.56
     },
     {
       "name": "MM",
-      "amplitude": 0.01169837043965417,
-      "phase": 297.99466400555036
+      "amplitude": 0.012,
+      "phase": 297.99
     },
     {
       "name": "MF",
-      "amplitude": 0.010050118689429965,
-      "phase": 258.1217380835991
+      "amplitude": 0.01,
+      "phase": 258.12
     },
     {
       "name": "SA",
-      "amplitude": 0.03095294832279535,
-      "phase": 156.979410510839
+      "amplitude": 0.031,
+      "phase": 156.98
     },
     {
       "name": "SSA",
-      "amplitude": 0.019522531084824827,
-      "phase": 271.0678675531333
+      "amplitude": 0.02,
+      "phase": 271.07
     },
     {
       "name": "T2",
-      "amplitude": 0.0009007541153017068,
-      "phase": 115.81128360226171
+      "amplitude": 0.001,
+      "phase": 115.81
     },
     {
       "name": "J1",
-      "amplitude": 0.0009106664269389713,
-      "phase": 150.23944100510045
+      "amplitude": 0.001,
+      "phase": 150.24
     },
     {
       "name": "L2",
-      "amplitude": 0.005852958568943473,
-      "phase": 253.46870512662042
+      "amplitude": 0.006,
+      "phase": 253.47
     },
     {
       "name": "R2",
-      "amplitude": 0.0009457695308238015,
-      "phase": 187.37043250329933
+      "amplitude": 0.001,
+      "phase": 187.37
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0008234323823426704,
-      "phase": 255.2805904396936
+      "amplitude": 0.001,
+      "phase": 255.28
     },
     {
       "name": "MSF",
-      "amplitude": 0.0028412620596146654,
-      "phase": 234.4177991657382
+      "amplitude": 0.003,
+      "phase": 234.42
     },
     {
       "name": "MSQM",
-      "amplitude": 0.004170442834639802,
-      "phase": 205.6768330818133
+      "amplitude": 0.004,
+      "phase": 205.68
     },
     {
       "name": "EP2",
-      "amplitude": 0.0030013858407668607,
-      "phase": 260.89362447086694
+      "amplitude": 0.003,
+      "phase": 260.89
     },
     {
       "name": "M3",
-      "amplitude": 0.0005719360653819905,
-      "phase": 344.45446419837435
+      "amplitude": 0.001,
+      "phase": 344.45
     },
     {
       "name": "MU2",
-      "amplitude": 0.011552871654003866,
-      "phase": 308.8306172356932
+      "amplitude": 0.012,
+      "phase": 308.83
     },
     {
       "name": "MTM",
-      "amplitude": 0.0038616761294919953,
-      "phase": 352.3368339815594
+      "amplitude": 0.004,
+      "phase": 352.34
     },
     {
       "name": "NU2",
-      "amplitude": 0.004567596155586871,
-      "phase": 139.03333230736212
+      "amplitude": 0.005,
+      "phase": 139.03
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0030553198313329364,
-      "phase": 251.33320660832067
+      "amplitude": 0.003,
+      "phase": 251.33
     },
     {
       "name": "MN4",
-      "amplitude": 0.0007710693501442129,
-      "phase": 260.86127252442907
+      "amplitude": 0.001,
+      "phase": 260.86
     },
     {
       "name": "MS4",
-      "amplitude": 0.00032385288987133424,
-      "phase": 154.60647270746608
+      "amplitude": 0,
+      "phase": 154.61
     },
     {
       "name": "N4",
-      "amplitude": 0.00007124673594449574,
-      "phase": 177.8856647626718
+      "amplitude": 0,
+      "phase": 177.89
     },
     {
       "name": "M6",
-      "amplitude": 0.0005768955015216435,
-      "phase": 237.4831802098692
+      "amplitude": 0.001,
+      "phase": 237.48
     },
     {
       "name": "M8",
-      "amplitude": 0.00007071945479839052,
-      "phase": 78.18925792347216
+      "amplitude": 0,
+      "phase": 78.19
     },
     {
       "name": "S4",
-      "amplitude": 0.00035041575346303553,
-      "phase": 292.0268687652405
+      "amplitude": 0,
+      "phase": 292.03
     },
     {
       "name": "OO1",
-      "amplitude": 0.0013296331881218185,
-      "phase": 140.20841740043176
+      "amplitude": 0.001,
+      "phase": 140.21
     },
     {
       "name": "S3",
-      "amplitude": 0.0006988411056528793,
-      "phase": 32.76894872304945
+      "amplitude": 0.001,
+      "phase": 32.77
     },
     {
       "name": "MA2",
-      "amplitude": 0.005871288827035053,
-      "phase": 120.2142543486799
+      "amplitude": 0.006,
+      "phase": 120.21
     },
     {
       "name": "MB2",
-      "amplitude": 0.007506315417561973,
-      "phase": 284.8543315529789
+      "amplitude": 0.008,
+      "phase": 284.85
     },
     {
       "name": "T3",
-      "amplitude": 0.0009779513833110156,
-      "phase": 282.68727118087844
+      "amplitude": 0.001,
+      "phase": 282.69
     },
     {
       "name": "R3",
-      "amplitude": 0.0010215098406354177,
-      "phase": 19.247185527856004
+      "amplitude": 0.001,
+      "phase": 19.25
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00034329294952091413,
-      "phase": 261.04631613145625
+      "amplitude": 0,
+      "phase": 261.05
     },
     {
       "name": "SGM",
-      "amplitude": 0.0025367603343057045,
-      "phase": 222.70584089490467
+      "amplitude": 0.003,
+      "phase": 222.71
     },
     {
       "name": "3L2",
-      "amplitude": 0.00023796935922173549,
-      "phase": 14.106009183599326
+      "amplitude": 0,
+      "phase": 14.11
     },
     {
       "name": "3N2",
-      "amplitude": 0.0014070188897250232,
-      "phase": 45.58814023369865
+      "amplitude": 0.001,
+      "phase": 45.59
     },
     {
       "name": "2SM2",
-      "amplitude": 0.001741081627751619,
-      "phase": 251.48944699881008
+      "amplitude": 0.002,
+      "phase": 251.49
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00030877736185009897,
-      "phase": 322.3353803193052
+      "amplitude": 0,
+      "phase": 322.34
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00011524303013290077,
-      "phase": 26.30544495706522
+      "amplitude": 0,
+      "phase": 26.31
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00021965130326546747,
-      "phase": 159.57914544928803
+      "amplitude": 0,
+      "phase": 159.58
     }
   ],
   "epoch": {

--- a/data/ticon/ueckermnde-9690088-deu-wsv.json
+++ b/data/ticon/ueckermnde-9690088-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.0020194361878107187,
-      "phase": 99.7935224686587
+      "amplitude": 0.002,
+      "phase": 99.79
     },
     {
       "name": "N2",
-      "amplitude": 0.0004750279162816288,
-      "phase": 63.3339643729704
+      "amplitude": 0,
+      "phase": 63.33
     },
     {
       "name": "S2",
-      "amplitude": 0.000763172436700551,
-      "phase": 179.2755788375025
+      "amplitude": 0.001,
+      "phase": 179.28
     },
     {
       "name": "K2",
-      "amplitude": 0.00006314093300708707,
-      "phase": 59.55253611369403
+      "amplitude": 0,
+      "phase": 59.55
     },
     {
       "name": "2N2",
-      "amplitude": 0.00019445872595584053,
-      "phase": 27.03656879613959
+      "amplitude": 0,
+      "phase": 27.04
     },
     {
       "name": "S1",
-      "amplitude": 0.004190494877567311,
-      "phase": 135.07837391531245
+      "amplitude": 0.004,
+      "phase": 135.08
     },
     {
       "name": "K1",
-      "amplitude": 0.0007458448742693321,
-      "phase": 198.38978396737522
+      "amplitude": 0.001,
+      "phase": 198.39
     },
     {
       "name": "P1",
-      "amplitude": 0.0013879696342351741,
-      "phase": 133.65386513919447
+      "amplitude": 0.001,
+      "phase": 133.65
     },
     {
       "name": "O1",
-      "amplitude": 0.00275700098007419,
-      "phase": 251.92528445865116
+      "amplitude": 0.003,
+      "phase": 251.93
     },
     {
       "name": "Q1",
-      "amplitude": 0.0006549478807397087,
-      "phase": 200.0533860202009
+      "amplitude": 0.001,
+      "phase": 200.05
     },
     {
       "name": "M1",
-      "amplitude": 0.00013353005769832843,
-      "phase": 175.54819571858525
+      "amplitude": 0,
+      "phase": 175.55
     },
     {
       "name": "M4",
-      "amplitude": 0.00014625303975916308,
-      "phase": 142.026169785594
+      "amplitude": 0,
+      "phase": 142.03
     },
     {
       "name": "MM",
-      "amplitude": 0.010417998002948086,
-      "phase": 291.01283393077756
+      "amplitude": 0.01,
+      "phase": 291.01
     },
     {
       "name": "MF",
-      "amplitude": 0.0071854945373615335,
-      "phase": 291.111445595673
+      "amplitude": 0.007,
+      "phase": 291.11
     },
     {
       "name": "SA",
-      "amplitude": 0.021752807669915074,
-      "phase": 218.75315512920136
+      "amplitude": 0.022,
+      "phase": 218.75
     },
     {
       "name": "SSA",
-      "amplitude": 0.03641933515903549,
-      "phase": 256.88648449571565
+      "amplitude": 0.036,
+      "phase": 256.89
     },
     {
       "name": "T2",
-      "amplitude": 0.00007490744777844854,
-      "phase": 79.56833786250957
+      "amplitude": 0,
+      "phase": 79.57
     },
     {
       "name": "J1",
-      "amplitude": 0.00014084295744785046,
-      "phase": 174.03477004831825
+      "amplitude": 0,
+      "phase": 174.03
     },
     {
       "name": "L2",
-      "amplitude": 0.00009637327064024748,
-      "phase": 193.08623690967798
+      "amplitude": 0,
+      "phase": 193.09
     },
     {
       "name": "R2",
-      "amplitude": 0.00012879237866008945,
-      "phase": 161.5184713607299
+      "amplitude": 0,
+      "phase": 161.52
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00014797868181394642,
-      "phase": 299.7668045276196
+      "amplitude": 0,
+      "phase": 299.77
     },
     {
       "name": "MSF",
-      "amplitude": 0.0015291524050445758,
-      "phase": 298.15142581790286
+      "amplitude": 0.002,
+      "phase": 298.15
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003222933328457448,
-      "phase": 216.20968807731379
+      "amplitude": 0.003,
+      "phase": 216.21
     },
     {
       "name": "EP2",
-      "amplitude": 0.0001303462190145181,
-      "phase": 199.22913335781553
+      "amplitude": 0,
+      "phase": 199.23
     },
     {
       "name": "M3",
-      "amplitude": 0.00006100055966453295,
-      "phase": 184.6909657925196
+      "amplitude": 0,
+      "phase": 184.69
     },
     {
       "name": "MU2",
-      "amplitude": 0.0001925867134325302,
-      "phase": 277.89204295473513
+      "amplitude": 0,
+      "phase": 277.89
     },
     {
       "name": "MTM",
-      "amplitude": 0.003598458464950143,
-      "phase": 25.397207324140936
+      "amplitude": 0.004,
+      "phase": 25.4
     },
     {
       "name": "NU2",
-      "amplitude": 0.00021941741228102254,
-      "phase": 106.50070564394662
+      "amplitude": 0,
+      "phase": 106.5
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00014347782199608956,
-      "phase": 223.92886111129508
+      "amplitude": 0,
+      "phase": 223.93
     },
     {
       "name": "MN4",
-      "amplitude": 0.00011309919806924545,
-      "phase": 66.98553943605589
+      "amplitude": 0,
+      "phase": 66.99
     },
     {
       "name": "MS4",
-      "amplitude": 0.00012936074182890196,
-      "phase": 87.93131034410891
+      "amplitude": 0,
+      "phase": 87.93
     },
     {
       "name": "N4",
-      "amplitude": 0.00007484272798634965,
-      "phase": 350.3833812931768
+      "amplitude": 0,
+      "phase": 350.38
     },
     {
       "name": "M6",
-      "amplitude": 0.000016885969269609343,
-      "phase": 246.96333873900255
+      "amplitude": 0,
+      "phase": 246.96
     },
     {
       "name": "M8",
-      "amplitude": 0.000008662873780352578,
-      "phase": 152.31613112992738
+      "amplitude": 0,
+      "phase": 152.32
     },
     {
       "name": "S4",
-      "amplitude": 0.00006942745302505087,
-      "phase": 222.2275926531262
+      "amplitude": 0,
+      "phase": 222.23
     },
     {
       "name": "OO1",
-      "amplitude": 0.0001804701068995663,
-      "phase": 85.22899761659448
+      "amplitude": 0,
+      "phase": 85.23
     },
     {
       "name": "S3",
-      "amplitude": 0.00014180368434274813,
-      "phase": 36.32489498290573
+      "amplitude": 0,
+      "phase": 36.32
     },
     {
       "name": "MA2",
-      "amplitude": 0.00027331533649689984,
-      "phase": 55.96371521312426
+      "amplitude": 0,
+      "phase": 55.96
     },
     {
       "name": "MB2",
-      "amplitude": 0.0003071728278708573,
-      "phase": 246.38361110997613
+      "amplitude": 0,
+      "phase": 246.38
     },
     {
       "name": "T3",
-      "amplitude": 0.00016265107905739042,
-      "phase": 286.210304089588
+      "amplitude": 0,
+      "phase": 286.21
     },
     {
       "name": "R3",
-      "amplitude": 0.00024259208597279558,
-      "phase": 60.91177055262045
+      "amplitude": 0,
+      "phase": 60.91
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00019881563955342167,
-      "phase": 278.41537400530586
+      "amplitude": 0,
+      "phase": 278.42
     },
     {
       "name": "SGM",
-      "amplitude": 0.000014679506239925877,
-      "phase": 53.50445521984733
+      "amplitude": 0,
+      "phase": 53.5
     },
     {
       "name": "3L2",
-      "amplitude": 0.00014055373177965211,
-      "phase": 278.80386302084383
+      "amplitude": 0,
+      "phase": 278.8
     },
     {
       "name": "3N2",
-      "amplitude": 0.0000428367385396726,
-      "phase": 176.26012459134347
+      "amplitude": 0,
+      "phase": 176.26
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00010951494459526372,
-      "phase": 210.45130288556336
+      "amplitude": 0,
+      "phase": 210.45
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00004708761883062216,
-      "phase": 42.88997869467585
+      "amplitude": 0,
+      "phase": 42.89
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00004067878237615382,
-      "phase": 151.27360392426783
+      "amplitude": 0,
+      "phase": 151.27
     },
     {
       "name": "2MO5",
-      "amplitude": 0.000040274043875149554,
-      "phase": 280.20738415881294
+      "amplitude": 0,
+      "phase": 280.21
     }
   ],
   "epoch": {

--- a/data/ticon/uetersen-5970016-deu-wsv.json
+++ b/data/ticon/uetersen-5970016-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.9104369157502061,
-      "phase": 80.66660406969095
+      "amplitude": 0.91,
+      "phase": 80.67
     },
     {
       "name": "N2",
-      "amplitude": 0.13170891967856985,
-      "phase": 54.23535959768799
+      "amplitude": 0.132,
+      "phase": 54.24
     },
     {
       "name": "S2",
-      "amplitude": 0.19689234467510214,
-      "phase": 156.05433972523542
+      "amplitude": 0.197,
+      "phase": 156.05
     },
     {
       "name": "K2",
-      "amplitude": 0.05982542510165345,
-      "phase": 156.70728631459224
+      "amplitude": 0.06,
+      "phase": 156.71
     },
     {
       "name": "2N2",
-      "amplitude": 0.011091274206654504,
-      "phase": 37.93793945492217
+      "amplitude": 0.011,
+      "phase": 37.94
     },
     {
       "name": "S1",
-      "amplitude": 0.013329015642159318,
-      "phase": 94.43150009404064
+      "amplitude": 0.013,
+      "phase": 94.43
     },
     {
       "name": "K1",
-      "amplitude": 0.056211763492517684,
-      "phase": 115.40174562614999
+      "amplitude": 0.056,
+      "phase": 115.4
     },
     {
       "name": "P1",
-      "amplitude": 0.0225907450963954,
-      "phase": 106.59268456789994
+      "amplitude": 0.023,
+      "phase": 106.59
     },
     {
       "name": "O1",
-      "amplitude": 0.06886595158631335,
-      "phase": 316.94517478289964
+      "amplitude": 0.069,
+      "phase": 316.95
     },
     {
       "name": "Q1",
-      "amplitude": 0.019036032442250148,
-      "phase": 251.63819474581283
+      "amplitude": 0.019,
+      "phase": 251.64
     },
     {
       "name": "M1",
-      "amplitude": 0.00175139816245796,
-      "phase": 155.06156631748195
+      "amplitude": 0.002,
+      "phase": 155.06
     },
     {
       "name": "M4",
-      "amplitude": 0.11714826589203381,
-      "phase": 82.24549172590775
+      "amplitude": 0.117,
+      "phase": 82.25
     },
     {
       "name": "MM",
-      "amplitude": 0.013927921120880005,
-      "phase": 91.26837634210852
+      "amplitude": 0.014,
+      "phase": 91.27
     },
     {
       "name": "MF",
-      "amplitude": 0.01941029048933245,
-      "phase": 96.02771249399461
+      "amplitude": 0.019,
+      "phase": 96.03
     },
     {
       "name": "SA",
-      "amplitude": 0.08010344693953828,
-      "phase": 279.036530779533
+      "amplitude": 0.08,
+      "phase": 279.04
     },
     {
       "name": "SSA",
-      "amplitude": 0.05394608962907662,
-      "phase": 231.01624063589048
+      "amplitude": 0.054,
+      "phase": 231.02
     },
     {
       "name": "T2",
-      "amplitude": 0.007093355866871136,
-      "phase": 155.86353100251245
+      "amplitude": 0.007,
+      "phase": 155.86
     },
     {
       "name": "J1",
-      "amplitude": 0.0057923121985648356,
-      "phase": 241.60137838854266
+      "amplitude": 0.006,
+      "phase": 241.6
     },
     {
       "name": "L2",
-      "amplitude": 0.0872158973207715,
-      "phase": 100.53213819433324
+      "amplitude": 0.087,
+      "phase": 100.53
     },
     {
       "name": "R2",
-      "amplitude": 0.00841313336334506,
-      "phase": 169.6955677292434
+      "amplitude": 0.008,
+      "phase": 169.7
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0039534007151575306,
-      "phase": 188.79468700723564
+      "amplitude": 0.004,
+      "phase": 188.79
     },
     {
       "name": "MSF",
-      "amplitude": 0.07783081885354391,
-      "phase": 66.35610259087537
+      "amplitude": 0.078,
+      "phase": 66.36
     },
     {
       "name": "MSQM",
-      "amplitude": 0.005880386132353485,
-      "phase": 16.900985694668634
+      "amplitude": 0.006,
+      "phase": 16.9
     },
     {
       "name": "EP2",
-      "amplitude": 0.027166557719872135,
-      "phase": 147.28820720551977
+      "amplitude": 0.027,
+      "phase": 147.29
     },
     {
       "name": "M3",
-      "amplitude": 0.0023287921004503903,
-      "phase": 149.2626493506142
+      "amplitude": 0.002,
+      "phase": 149.26
     },
     {
       "name": "MU2",
-      "amplitude": 0.12923477408486592,
-      "phase": 175.68620785464395
+      "amplitude": 0.129,
+      "phase": 175.69
     },
     {
       "name": "MTM",
-      "amplitude": 0.003643314083684712,
-      "phase": 160.97750995419335
+      "amplitude": 0.004,
+      "phase": 160.98
     },
     {
       "name": "NU2",
-      "amplitude": 0.06306377314574585,
-      "phase": 39.51915056000519
+      "amplitude": 0.063,
+      "phase": 39.52
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.040559209916852405,
-      "phase": 103.38400346845305
+      "amplitude": 0.041,
+      "phase": 103.38
     },
     {
       "name": "MN4",
-      "amplitude": 0.03759764923057463,
-      "phase": 55.40510821986925
+      "amplitude": 0.038,
+      "phase": 55.41
     },
     {
       "name": "MS4",
-      "amplitude": 0.05905123525726988,
-      "phase": 152.29674267930295
+      "amplitude": 0.059,
+      "phase": 152.3
     },
     {
       "name": "N4",
-      "amplitude": 0.007031150929100396,
-      "phase": 41.634942529011425
+      "amplitude": 0.007,
+      "phase": 41.63
     },
     {
       "name": "M6",
-      "amplitude": 0.0282104736953547,
-      "phase": 303.8162401032922
+      "amplitude": 0.028,
+      "phase": 303.82
     },
     {
       "name": "M8",
-      "amplitude": 0.019514154771449275,
-      "phase": 295.8118928877703
+      "amplitude": 0.02,
+      "phase": 295.81
     },
     {
       "name": "S4",
-      "amplitude": 0.0027966409972240702,
-      "phase": 294.20740422941714
+      "amplitude": 0.003,
+      "phase": 294.21
     },
     {
       "name": "OO1",
-      "amplitude": 0.002178709544502379,
-      "phase": 260.1494478741139
+      "amplitude": 0.002,
+      "phase": 260.15
     },
     {
       "name": "S3",
-      "amplitude": 0.0016509861958624702,
-      "phase": 57.28406964402285
+      "amplitude": 0.002,
+      "phase": 57.28
     },
     {
       "name": "MA2",
-      "amplitude": 0.033312207464909684,
-      "phase": 340.14425651129767
+      "amplitude": 0.033,
+      "phase": 340.14
     },
     {
       "name": "MB2",
-      "amplitude": 0.037354564273747976,
-      "phase": 187.51123422036798
+      "amplitude": 0.037,
+      "phase": 187.51
     },
     {
       "name": "T3",
-      "amplitude": 0.0010463956587574248,
-      "phase": 124.74233142222124
+      "amplitude": 0.001,
+      "phase": 124.74
     },
     {
       "name": "R3",
-      "amplitude": 0.005273607586800079,
-      "phase": 160.15733986254565
+      "amplitude": 0.005,
+      "phase": 160.16
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005337675948051798,
-      "phase": 269.2859653313416
+      "amplitude": 0.005,
+      "phase": 269.29
     },
     {
       "name": "SGM",
-      "amplitude": 0.0051123437864948485,
-      "phase": 95.76914584745981
+      "amplitude": 0.005,
+      "phase": 95.77
     },
     {
       "name": "3L2",
-      "amplitude": 0.0024726778712484136,
-      "phase": 345.37991970138035
+      "amplitude": 0.002,
+      "phase": 345.38
     },
     {
       "name": "3N2",
-      "amplitude": 0.01413008630672828,
-      "phase": 200.57934862959942
+      "amplitude": 0.014,
+      "phase": 200.58
     },
     {
       "name": "2SM2",
-      "amplitude": 0.022812100461937653,
-      "phase": 26.096579586777295
+      "amplitude": 0.023,
+      "phase": 26.1
     },
     {
       "name": "2MS6",
-      "amplitude": 0.027065519836828596,
-      "phase": 18.637630676164008
+      "amplitude": 0.027,
+      "phase": 18.64
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0027885286623024956,
-      "phase": 78.5979078026553
+      "amplitude": 0.003,
+      "phase": 78.6
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005303132913544534,
-      "phase": 274.96605432260003
+      "amplitude": 0.005,
+      "phase": 274.97
     }
   ],
   "epoch": {

--- a/data/ticon/vegesack-4950010-deu-wsv.json
+++ b/data/ticon/vegesack-4950010-deu-wsv.json
@@ -1,6 +1,6 @@
 {
   "name": "Vegesack",
-  "region": "City state Bremen",
+  "region": "Bremen",
   "country": "Germany",
   "continent": "Europe",
   "latitude": 53.17091,
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.7052941933725607,
-      "phase": 35.65035197103174
+      "amplitude": 1.705,
+      "phase": 35.65
     },
     {
       "name": "N2",
-      "amplitude": 0.259785919589406,
-      "phase": 11.597614410747383
+      "amplitude": 0.26,
+      "phase": 11.6
     },
     {
       "name": "S2",
-      "amplitude": 0.42602704456416,
-      "phase": 116.44561962492708
+      "amplitude": 0.426,
+      "phase": 116.45
     },
     {
       "name": "K2",
-      "amplitude": 0.12505477646568008,
-      "phase": 114.6637144937414
+      "amplitude": 0.125,
+      "phase": 114.66
     },
     {
       "name": "2N2",
-      "amplitude": 0.026640321584347586,
-      "phase": 351.0311172463838
+      "amplitude": 0.027,
+      "phase": 351.03
     },
     {
       "name": "S1",
-      "amplitude": 0.015382538156824492,
-      "phase": 90.61578384269876
+      "amplitude": 0.015,
+      "phase": 90.62
     },
     {
       "name": "K1",
-      "amplitude": 0.066929069086639,
-      "phase": 72.9484384276717
+      "amplitude": 0.067,
+      "phase": 72.95
     },
     {
       "name": "P1",
-      "amplitude": 0.02853692195148139,
-      "phase": 80.25325238850826
+      "amplitude": 0.029,
+      "phase": 80.25
     },
     {
       "name": "O1",
-      "amplitude": 0.08596301862202199,
-      "phase": 279.05478096195156
+      "amplitude": 0.086,
+      "phase": 279.05
     },
     {
       "name": "Q1",
-      "amplitude": 0.02340089838140461,
-      "phase": 217.58642576189152
+      "amplitude": 0.023,
+      "phase": 217.59
     },
     {
       "name": "M1",
-      "amplitude": 0.002490983413672608,
-      "phase": 136.90154196949067
+      "amplitude": 0.002,
+      "phase": 136.9
     },
     {
       "name": "M4",
-      "amplitude": 0.12773046513635075,
-      "phase": 336.062146150197
+      "amplitude": 0.128,
+      "phase": 336.06
     },
     {
       "name": "MM",
-      "amplitude": 0.010081858683772434,
-      "phase": 107.10480174911277
+      "amplitude": 0.01,
+      "phase": 107.1
     },
     {
       "name": "MF",
-      "amplitude": 0.01227943210727188,
-      "phase": 98.6981717816301
+      "amplitude": 0.012,
+      "phase": 98.7
     },
     {
       "name": "SA",
-      "amplitude": 0.06226348399676866,
-      "phase": 275.1087940845163
+      "amplitude": 0.062,
+      "phase": 275.11
     },
     {
       "name": "SSA",
-      "amplitude": 0.05423838299421161,
-      "phase": 231.55518540283026
+      "amplitude": 0.054,
+      "phase": 231.56
     },
     {
       "name": "T2",
-      "amplitude": 0.026394162470610532,
-      "phase": 75.42599347856321
+      "amplitude": 0.026,
+      "phase": 75.43
     },
     {
       "name": "J1",
-      "amplitude": 0.003663941675282434,
-      "phase": 197.26270322001415
+      "amplitude": 0.004,
+      "phase": 197.26
     },
     {
       "name": "L2",
-      "amplitude": 0.1543919074621041,
-      "phase": 49.44912101363127
+      "amplitude": 0.154,
+      "phase": 49.45
     },
     {
       "name": "R2",
-      "amplitude": 0.009408654111935472,
-      "phase": 256.3868237079123
+      "amplitude": 0.009,
+      "phase": 256.39
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004978544790456856,
-      "phase": 159.4552475712601
+      "amplitude": 0.005,
+      "phase": 159.46
     },
     {
       "name": "MSF",
-      "amplitude": 0.05218777100913352,
-      "phase": 65.10096070992364
+      "amplitude": 0.052,
+      "phase": 65.1
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007595557660695291,
-      "phase": 37.25840152464866
+      "amplitude": 0.008,
+      "phase": 37.26
     },
     {
       "name": "EP2",
-      "amplitude": 0.047910591302175086,
-      "phase": 92.12547959525784
+      "amplitude": 0.048,
+      "phase": 92.13
     },
     {
       "name": "M3",
-      "amplitude": 0.0045120951487797045,
-      "phase": 112.43745843510203
+      "amplitude": 0.005,
+      "phase": 112.44
     },
     {
       "name": "MU2",
-      "amplitude": 0.23514894613817117,
-      "phase": 115.77128584044175
+      "amplitude": 0.235,
+      "phase": 115.77
     },
     {
       "name": "MTM",
-      "amplitude": 0.0017726714896935355,
-      "phase": 231.1784522851414
+      "amplitude": 0.002,
+      "phase": 231.18
     },
     {
       "name": "NU2",
-      "amplitude": 0.1117606280614879,
-      "phase": 346.0486707602782
+      "amplitude": 0.112,
+      "phase": 346.05
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07269487026410512,
-      "phase": 49.84394244491085
+      "amplitude": 0.073,
+      "phase": 49.84
     },
     {
       "name": "MN4",
-      "amplitude": 0.042041749191021084,
-      "phase": 312.788987871921
+      "amplitude": 0.042,
+      "phase": 312.79
     },
     {
       "name": "MS4",
-      "amplitude": 0.08076952070211879,
-      "phase": 52.65858121143185
+      "amplitude": 0.081,
+      "phase": 52.66
     },
     {
       "name": "N4",
-      "amplitude": 0.008556041920275778,
-      "phase": 289.66632183207395
+      "amplitude": 0.009,
+      "phase": 289.67
     },
     {
       "name": "M6",
-      "amplitude": 0.05905707647112991,
-      "phase": 155.6003494682185
+      "amplitude": 0.059,
+      "phase": 155.6
     },
     {
       "name": "M8",
-      "amplitude": 0.009648558946808434,
-      "phase": 109.41350937674537
+      "amplitude": 0.01,
+      "phase": 109.41
     },
     {
       "name": "S4",
-      "amplitude": 0.009983451382499522,
-      "phase": 198.70382736749383
+      "amplitude": 0.01,
+      "phase": 198.7
     },
     {
       "name": "OO1",
-      "amplitude": 0.002430654438382738,
-      "phase": 229.90410945092898
+      "amplitude": 0.002,
+      "phase": 229.9
     },
     {
       "name": "S3",
-      "amplitude": 0.0009681879459098354,
-      "phase": 355.5782305973558
+      "amplitude": 0.001,
+      "phase": 355.58
     },
     {
       "name": "MA2",
-      "amplitude": 0.0909876661994763,
-      "phase": 2.7397998268451147
+      "amplitude": 0.091,
+      "phase": 2.74
     },
     {
       "name": "MB2",
-      "amplitude": 0.03371378253340765,
-      "phase": 257.8978582655493
+      "amplitude": 0.034,
+      "phase": 257.9
     },
     {
       "name": "T3",
-      "amplitude": 0.0015125018990159798,
-      "phase": 83.55077617846871
+      "amplitude": 0.002,
+      "phase": 83.55
     },
     {
       "name": "R3",
-      "amplitude": 0.005115052937761393,
-      "phase": 116.40754928166098
+      "amplitude": 0.005,
+      "phase": 116.41
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005381281576958351,
-      "phase": 227.82947645090738
+      "amplitude": 0.005,
+      "phase": 227.83
     },
     {
       "name": "SGM",
-      "amplitude": 0.0059476661343981045,
-      "phase": 52.32868044927466
+      "amplitude": 0.006,
+      "phase": 52.33
     },
     {
       "name": "3L2",
-      "amplitude": 0.003985006056266221,
-      "phase": 322.29386000077585
+      "amplitude": 0.004,
+      "phase": 322.29
     },
     {
       "name": "3N2",
-      "amplitude": 0.02684778128499978,
-      "phase": 194.98930111041042
+      "amplitude": 0.027,
+      "phase": 194.99
     },
     {
       "name": "2SM2",
-      "amplitude": 0.046594461175886503,
-      "phase": 338.6476367385989
+      "amplitude": 0.047,
+      "phase": 338.65
     },
     {
       "name": "2MS6",
-      "amplitude": 0.057795969295586086,
-      "phase": 231.0242147779865
+      "amplitude": 0.058,
+      "phase": 231.02
     },
     {
       "name": "2MK5",
-      "amplitude": 0.007411011748344586,
-      "phase": 162.25763648860266
+      "amplitude": 0.007,
+      "phase": 162.26
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005980978201916924,
-      "phase": 343.9280228988104
+      "amplitude": 0.006,
+      "phase": 343.93
     }
   ],
   "epoch": {

--- a/data/ticon/vlissingen-vlis-nld-rws.json
+++ b/data/ticon/vlissingen-vlis-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.5590409299999999,
-      "phase": 44.516549
+      "amplitude": 1.839,
+      "phase": 29.46
     },
     {
       "name": "N2",
-      "amplitude": 0.07482597,
-      "phase": 183.067327
+      "amplitude": 0.311,
+      "phase": 6.49
     },
     {
       "name": "S2",
-      "amplitude": 0.42316683,
-      "phase": 104.29877999999997
+      "amplitude": 0.492,
+      "phase": 87.91
     },
     {
       "name": "K2",
-      "amplitude": 0.07616668,
-      "phase": 98.772989
+      "amplitude": 0.141,
+      "phase": 87.8
     },
     {
       "name": "2N2",
-      "amplitude": 0.03656777,
-      "phase": 236.42946
+      "amplitude": 0.05,
+      "phase": 238.6
     },
     {
       "name": "S1",
-      "amplitude": 0.029061020000000003,
-      "phase": 54.00660399999998
+      "amplitude": 0.016,
+      "phase": 29.43
     },
     {
       "name": "K1",
-      "amplitude": 0.044540170000000004,
-      "phase": 5.888661000000013
+      "amplitude": 0.052,
+      "phase": 354.74
     },
     {
       "name": "P1",
-      "amplitude": 0.04673372,
-      "phase": 339.361625
+      "amplitude": 0.042,
+      "phase": 335.56
     },
     {
       "name": "O1",
-      "amplitude": 0.10720637,
-      "phase": 188.081986
+      "amplitude": 0.106,
+      "phase": 179.72
     },
     {
       "name": "Q1",
-      "amplitude": 0.030694759999999998,
-      "phase": 146.03553399999998
+      "amplitude": 0.031,
+      "phase": 134.28
     },
     {
       "name": "M1",
-      "amplitude": 0.012011810000000001,
-      "phase": 239.644541
+      "amplitude": 0.005,
+      "phase": 348.37
     },
     {
       "name": "M4",
-      "amplitude": 0.11827083,
-      "phase": 90.94150100000002
+      "amplitude": 0.134,
+      "phase": 60.27
     },
     {
       "name": "MM",
-      "amplitude": 0.050401629999999996,
-      "phase": 303.163772
+      "amplitude": 0.05,
+      "phase": 302.24
     },
     {
       "name": "MF",
-      "amplitude": 0.01087238,
-      "phase": 228.048198
+      "amplitude": 0.01,
+      "phase": 228.24
     },
     {
       "name": "SA",
-      "amplitude": 0.33159930000000004,
-      "phase": 208.707803
+      "amplitude": 0.327,
+      "phase": 208.1
     },
     {
       "name": "SSA",
-      "amplitude": 0.12793325,
-      "phase": 74.281049
+      "amplitude": 0.125,
+      "phase": 74.77
     },
     {
       "name": "T2",
-      "amplitude": 0.11500991,
-      "phase": 30.567542000000003
+      "amplitude": 0.029,
+      "phase": 72.18
     },
     {
       "name": "J1",
-      "amplitude": 0.00993345,
-      "phase": 107.268982
+      "amplitude": 0.009,
+      "phase": 97.21
     },
     {
       "name": "L2",
-      "amplitude": 0.0290996,
-      "phase": 84.160417
+      "amplitude": 0.25,
+      "phase": 29.72
     },
     {
       "name": "R2",
-      "amplitude": 0.03196145,
-      "phase": 302.469148
+      "amplitude": 0.006,
+      "phase": 219
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00488868,
-      "phase": 103.51578999999998
+      "amplitude": 0.005,
+      "phase": 85.11
     },
     {
       "name": "MSF",
-      "amplitude": 0.04713775,
-      "phase": 335.998656
+      "amplitude": 0.049,
+      "phase": 334.47
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008222420000000001,
-      "phase": 340.496723
+      "amplitude": 0.009,
+      "phase": 337.27
     },
     {
       "name": "EP2",
-      "amplitude": 0.03547936,
-      "phase": 125.467243
+      "amplitude": 0.039,
+      "phase": 126.18
     },
     {
       "name": "M3",
-      "amplitude": 0.00229109,
-      "phase": 300.248363
+      "amplitude": 0.004,
+      "phase": 94.92
     },
     {
       "name": "MU2",
-      "amplitude": 0.11638677,
-      "phase": 137.25408100000004
+      "amplitude": 0.129,
+      "phase": 129.57
     },
     {
       "name": "MTM",
-      "amplitude": 0.00911351,
-      "phase": 125.02847500000001
+      "amplitude": 0.012,
+      "phase": 130.04
     },
     {
       "name": "NU2",
-      "amplitude": 0.08873394,
-      "phase": 16.65096699999998
+      "amplitude": 0.089,
+      "phase": 353.69
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.10767027000000001,
-      "phase": 74.992752
+      "amplitude": 0.052,
+      "phase": 56.62
     },
     {
       "name": "MN4",
-      "amplitude": 0.051624540000000003,
-      "phase": 62.11378300000001
+      "amplitude": 0.053,
+      "phase": 35.39
     },
     {
       "name": "MS4",
-      "amplitude": 0.08198658,
-      "phase": 154.30166199999996
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.15604272,
-      "phase": 246.139639
+      "amplitude": 0.089,
+      "phase": 125.22
     },
     {
       "name": "N4",
-      "amplitude": 0.00213554,
-      "phase": 151.94867899999997
+      "amplitude": 0.005,
+      "phase": 287.74
     },
     {
       "name": "M6",
-      "amplitude": 0.06622725,
-      "phase": 71.410143
+      "amplitude": 0.096,
+      "phase": 16.09
     },
     {
       "name": "M8",
-      "amplitude": 0.02064386,
-      "phase": 61.306745999999976
+      "amplitude": 0.035,
+      "phase": 348.15
     },
     {
       "name": "S4",
-      "amplitude": 0.01027612,
-      "phase": 241.34505000000001
+      "amplitude": 0.01,
+      "phase": 226.46
     },
     {
       "name": "OO1",
-      "amplitude": 0.0037107800000000003,
-      "phase": 177.94585800000004
+      "amplitude": 0.002,
+      "phase": 149.82
     },
     {
       "name": "S3",
-      "amplitude": 0.00838687,
-      "phase": 129.356991
+      "amplitude": 0.01,
+      "phase": 322.81
     },
     {
       "name": "MA2",
-      "amplitude": 0.36456659,
-      "phase": 34.634097999999994
+      "amplitude": 0.026,
+      "phase": 167.51
     },
     {
       "name": "MB2",
-      "amplitude": 0.1303819,
-      "phase": 213.914718
+      "amplitude": 0.08,
+      "phase": 205.49
     },
     {
       "name": "T3",
-      "amplitude": 0.00433117,
-      "phase": 94.49574100000001
+      "amplitude": 0.007,
+      "phase": 271.87
     },
     {
       "name": "R3",
-      "amplitude": 0.01334573,
-      "phase": 238.50992100000002
+      "amplitude": 0.014,
+      "phase": 306.35
     },
     {
       "name": "RHO1",
-      "amplitude": 0.010816669999999999,
-      "phase": 175.598293
+      "amplitude": 0.009,
+      "phase": 153.7
     },
     {
       "name": "SGM",
-      "amplitude": 0.00904374,
-      "phase": 23.615429000000006
+      "amplitude": 0.007,
+      "phase": 187.53
     },
     {
       "name": "3L2",
-      "amplitude": 0.09472365999999999,
-      "phase": 175.963079
+      "amplitude": 0.098,
+      "phase": 68.77
     },
     {
       "name": "3N2",
-      "amplitude": 0.33886279,
-      "phase": 78.33955400000002
+      "amplitude": 0.014,
+      "phase": 110.65
     },
     {
       "name": "2SM2",
-      "amplitude": 0.05222538,
-      "phase": 327.522679
+      "amplitude": 0.046,
+      "phase": 320.88
     },
     {
       "name": "2MS6",
-      "amplitude": 0.073425,
-      "phase": 118.55319199999997
+      "amplitude": 0.096,
+      "phase": 73.1
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00944056,
-      "phase": 92.13161600000001
+      "amplitude": 0.01,
+      "phase": 147.84
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00430418,
-      "phase": 143.899087
+      "amplitude": 0.005,
+      "phase": 356.1
     }
   ],
   "epoch": {

--- a/data/ticon/walsoorden-walsodn-nld-rws.json
+++ b/data/ticon/walsoorden-walsodn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.9592104399999999,
-      "phase": 70.28677600000003
+      "amplitude": 2.026,
+      "phase": 53.59
     },
     {
       "name": "N2",
-      "amplitude": 0.31555163,
-      "phase": 47.08332100000001
+      "amplitude": 0.325,
+      "phase": 30.47
     },
     {
       "name": "S2",
-      "amplitude": 0.5124111299999999,
-      "phase": 132.45851400000004
+      "amplitude": 0.528,
+      "phase": 115.32
     },
     {
       "name": "K2",
-      "amplitude": 0.14162723,
-      "phase": 137.340887
+      "amplitude": 0.156,
+      "phase": 114.25
     },
     {
       "name": "2N2",
-      "amplitude": 0.03446371,
-      "phase": 22.133711000000005
+      "amplitude": 0.036,
+      "phase": 6.4
     },
     {
       "name": "S1",
-      "amplitude": 0.01096386,
-      "phase": 44.93856099999999
+      "amplitude": 0.009,
+      "phase": 348.1
     },
     {
       "name": "K1",
-      "amplitude": 0.0690148,
-      "phase": 22.388981
+      "amplitude": 0.07,
+      "phase": 13.37
     },
     {
       "name": "P1",
-      "amplitude": 0.03604442,
-      "phase": 4.745247000000006
+      "amplitude": 0.036,
+      "phase": 357.57
     },
     {
       "name": "O1",
-      "amplitude": 0.10407427999999999,
-      "phase": 203.019514
+      "amplitude": 0.104,
+      "phase": 194.5
     },
     {
       "name": "Q1",
-      "amplitude": 0.03332346,
-      "phase": 145.194679
+      "amplitude": 0.034,
+      "phase": 136.87
     },
     {
       "name": "M1",
-      "amplitude": 0.0015884,
-      "phase": 4.733052999999984
+      "amplitude": 0.003,
+      "phase": 19.45
     },
     {
       "name": "M4",
-      "amplitude": 0.10678139,
-      "phase": 146.921601
+      "amplitude": 0.123,
+      "phase": 112.25
     },
     {
       "name": "MM",
-      "amplitude": 0.01566082,
-      "phase": 32.94526400000001
+      "amplitude": 0.016,
+      "phase": 32.7
     },
     {
       "name": "MF",
-      "amplitude": 0.01009308,
-      "phase": 65.38161000000002
+      "amplitude": 0.01,
+      "phase": 64.88
     },
     {
       "name": "SA",
-      "amplitude": 0.06157373,
-      "phase": 214.906219
+      "amplitude": 0.062,
+      "phase": 215.22
     },
     {
       "name": "SSA",
-      "amplitude": 0.00665926,
-      "phase": 215.061591
+      "amplitude": 0.007,
+      "phase": 213.61
     },
     {
       "name": "T2",
-      "amplitude": 0.095522,
-      "phase": 49.38867800000003
+      "amplitude": 0.029,
+      "phase": 99.42
     },
     {
       "name": "J1",
-      "amplitude": 0.00443385,
-      "phase": 145.647224
+      "amplitude": 0.004,
+      "phase": 135.44
     },
     {
       "name": "L2",
-      "amplitude": 0.15496817,
-      "phase": 85.79089199999999
+      "amplitude": 0.16,
+      "phase": 68.34
     },
     {
       "name": "R2",
-      "amplitude": 0.06999525000000001,
-      "phase": 236.43732799999998
+      "amplitude": 0.003,
+      "phase": 187.68
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00439704,
-      "phase": 111.19182799999999
+      "amplitude": 0.005,
+      "phase": 104.23
     },
     {
       "name": "MSF",
-      "amplitude": 0.05186997,
-      "phase": 48.17247400000002
+      "amplitude": 0.051,
+      "phase": 47.41
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0034088499999999997,
-      "phase": 144.452918
+      "amplitude": 0.003,
+      "phase": 147.77
     },
     {
       "name": "EP2",
-      "amplitude": 0.04033155,
-      "phase": 149.74728900000002
+      "amplitude": 0.04,
+      "phase": 133.48
     },
     {
       "name": "M3",
-      "amplitude": 0.008732469999999999,
-      "phase": 181.153361
+      "amplitude": 0.009,
+      "phase": 335.88
     },
     {
       "name": "MU2",
-      "amplitude": 0.18130118,
-      "phase": 166.857211
+      "amplitude": 0.189,
+      "phase": 150.11
     },
     {
       "name": "MTM",
-      "amplitude": 0.00203089,
-      "phase": 224.530757
+      "amplitude": 0.002,
+      "phase": 225.57
     },
     {
       "name": "NU2",
-      "amplitude": 0.11412591000000001,
-      "phase": 31.543097999999986
+      "amplitude": 0.118,
+      "phase": 16.31
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06968805,
-      "phase": 85.21616699999998
+      "amplitude": 0.072,
+      "phase": 66.99
     },
     {
       "name": "MN4",
-      "amplitude": 0.03487672,
-      "phase": 121.46371899999997
+      "amplitude": 0.041,
+      "phase": 87.7
     },
     {
       "name": "MS4",
-      "amplitude": 0.06672427,
-      "phase": 206.307384
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.08307923,
-      "phase": 208.468631
+      "amplitude": 0.076,
+      "phase": 173.05
     },
     {
       "name": "N4",
-      "amplitude": 0.006042990000000001,
-      "phase": 95.54051500000003
+      "amplitude": 0.007,
+      "phase": 63.51
     },
     {
       "name": "M6",
-      "amplitude": 0.07407608,
-      "phase": 186.311454
+      "amplitude": 0.101,
+      "phase": 132.8
     },
     {
       "name": "M8",
-      "amplitude": 0.01358595,
-      "phase": 168.31502899999998
+      "amplitude": 0.025,
+      "phase": 92.41
     },
     {
       "name": "S4",
-      "amplitude": 0.00282083,
-      "phase": 316.117606
+      "amplitude": 0.003,
+      "phase": 284.56
     },
     {
       "name": "OO1",
-      "amplitude": 0.00499707,
-      "phase": 158.37057100000004
+      "amplitude": 0.005,
+      "phase": 151.99
     },
     {
       "name": "S3",
-      "amplitude": 0.0030233900000000004,
-      "phase": 125.17841099999998
+      "amplitude": 0,
+      "phase": 36.21
     },
     {
       "name": "MA2",
-      "amplitude": 0.34432578999999996,
-      "phase": 47.894506999999976
+      "amplitude": 0.035,
+      "phase": 10.67
     },
     {
       "name": "MB2",
-      "amplitude": 0.31115377,
-      "phase": 262.881681
+      "amplitude": 0.016,
+      "phase": 153.67
     },
     {
       "name": "T3",
-      "amplitude": 0.00214315,
-      "phase": 84.52619199999998
+      "amplitude": 0.003,
+      "phase": 262.33
     },
     {
       "name": "R3",
-      "amplitude": 0.0102387,
-      "phase": 322.562072
+      "amplitude": 0.011,
+      "phase": 25.72
     },
     {
       "name": "RHO1",
-      "amplitude": 0.007385350000000001,
-      "phase": 139.92280800000003
+      "amplitude": 0.008,
+      "phase": 132.74
     },
     {
       "name": "SGM",
-      "amplitude": 0.0039057999999999996,
-      "phase": 127.2969
+      "amplitude": 0.004,
+      "phase": 299.85
     },
     {
       "name": "3L2",
-      "amplitude": 0.0033336900000000003,
-      "phase": 287.681301
+      "amplitude": 0.003,
+      "phase": 358.35
     },
     {
       "name": "3N2",
-      "amplitude": 0.00475761,
-      "phase": 140.891457
+      "amplitude": 0.021,
+      "phase": 220.36
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04950984,
-      "phase": 359.731418
+      "amplitude": 0.051,
+      "phase": 341.53
     },
     {
       "name": "2MS6",
-      "amplitude": 0.07025262,
-      "phase": 237.213423
+      "amplitude": 0.096,
+      "phase": 183.68
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00855295,
-      "phase": 180.879939
+      "amplitude": 0.011,
+      "phase": 226.34
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00449283,
-      "phase": 212.632086
+      "amplitude": 0.006,
+      "phase": 79.03
     }
   ],
   "epoch": {

--- a/data/ticon/wangeroogenord-9420030-deu-wsv.json
+++ b/data/ticon/wangeroogenord-9420030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3259115427015442,
-      "phase": 302.3610884113767
+      "amplitude": 1.326,
+      "phase": 302.36
     },
     {
       "name": "N2",
-      "amplitude": 0.21183642406934133,
-      "phase": 277.0112212542464
+      "amplitude": 0.212,
+      "phase": 277.01
     },
     {
       "name": "S2",
-      "amplitude": 0.3526434923347616,
-      "phase": 10.371401640969168
+      "amplitude": 0.353,
+      "phase": 10.37
     },
     {
       "name": "K2",
-      "amplitude": 0.10559150083476702,
-      "phase": 8.62195545551117
+      "amplitude": 0.106,
+      "phase": 8.62
     },
     {
       "name": "2N2",
-      "amplitude": 0.023890237960175448,
-      "phase": 257.03818023925146
+      "amplitude": 0.024,
+      "phase": 257.04
     },
     {
       "name": "S1",
-      "amplitude": 0.01009764569981573,
-      "phase": 11.003038301637673
+      "amplitude": 0.01,
+      "phase": 11
     },
     {
       "name": "K1",
-      "amplitude": 0.07129595118338276,
-      "phase": 16.47683376760108
+      "amplitude": 0.071,
+      "phase": 16.48
     },
     {
       "name": "P1",
-      "amplitude": 0.02909033250699359,
-      "phase": 23.177032894881677
+      "amplitude": 0.029,
+      "phase": 23.18
     },
     {
       "name": "O1",
-      "amplitude": 0.0925439585151646,
-      "phase": 227.73737872983045
+      "amplitude": 0.093,
+      "phase": 227.74
     },
     {
       "name": "Q1",
-      "amplitude": 0.029668914243831737,
-      "phase": 169.55818340660505
+      "amplitude": 0.03,
+      "phase": 169.56
     },
     {
       "name": "M1",
-      "amplitude": 0.0016047445727622454,
-      "phase": 78.42969397085625
+      "amplitude": 0.002,
+      "phase": 78.43
     },
     {
       "name": "M4",
-      "amplitude": 0.060993198378213556,
-      "phase": 145.14198511460484
+      "amplitude": 0.061,
+      "phase": 145.14
     },
     {
       "name": "MM",
-      "amplitude": 0.025245476880270436,
-      "phase": 176.79482907249576
+      "amplitude": 0.025,
+      "phase": 176.79
     },
     {
       "name": "MF",
-      "amplitude": 0.010831172915776708,
-      "phase": 183.1841689804648
+      "amplitude": 0.011,
+      "phase": 183.18
     },
     {
       "name": "SA",
-      "amplitude": 0.10592724957665144,
-      "phase": 224.10636928818215
+      "amplitude": 0.106,
+      "phase": 224.11
     },
     {
       "name": "SSA",
-      "amplitude": 0.034974160398683125,
-      "phase": 205.0347799916518
+      "amplitude": 0.035,
+      "phase": 205.03
     },
     {
       "name": "T2",
-      "amplitude": 0.01926910954996609,
-      "phase": 355.97401238041505
+      "amplitude": 0.019,
+      "phase": 355.97
     },
     {
       "name": "J1",
-      "amplitude": 0.0016146057821269414,
-      "phase": 125.1868643520636
+      "amplitude": 0.002,
+      "phase": 125.19
     },
     {
       "name": "L2",
-      "amplitude": 0.10301043769150503,
-      "phase": 320.0489075689867
+      "amplitude": 0.103,
+      "phase": 320.05
     },
     {
       "name": "R2",
-      "amplitude": 0.004599742876044901,
-      "phase": 348.2987769694022
+      "amplitude": 0.005,
+      "phase": 348.3
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005825235635207831,
-      "phase": 111.7778057654391
+      "amplitude": 0.006,
+      "phase": 111.78
     },
     {
       "name": "MSF",
-      "amplitude": 0.004638371303871852,
-      "phase": 314.225749180628
+      "amplitude": 0.005,
+      "phase": 314.23
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007583210434850483,
-      "phase": 66.91812675707132
+      "amplitude": 0.008,
+      "phase": 66.92
     },
     {
       "name": "EP2",
-      "amplitude": 0.028710000101504544,
-      "phase": 8.974774759033778
+      "amplitude": 0.029,
+      "phase": 8.97
     },
     {
       "name": "M3",
-      "amplitude": 0.004062282066581864,
-      "phase": 302.8925567193983
+      "amplitude": 0.004,
+      "phase": 302.89
     },
     {
       "name": "MU2",
-      "amplitude": 0.12521150114599716,
-      "phase": 31.636501751765365
+      "amplitude": 0.125,
+      "phase": 31.64
     },
     {
       "name": "MTM",
-      "amplitude": 0.003686650521826778,
-      "phase": 250.00286608415382
+      "amplitude": 0.004,
+      "phase": 250
     },
     {
       "name": "NU2",
-      "amplitude": 0.07509372621556332,
-      "phase": 262.39025923910157
+      "amplitude": 0.075,
+      "phase": 262.39
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04890211979348811,
-      "phase": 313.3395749331766
+      "amplitude": 0.049,
+      "phase": 313.34
     },
     {
       "name": "MN4",
-      "amplitude": 0.02280020346445659,
-      "phase": 125.46147875076065
+      "amplitude": 0.023,
+      "phase": 125.46
     },
     {
       "name": "MS4",
-      "amplitude": 0.041442643385666986,
-      "phase": 200.19691385395424
+      "amplitude": 0.041,
+      "phase": 200.2
     },
     {
       "name": "N4",
-      "amplitude": 0.005282613040981085,
-      "phase": 101.93277990925384
+      "amplitude": 0.005,
+      "phase": 101.93
     },
     {
       "name": "M6",
-      "amplitude": 0.04963054423435677,
-      "phase": 288.64771382624724
+      "amplitude": 0.05,
+      "phase": 288.65
     },
     {
       "name": "M8",
-      "amplitude": 0.005755314708967048,
-      "phase": 118.04880627530588
+      "amplitude": 0.006,
+      "phase": 118.05
     },
     {
       "name": "S4",
-      "amplitude": 0.005725184892179348,
-      "phase": 299.5886264185795
+      "amplitude": 0.006,
+      "phase": 299.59
     },
     {
       "name": "OO1",
-      "amplitude": 0.0024134521968530824,
-      "phase": 183.1275645694533
+      "amplitude": 0.002,
+      "phase": 183.13
     },
     {
       "name": "S3",
-      "amplitude": 0.0004923513218504521,
-      "phase": 114.44968760856796
+      "amplitude": 0,
+      "phase": 114.45
     },
     {
       "name": "MA2",
-      "amplitude": 0.03857884634492912,
-      "phase": 249.08674775147657
+      "amplitude": 0.039,
+      "phase": 249.09
     },
     {
       "name": "MB2",
-      "amplitude": 0.028786331528095656,
-      "phase": 24.346736683397808
+      "amplitude": 0.029,
+      "phase": 24.35
     },
     {
       "name": "T3",
-      "amplitude": 0.0006786724130897697,
-      "phase": 326.78965809641875
+      "amplitude": 0.001,
+      "phase": 326.79
     },
     {
       "name": "R3",
-      "amplitude": 0.002734575334123549,
-      "phase": 349.16498595456187
+      "amplitude": 0.003,
+      "phase": 349.16
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00603412717952035,
-      "phase": 177.32971740434152
+      "amplitude": 0.006,
+      "phase": 177.33
     },
     {
       "name": "SGM",
-      "amplitude": 0.0024705459572853623,
-      "phase": 44.995513046759754
+      "amplitude": 0.002,
+      "phase": 45
     },
     {
       "name": "3L2",
-      "amplitude": 0.004219021770540321,
-      "phase": 210.80937704305572
+      "amplitude": 0.004,
+      "phase": 210.81
     },
     {
       "name": "3N2",
-      "amplitude": 0.016180392934064404,
-      "phase": 101.8994163344421
+      "amplitude": 0.016,
+      "phase": 101.9
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03329852328121158,
-      "phase": 231.25005324644755
+      "amplitude": 0.033,
+      "phase": 231.25
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04925235751165404,
-      "phase": 348.63297720906286
+      "amplitude": 0.049,
+      "phase": 348.63
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0012741767815156585,
-      "phase": 355.03569601544774
+      "amplitude": 0.001,
+      "phase": 355.04
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0029935041377171217,
-      "phase": 259.98870353915896
+      "amplitude": 0.003,
+      "phase": 259.99
     }
   ],
   "epoch": {

--- a/data/ticon/wangeroogewest-9420040-deu-wsv.json
+++ b/data/ticon/wangeroogewest-9420040-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3136503319798076,
-      "phase": 306.7212226478818
+      "amplitude": 1.314,
+      "phase": 306.72
     },
     {
       "name": "N2",
-      "amplitude": 0.21161203914769774,
-      "phase": 281.8155223072468
+      "amplitude": 0.212,
+      "phase": 281.82
     },
     {
       "name": "S2",
-      "amplitude": 0.349751568776896,
-      "phase": 15.797721762694096
+      "amplitude": 0.35,
+      "phase": 15.8
     },
     {
       "name": "K2",
-      "amplitude": 0.10392126062828058,
-      "phase": 13.860726326388146
+      "amplitude": 0.104,
+      "phase": 13.86
     },
     {
       "name": "2N2",
-      "amplitude": 0.0235017535931224,
-      "phase": 261.66680473501833
+      "amplitude": 0.024,
+      "phase": 261.67
     },
     {
       "name": "S1",
-      "amplitude": 0.010042729611385685,
-      "phase": 17.431410561851067
+      "amplitude": 0.01,
+      "phase": 17.43
     },
     {
       "name": "K1",
-      "amplitude": 0.07007098031913245,
-      "phase": 21.059603426561807
+      "amplitude": 0.07,
+      "phase": 21.06
     },
     {
       "name": "P1",
-      "amplitude": 0.029261810650880127,
-      "phase": 27.76982715904353
+      "amplitude": 0.029,
+      "phase": 27.77
     },
     {
       "name": "O1",
-      "amplitude": 0.09118546498863371,
-      "phase": 231.63258090534154
+      "amplitude": 0.091,
+      "phase": 231.63
     },
     {
       "name": "Q1",
-      "amplitude": 0.02892522940583487,
-      "phase": 173.31408457722853
+      "amplitude": 0.029,
+      "phase": 173.31
     },
     {
       "name": "M1",
-      "amplitude": 0.0018033994289698462,
-      "phase": 85.09725881133727
+      "amplitude": 0.002,
+      "phase": 85.1
     },
     {
       "name": "M4",
-      "amplitude": 0.03067007477273974,
-      "phase": 120.28009799815243
+      "amplitude": 0.031,
+      "phase": 120.28
     },
     {
       "name": "MM",
-      "amplitude": 0.022477855291773003,
-      "phase": 178.2153771546558
+      "amplitude": 0.022,
+      "phase": 178.22
     },
     {
       "name": "MF",
-      "amplitude": 0.010623527849848088,
-      "phase": 177.18926888537453
+      "amplitude": 0.011,
+      "phase": 177.19
     },
     {
       "name": "SA",
-      "amplitude": 0.10917596473747908,
-      "phase": 224.22539275484007
+      "amplitude": 0.109,
+      "phase": 224.23
     },
     {
       "name": "SSA",
-      "amplitude": 0.03797402045823431,
-      "phase": 202.87401252233704
+      "amplitude": 0.038,
+      "phase": 202.87
     },
     {
       "name": "T2",
-      "amplitude": 0.018213392182315987,
-      "phase": 356.80930106335063
+      "amplitude": 0.018,
+      "phase": 356.81
     },
     {
       "name": "J1",
-      "amplitude": 0.001537048931613686,
-      "phase": 141.3510641356712
+      "amplitude": 0.002,
+      "phase": 141.35
     },
     {
       "name": "L2",
-      "amplitude": 0.10242310184142735,
-      "phase": 323.1064278237399
+      "amplitude": 0.102,
+      "phase": 323.11
     },
     {
       "name": "R2",
-      "amplitude": 0.0037754971059027792,
-      "phase": 355.0232085676374
+      "amplitude": 0.004,
+      "phase": 355.02
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0058406678637043415,
-      "phase": 117.63258256251066
+      "amplitude": 0.006,
+      "phase": 117.63
     },
     {
       "name": "MSF",
-      "amplitude": 0.0039546382409648825,
-      "phase": 18.390016181783096
+      "amplitude": 0.004,
+      "phase": 18.39
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008416994223358345,
-      "phase": 64.00492129479034
+      "amplitude": 0.008,
+      "phase": 64
     },
     {
       "name": "EP2",
-      "amplitude": 0.029552156745375778,
-      "phase": 11.123914025886847
+      "amplitude": 0.03,
+      "phase": 11.12
     },
     {
       "name": "M3",
-      "amplitude": 0.004139347108939776,
-      "phase": 314.1216670912386
+      "amplitude": 0.004,
+      "phase": 314.12
     },
     {
       "name": "MU2",
-      "amplitude": 0.12675964620672664,
-      "phase": 33.47178328427759
+      "amplitude": 0.127,
+      "phase": 33.47
     },
     {
       "name": "MTM",
-      "amplitude": 0.005533105408576757,
-      "phase": 255.1929708511732
+      "amplitude": 0.006,
+      "phase": 255.19
     },
     {
       "name": "NU2",
-      "amplitude": 0.07388180124534238,
-      "phase": 266.4316875054003
+      "amplitude": 0.074,
+      "phase": 266.43
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04869838912970383,
-      "phase": 317.48838566969783
+      "amplitude": 0.049,
+      "phase": 317.49
     },
     {
       "name": "MN4",
-      "amplitude": 0.01134824381550834,
-      "phase": 111.08148711079474
+      "amplitude": 0.011,
+      "phase": 111.08
     },
     {
       "name": "MS4",
-      "amplitude": 0.029310846598329218,
-      "phase": 174.2277174745857
+      "amplitude": 0.029,
+      "phase": 174.23
     },
     {
       "name": "N4",
-      "amplitude": 0.002948348876200081,
-      "phase": 93.05477318263229
+      "amplitude": 0.003,
+      "phase": 93.05
     },
     {
       "name": "M6",
-      "amplitude": 0.040385564938550535,
-      "phase": 270.1158040320668
+      "amplitude": 0.04,
+      "phase": 270.12
     },
     {
       "name": "M8",
-      "amplitude": 0.012472381541616789,
-      "phase": 120.06470504647149
+      "amplitude": 0.012,
+      "phase": 120.06
     },
     {
       "name": "S4",
-      "amplitude": 0.005430535237141608,
-      "phase": 287.5916510336379
+      "amplitude": 0.005,
+      "phase": 287.59
     },
     {
       "name": "OO1",
-      "amplitude": 0.002477471778381483,
-      "phase": 192.70740239431913
+      "amplitude": 0.002,
+      "phase": 192.71
     },
     {
       "name": "S3",
-      "amplitude": 0.0005977078830510698,
-      "phase": 119.32734995861551
+      "amplitude": 0.001,
+      "phase": 119.33
     },
     {
       "name": "MA2",
-      "amplitude": 0.04005207248578322,
-      "phase": 253.08758948111597
+      "amplitude": 0.04,
+      "phase": 253.09
     },
     {
       "name": "MB2",
-      "amplitude": 0.025760061867655316,
-      "phase": 29.273895518912923
+      "amplitude": 0.026,
+      "phase": 29.27
     },
     {
       "name": "T3",
-      "amplitude": 0.0002787967893697694,
-      "phase": 335.6270322821312
+      "amplitude": 0,
+      "phase": 335.63
     },
     {
       "name": "R3",
-      "amplitude": 0.0022879305293544627,
-      "phase": 357.0210432555204
+      "amplitude": 0.002,
+      "phase": 357.02
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005846661774681202,
-      "phase": 180.3894647969187
+      "amplitude": 0.006,
+      "phase": 180.39
     },
     {
       "name": "SGM",
-      "amplitude": 0.002171514585686526,
-      "phase": 48.89752511527354
+      "amplitude": 0.002,
+      "phase": 48.9
     },
     {
       "name": "3L2",
-      "amplitude": 0.0036885167664722773,
-      "phase": 222.58468459514594
+      "amplitude": 0.004,
+      "phase": 222.58
     },
     {
       "name": "3N2",
-      "amplitude": 0.016996678633523107,
-      "phase": 105.34622896556573
+      "amplitude": 0.017,
+      "phase": 105.35
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03300503109825568,
-      "phase": 234.57376571186686
+      "amplitude": 0.033,
+      "phase": 234.57
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04215446401782405,
-      "phase": 331.6700671027505
+      "amplitude": 0.042,
+      "phase": 331.67
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0033780475166937723,
-      "phase": 260.62637472769273
+      "amplitude": 0.003,
+      "phase": 260.63
     },
     {
       "name": "2MO5",
-      "amplitude": 0.000901168086938881,
-      "phase": 59.971717551691654
+      "amplitude": 0.001,
+      "phase": 59.97
     }
   ],
   "epoch": {

--- a/data/ticon/warnemnde-9640015-deu-wsv.json
+++ b/data/ticon/warnemnde-9640015-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.04976299880404345,
-      "phase": 179.52804271065293
+      "amplitude": 0.05,
+      "phase": 179.53
     },
     {
       "name": "N2",
-      "amplitude": 0.01077240812890004,
-      "phase": 119.05813558511932
+      "amplitude": 0.011,
+      "phase": 119.06
     },
     {
       "name": "S2",
-      "amplitude": 0.009111313009689459,
-      "phase": 169.51056827565753
+      "amplitude": 0.009,
+      "phase": 169.51
     },
     {
       "name": "K2",
-      "amplitude": 0.002337360358461159,
-      "phase": 153.60569072928615
+      "amplitude": 0.002,
+      "phase": 153.61
     },
     {
       "name": "2N2",
-      "amplitude": 0.0010646247528501632,
-      "phase": 80.27379381686069
+      "amplitude": 0.001,
+      "phase": 80.27
     },
     {
       "name": "S1",
-      "amplitude": 0.0018636073339826347,
-      "phase": 160.45589705429006
+      "amplitude": 0.002,
+      "phase": 160.46
     },
     {
       "name": "K1",
-      "amplitude": 0.013460992873818143,
-      "phase": 201.2750604595642
+      "amplitude": 0.013,
+      "phase": 201.28
     },
     {
       "name": "P1",
-      "amplitude": 0.003857919170142244,
-      "phase": 243.60059482564367
+      "amplitude": 0.004,
+      "phase": 243.6
     },
     {
       "name": "O1",
-      "amplitude": 0.01687779192361137,
-      "phase": 127.66426933133391
+      "amplitude": 0.017,
+      "phase": 127.66
     },
     {
       "name": "Q1",
-      "amplitude": 0.0025878994351444824,
-      "phase": 346.7273518417846
+      "amplitude": 0.003,
+      "phase": 346.73
     },
     {
       "name": "M1",
-      "amplitude": 0.0004523623914047733,
-      "phase": 25.945940413679352
+      "amplitude": 0,
+      "phase": 25.95
     },
     {
       "name": "M4",
-      "amplitude": 0.0006244331485878039,
-      "phase": 35.01365632938007
+      "amplitude": 0.001,
+      "phase": 35.01
     },
     {
       "name": "MM",
-      "amplitude": 0.010012977683619185,
-      "phase": 280.6434691580387
+      "amplitude": 0.01,
+      "phase": 280.64
     },
     {
       "name": "MF",
-      "amplitude": 0.008747193543565323,
-      "phase": 254.88665216739327
+      "amplitude": 0.009,
+      "phase": 254.89
     },
     {
       "name": "SA",
-      "amplitude": 0.036196335276147254,
-      "phase": 174.80819264942852
+      "amplitude": 0.036,
+      "phase": 174.81
     },
     {
       "name": "SSA",
-      "amplitude": 0.0273697109379184,
-      "phase": 250.8590917143107
+      "amplitude": 0.027,
+      "phase": 250.86
     },
     {
       "name": "T2",
-      "amplitude": 0.0009525682956156788,
-      "phase": 136.1605137185519
+      "amplitude": 0.001,
+      "phase": 136.16
     },
     {
       "name": "J1",
-      "amplitude": 0.0009275130256224533,
-      "phase": 181.59997474982657
+      "amplitude": 0.001,
+      "phase": 181.6
     },
     {
       "name": "L2",
-      "amplitude": 0.004413682831821865,
-      "phase": 269.6639582719312
+      "amplitude": 0.004,
+      "phase": 269.66
     },
     {
       "name": "R2",
-      "amplitude": 0.0011123135948552273,
-      "phase": 226.08523894909897
+      "amplitude": 0.001,
+      "phase": 226.09
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0005349515404950777,
-      "phase": 281.9602936624019
+      "amplitude": 0.001,
+      "phase": 281.96
     },
     {
       "name": "MSF",
-      "amplitude": 0.0023243076876670226,
-      "phase": 246.31229675403716
+      "amplitude": 0.002,
+      "phase": 246.31
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0033532432650990023,
-      "phase": 198.43932670336747
+      "amplitude": 0.003,
+      "phase": 198.44
     },
     {
       "name": "EP2",
-      "amplitude": 0.002358797834067111,
-      "phase": 277.0725470741323
+      "amplitude": 0.002,
+      "phase": 277.07
     },
     {
       "name": "M3",
-      "amplitude": 0.00017655253620165476,
-      "phase": 40.80740594691218
+      "amplitude": 0,
+      "phase": 40.81
     },
     {
       "name": "MU2",
-      "amplitude": 0.008841813714627734,
-      "phase": 321.8378238872195
+      "amplitude": 0.009,
+      "phase": 321.84
     },
     {
       "name": "MTM",
-      "amplitude": 0.002950347751147574,
-      "phase": 335.98535443255497
+      "amplitude": 0.003,
+      "phase": 335.99
     },
     {
       "name": "NU2",
-      "amplitude": 0.0034761805558706444,
-      "phase": 162.04767248530152
+      "amplitude": 0.003,
+      "phase": 162.05
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.002301685862502997,
-      "phase": 265.974008865644
+      "amplitude": 0.002,
+      "phase": 265.97
     },
     {
       "name": "MN4",
-      "amplitude": 0.00016841246443477777,
-      "phase": 335.8259964999143
+      "amplitude": 0,
+      "phase": 335.83
     },
     {
       "name": "MS4",
-      "amplitude": 0.00013408959473108694,
-      "phase": 197.40849721081278
+      "amplitude": 0,
+      "phase": 197.41
     },
     {
       "name": "N4",
-      "amplitude": 0.00004427419511585679,
-      "phase": 69.2133898528021
+      "amplitude": 0,
+      "phase": 69.21
     },
     {
       "name": "M6",
-      "amplitude": 0.0003027051606184026,
-      "phase": 36.30297995055389
+      "amplitude": 0,
+      "phase": 36.3
     },
     {
       "name": "M8",
-      "amplitude": 0.000043395190997520805,
-      "phase": 83.2276929733988
+      "amplitude": 0,
+      "phase": 83.23
     },
     {
       "name": "S4",
-      "amplitude": 0.00012644465418999379,
-      "phase": 193.07363421736767
+      "amplitude": 0,
+      "phase": 193.07
     },
     {
       "name": "OO1",
-      "amplitude": 0.0013275902239610845,
-      "phase": 151.3914799892039
+      "amplitude": 0.001,
+      "phase": 151.39
     },
     {
       "name": "S3",
-      "amplitude": 0.00009133337622698693,
-      "phase": 88.29066060201467
+      "amplitude": 0,
+      "phase": 88.29
     },
     {
       "name": "MA2",
-      "amplitude": 0.004794508587293002,
-      "phase": 149.84970690943476
+      "amplitude": 0.005,
+      "phase": 149.85
     },
     {
       "name": "MB2",
-      "amplitude": 0.005132482658169837,
-      "phase": 311.37670005897274
+      "amplitude": 0.005,
+      "phase": 311.38
     },
     {
       "name": "T3",
-      "amplitude": 0.00037496326139454926,
-      "phase": 307.67866128108113
+      "amplitude": 0,
+      "phase": 307.68
     },
     {
       "name": "R3",
-      "amplitude": 0.0003398437533254423,
-      "phase": 64.78187208749148
+      "amplitude": 0,
+      "phase": 64.78
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0003371144823916492,
-      "phase": 288.11104876051786
+      "amplitude": 0,
+      "phase": 288.11
     },
     {
       "name": "SGM",
-      "amplitude": 0.002254075305389223,
-      "phase": 232.67472263724176
+      "amplitude": 0.002,
+      "phase": 232.67
     },
     {
       "name": "3L2",
-      "amplitude": 0.0005265960542892828,
-      "phase": 72.40567550024633
+      "amplitude": 0.001,
+      "phase": 72.41
     },
     {
       "name": "3N2",
-      "amplitude": 0.0009457959106652296,
-      "phase": 70.6538144807671
+      "amplitude": 0.001,
+      "phase": 70.65
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0015290089512144558,
-      "phase": 277.0224391193546
+      "amplitude": 0.002,
+      "phase": 277.02
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00024926497160265116,
-      "phase": 142.82328770636786
+      "amplitude": 0,
+      "phase": 142.82
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0001886565053101939,
-      "phase": 312.40189634873633
+      "amplitude": 0,
+      "phase": 312.4
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0000894341560684539,
-      "phase": 284.7019738210658
+      "amplitude": 0,
+      "phase": 284.7
     }
   ],
   "epoch": {

--- a/data/ticon/wasserhorst-4930010-deu-wsv.json
+++ b/data/ticon/wasserhorst-4930010-deu-wsv.json
@@ -1,6 +1,6 @@
 {
   "name": "Wasserhorst",
-  "region": "City state Bremen",
+  "region": "Bremen",
   "country": "Germany",
   "continent": "Europe",
   "latitude": 53.164336,
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.309172234309261,
-      "phase": 52.65250712562272
+      "amplitude": 1.309,
+      "phase": 52.65
     },
     {
       "name": "N2",
-      "amplitude": 0.1911027226323266,
-      "phase": 29.906030056674695
+      "amplitude": 0.191,
+      "phase": 29.91
     },
     {
       "name": "S2",
-      "amplitude": 0.30440395885646143,
-      "phase": 135.31452833753713
+      "amplitude": 0.304,
+      "phase": 135.31
     },
     {
       "name": "K2",
-      "amplitude": 0.09265322858590802,
-      "phase": 136.20612286198173
+      "amplitude": 0.093,
+      "phase": 136.21
     },
     {
       "name": "2N2",
-      "amplitude": 0.01835529419205304,
-      "phase": 13.2444723141856
+      "amplitude": 0.018,
+      "phase": 13.24
     },
     {
       "name": "S1",
-      "amplitude": 0.01753345520839067,
-      "phase": 70.47757843181648
+      "amplitude": 0.018,
+      "phase": 70.48
     },
     {
       "name": "K1",
-      "amplitude": 0.04750377457282938,
-      "phase": 80.87313669755213
+      "amplitude": 0.048,
+      "phase": 80.87
     },
     {
       "name": "P1",
-      "amplitude": 0.01927539098833443,
-      "phase": 107.49420794812522
+      "amplitude": 0.019,
+      "phase": 107.49
     },
     {
       "name": "O1",
-      "amplitude": 0.0609020157132752,
-      "phase": 291.19411760494125
+      "amplitude": 0.061,
+      "phase": 291.19
     },
     {
       "name": "Q1",
-      "amplitude": 0.014818667301466209,
-      "phase": 225.96981834976216
+      "amplitude": 0.015,
+      "phase": 225.97
     },
     {
       "name": "M1",
-      "amplitude": 0.00172852014207215,
-      "phase": 166.03297260653028
+      "amplitude": 0.002,
+      "phase": 166.03
     },
     {
       "name": "M4",
-      "amplitude": 0.17043050767200218,
-      "phase": 34.330627722604845
+      "amplitude": 0.17,
+      "phase": 34.33
     },
     {
       "name": "MM",
-      "amplitude": 0.007174292279637404,
-      "phase": 87.58568775884345
+      "amplitude": 0.007,
+      "phase": 87.59
     },
     {
       "name": "MF",
-      "amplitude": 0.017584851563026468,
-      "phase": 107.10120495592975
+      "amplitude": 0.018,
+      "phase": 107.1
     },
     {
       "name": "SA",
-      "amplitude": 0.07034280919704479,
-      "phase": 299.75160904047755
+      "amplitude": 0.07,
+      "phase": 299.75
     },
     {
       "name": "SSA",
-      "amplitude": 0.045380574618265015,
-      "phase": 236.0379919912519
+      "amplitude": 0.045,
+      "phase": 236.04
     },
     {
       "name": "T2",
-      "amplitude": 0.010070871722152357,
-      "phase": 82.26442249003412
+      "amplitude": 0.01,
+      "phase": 82.26
     },
     {
       "name": "J1",
-      "amplitude": 0.00157245354488924,
-      "phase": 254.53564047519092
+      "amplitude": 0.002,
+      "phase": 254.54
     },
     {
       "name": "L2",
-      "amplitude": 0.12881081529795388,
-      "phase": 68.08675777606078
+      "amplitude": 0.129,
+      "phase": 68.09
     },
     {
       "name": "R2",
-      "amplitude": 0.01097024186062984,
-      "phase": 207.72788607756425
+      "amplitude": 0.011,
+      "phase": 207.73
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0025548527758351013,
-      "phase": 156.18695994195014
+      "amplitude": 0.003,
+      "phase": 156.19
     },
     {
       "name": "MSF",
-      "amplitude": 0.059295051653391724,
-      "phase": 66.87180070597549
+      "amplitude": 0.059,
+      "phase": 66.87
     },
     {
       "name": "MSQM",
-      "amplitude": 0.006732890836459988,
-      "phase": 353.50699828641837
+      "amplitude": 0.007,
+      "phase": 353.51
     },
     {
       "name": "EP2",
-      "amplitude": 0.042053238963968204,
-      "phase": 113.0639660988848
+      "amplitude": 0.042,
+      "phase": 113.06
     },
     {
       "name": "M3",
-      "amplitude": 0.0035564290443260683,
-      "phase": 147.10316087072846
+      "amplitude": 0.004,
+      "phase": 147.1
     },
     {
       "name": "MU2",
-      "amplitude": 0.20422203529320265,
-      "phase": 136.2199410148654
+      "amplitude": 0.204,
+      "phase": 136.22
     },
     {
       "name": "MTM",
-      "amplitude": 0.0021202490274268744,
-      "phase": 186.0150290690228
+      "amplitude": 0.002,
+      "phase": 186.02
     },
     {
       "name": "NU2",
-      "amplitude": 0.09029144212290159,
-      "phase": 3.745888252528516
+      "amplitude": 0.09,
+      "phase": 3.75
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06168690688819775,
-      "phase": 70.66820519508781
+      "amplitude": 0.062,
+      "phase": 70.67
     },
     {
       "name": "MN4",
-      "amplitude": 0.052944240967780665,
-      "phase": 8.378557435356754
+      "amplitude": 0.053,
+      "phase": 8.38
     },
     {
       "name": "MS4",
-      "amplitude": 0.09307445002341168,
-      "phase": 111.08386187953829
+      "amplitude": 0.093,
+      "phase": 111.08
     },
     {
       "name": "N4",
-      "amplitude": 0.010121657711665715,
-      "phase": 352.05435946050534
+      "amplitude": 0.01,
+      "phase": 352.05
     },
     {
       "name": "M6",
-      "amplitude": 0.020060385764619094,
-      "phase": 248.2875950580792
+      "amplitude": 0.02,
+      "phase": 248.29
     },
     {
       "name": "M8",
-      "amplitude": 0.011341803215189279,
-      "phase": 193.69312914796964
+      "amplitude": 0.011,
+      "phase": 193.69
     },
     {
       "name": "S4",
-      "amplitude": 0.00819206707074688,
-      "phase": 274.59771084203936
+      "amplitude": 0.008,
+      "phase": 274.6
     },
     {
       "name": "OO1",
-      "amplitude": 0.0021743378104722116,
-      "phase": 290.4452490131313
+      "amplitude": 0.002,
+      "phase": 290.45
     },
     {
       "name": "S3",
-      "amplitude": 0.0012551636127067945,
-      "phase": 66.41659404222275
+      "amplitude": 0.001,
+      "phase": 66.42
     },
     {
       "name": "MA2",
-      "amplitude": 0.07878286316361656,
-      "phase": 353.9920560631136
+      "amplitude": 0.079,
+      "phase": 353.99
     },
     {
       "name": "MB2",
-      "amplitude": 0.05010365601637796,
-      "phase": 219.01877051452138
+      "amplitude": 0.05,
+      "phase": 219.02
     },
     {
       "name": "T3",
-      "amplitude": 0.0010888203749693382,
-      "phase": 158.89682126652633
+      "amplitude": 0.001,
+      "phase": 158.9
     },
     {
       "name": "R3",
-      "amplitude": 0.007848081812933004,
-      "phase": 99.94335894384767
+      "amplitude": 0.008,
+      "phase": 99.94
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005215058128550009,
-      "phase": 241.67602659568047
+      "amplitude": 0.005,
+      "phase": 241.68
     },
     {
       "name": "SGM",
-      "amplitude": 0.00947118627730072,
-      "phase": 62.6299289136893
+      "amplitude": 0.009,
+      "phase": 62.63
     },
     {
       "name": "3L2",
-      "amplitude": 0.0036693590481461447,
-      "phase": 314.7221241195514
+      "amplitude": 0.004,
+      "phase": 314.72
     },
     {
       "name": "3N2",
-      "amplitude": 0.02465306781527939,
-      "phase": 189.3992447786728
+      "amplitude": 0.025,
+      "phase": 189.4
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03828456300114313,
-      "phase": 357.2410878114555
+      "amplitude": 0.038,
+      "phase": 357.24
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02269744270846419,
-      "phase": 334.0172376393286
+      "amplitude": 0.023,
+      "phase": 334.02
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0034562871849228936,
-      "phase": 33.93279501723043
+      "amplitude": 0.003,
+      "phase": 33.93
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005683949155898126,
-      "phase": 235.01326045448673
+      "amplitude": 0.006,
+      "phase": 235.01
     }
   ],
   "epoch": {

--- a/data/ticon/weener-3790020-deu-wsv.json
+++ b/data/ticon/weener-3790020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.5376519338112906,
-      "phase": 344.9424984818181
+      "amplitude": 1.538,
+      "phase": 344.94
     },
     {
       "name": "N2",
-      "amplitude": 0.23573263210387757,
-      "phase": 323.09310839544304
+      "amplitude": 0.236,
+      "phase": 323.09
     },
     {
       "name": "S2",
-      "amplitude": 0.37468891370454827,
-      "phase": 64.38507030808034
+      "amplitude": 0.375,
+      "phase": 64.39
     },
     {
       "name": "K2",
-      "amplitude": 0.1099764026072703,
-      "phase": 63.71460955600327
+      "amplitude": 0.11,
+      "phase": 63.71
     },
     {
       "name": "2N2",
-      "amplitude": 0.022739839778553143,
-      "phase": 308.67091363224677
+      "amplitude": 0.023,
+      "phase": 308.67
     },
     {
       "name": "S1",
-      "amplitude": 0.019566023428422168,
-      "phase": 78.30389033722645
+      "amplitude": 0.02,
+      "phase": 78.3
     },
     {
       "name": "K1",
-      "amplitude": 0.07556904239377521,
-      "phase": 53.92246601669979
+      "amplitude": 0.076,
+      "phase": 53.92
     },
     {
       "name": "P1",
-      "amplitude": 0.03449352008505383,
-      "phase": 50.66648509843128
+      "amplitude": 0.034,
+      "phase": 50.67
     },
     {
       "name": "O1",
-      "amplitude": 0.08875686186743303,
-      "phase": 258.3443042324599
+      "amplitude": 0.089,
+      "phase": 258.34
     },
     {
       "name": "Q1",
-      "amplitude": 0.024994572276331586,
-      "phase": 194.82100619793198
+      "amplitude": 0.025,
+      "phase": 194.82
     },
     {
       "name": "M1",
-      "amplitude": 0.002520566697150533,
-      "phase": 116.69364735691465
+      "amplitude": 0.003,
+      "phase": 116.69
     },
     {
       "name": "M4",
-      "amplitude": 0.19506428612822257,
-      "phase": 213.05019109115932
+      "amplitude": 0.195,
+      "phase": 213.05
     },
     {
       "name": "MM",
-      "amplitude": 0.014915377939367338,
-      "phase": 85.71292879971634
+      "amplitude": 0.015,
+      "phase": 85.71
     },
     {
       "name": "MF",
-      "amplitude": 0.00799746376353893,
-      "phase": 59.608150563697734
+      "amplitude": 0.008,
+      "phase": 59.61
     },
     {
       "name": "SA",
-      "amplitude": 0.08327953604513713,
-      "phase": 254.99243655472065
+      "amplitude": 0.083,
+      "phase": 254.99
     },
     {
       "name": "SSA",
-      "amplitude": 0.04471973280605827,
-      "phase": 244.2153022925279
+      "amplitude": 0.045,
+      "phase": 244.22
     },
     {
       "name": "T2",
-      "amplitude": 0.02044449204417837,
-      "phase": 3.8851229860129024
+      "amplitude": 0.02,
+      "phase": 3.89
     },
     {
       "name": "J1",
-      "amplitude": 0.004978001467193403,
-      "phase": 172.9668221255307
+      "amplitude": 0.005,
+      "phase": 172.97
     },
     {
       "name": "L2",
-      "amplitude": 0.1443064138224748,
-      "phase": 356.1001646309153
+      "amplitude": 0.144,
+      "phase": 356.1
     },
     {
       "name": "R2",
-      "amplitude": 0.014897512876329141,
-      "phase": 200.87222959383874
+      "amplitude": 0.015,
+      "phase": 200.87
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004087360900812922,
-      "phase": 139.1152627200504
+      "amplitude": 0.004,
+      "phase": 139.12
     },
     {
       "name": "MSF",
-      "amplitude": 0.04938900987241001,
-      "phase": 44.07236652960927
+      "amplitude": 0.049,
+      "phase": 44.07
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0065644774624958385,
-      "phase": 48.19067981434358
+      "amplitude": 0.007,
+      "phase": 48.19
     },
     {
       "name": "EP2",
-      "amplitude": 0.04328984478592272,
-      "phase": 50.86025656432105
+      "amplitude": 0.043,
+      "phase": 50.86
     },
     {
       "name": "M3",
-      "amplitude": 0.00441340545548503,
-      "phase": 43.36974931527925
+      "amplitude": 0.004,
+      "phase": 43.37
     },
     {
       "name": "MU2",
-      "amplitude": 0.2077834093032075,
-      "phase": 66.37266893220351
+      "amplitude": 0.208,
+      "phase": 66.37
     },
     {
       "name": "MTM",
-      "amplitude": 0.005536767577034747,
-      "phase": 9.063956139211484
+      "amplitude": 0.006,
+      "phase": 9.06
     },
     {
       "name": "NU2",
-      "amplitude": 0.10142147709159105,
-      "phase": 295.19533140537754
+      "amplitude": 0.101,
+      "phase": 295.2
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06787076935249682,
-      "phase": 357.5253330746193
+      "amplitude": 0.068,
+      "phase": 357.53
     },
     {
       "name": "MN4",
-      "amplitude": 0.06193844624657534,
-      "phase": 189.2275543713358
+      "amplitude": 0.062,
+      "phase": 189.23
     },
     {
       "name": "MS4",
-      "amplitude": 0.11696308162446639,
-      "phase": 296.6642320485025
+      "amplitude": 0.117,
+      "phase": 296.66
     },
     {
       "name": "N4",
-      "amplitude": 0.01235543166926056,
-      "phase": 170.32597093015875
+      "amplitude": 0.012,
+      "phase": 170.33
     },
     {
       "name": "M6",
-      "amplitude": 0.09202080940667887,
-      "phase": 61.153723078704274
+      "amplitude": 0.092,
+      "phase": 61.15
     },
     {
       "name": "M8",
-      "amplitude": 0.030826893194542973,
-      "phase": 281.1145987784745
+      "amplitude": 0.031,
+      "phase": 281.11
     },
     {
       "name": "S4",
-      "amplitude": 0.013446420744501222,
-      "phase": 96.51318935912593
+      "amplitude": 0.013,
+      "phase": 96.51
     },
     {
       "name": "OO1",
-      "amplitude": 0.0032528332462763905,
-      "phase": 199.17024865268704
+      "amplitude": 0.003,
+      "phase": 199.17
     },
     {
       "name": "S3",
-      "amplitude": 0.001574808136289493,
-      "phase": 310.2255313967852
+      "amplitude": 0.002,
+      "phase": 310.23
     },
     {
       "name": "MA2",
-      "amplitude": 0.08996650177415297,
-      "phase": 294.1001211847993
+      "amplitude": 0.09,
+      "phase": 294.1
     },
     {
       "name": "MB2",
-      "amplitude": 0.04956317697840589,
-      "phase": 177.44383455302386
+      "amplitude": 0.05,
+      "phase": 177.44
     },
     {
       "name": "T3",
-      "amplitude": 0.000988364185276343,
-      "phase": 24.048043641057575
+      "amplitude": 0.001,
+      "phase": 24.05
     },
     {
       "name": "R3",
-      "amplitude": 0.006410019199934714,
-      "phase": 34.353897048478586
+      "amplitude": 0.006,
+      "phase": 34.35
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005811318494694472,
-      "phase": 223.58707787777382
+      "amplitude": 0.006,
+      "phase": 223.59
     },
     {
       "name": "SGM",
-      "amplitude": 0.006461073233477612,
-      "phase": 40.64402085982118
+      "amplitude": 0.006,
+      "phase": 40.64
     },
     {
       "name": "3L2",
-      "amplitude": 0.00105834374584535,
-      "phase": 234.56083072184623
+      "amplitude": 0.001,
+      "phase": 234.56
     },
     {
       "name": "3N2",
-      "amplitude": 0.029915863778265932,
-      "phase": 132.01074211184778
+      "amplitude": 0.03,
+      "phase": 132.01
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04131142779079732,
-      "phase": 283.4760341373443
+      "amplitude": 0.041,
+      "phase": 283.48
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0849081735204649,
-      "phase": 134.43938584581343
+      "amplitude": 0.085,
+      "phase": 134.44
     },
     {
       "name": "2MK5",
-      "amplitude": 0.012728564294133335,
-      "phase": 93.96604414154376
+      "amplitude": 0.013,
+      "phase": 93.97
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0089732615081288,
-      "phase": 300.94564166301643
+      "amplitude": 0.009,
+      "phase": 300.95
     }
   ],
   "epoch": {

--- a/data/ticon/wehrgeesthachtup-5930062-deu-wsv.json
+++ b/data/ticon/wehrgeesthachtup-5930062-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.010221964222177,
-      "phase": 127.45778266270077
+      "amplitude": 1.01,
+      "phase": 127.46
     },
     {
       "name": "N2",
-      "amplitude": 0.14646662270099917,
-      "phase": 100.87547189079339
+      "amplitude": 0.146,
+      "phase": 100.88
     },
     {
       "name": "S2",
-      "amplitude": 0.23306124867128894,
-      "phase": 207.04253740867327
+      "amplitude": 0.233,
+      "phase": 207.04
     },
     {
       "name": "K2",
-      "amplitude": 0.06350121494105225,
-      "phase": 210.52594709053085
+      "amplitude": 0.064,
+      "phase": 210.53
     },
     {
       "name": "2N2",
-      "amplitude": 0.01435421650063355,
-      "phase": 76.1880591363041
+      "amplitude": 0.014,
+      "phase": 76.19
     },
     {
       "name": "S1",
-      "amplitude": 0.019570667039155696,
-      "phase": 102.30467006642465
+      "amplitude": 0.02,
+      "phase": 102.3
     },
     {
       "name": "K1",
-      "amplitude": 0.059676131292423794,
-      "phase": 132.17607659179907
+      "amplitude": 0.06,
+      "phase": 132.18
     },
     {
       "name": "P1",
-      "amplitude": 0.021298014386990763,
-      "phase": 116.85479040433631
+      "amplitude": 0.021,
+      "phase": 116.85
     },
     {
       "name": "O1",
-      "amplitude": 0.06962935986857255,
-      "phase": 331.7834910507197
+      "amplitude": 0.07,
+      "phase": 331.78
     },
     {
       "name": "Q1",
-      "amplitude": 0.018135744793002454,
-      "phase": 268.9110677777194
+      "amplitude": 0.018,
+      "phase": 268.91
     },
     {
       "name": "M1",
-      "amplitude": 0.0018156560088639015,
-      "phase": 172.1495627215329
+      "amplitude": 0.002,
+      "phase": 172.15
     },
     {
       "name": "M4",
-      "amplitude": 0.19535604656674838,
-      "phase": 187.2507175621253
+      "amplitude": 0.195,
+      "phase": 187.25
     },
     {
       "name": "MM",
-      "amplitude": 0.019711769782225677,
-      "phase": 70.89261864230429
+      "amplitude": 0.02,
+      "phase": 70.89
     },
     {
       "name": "MF",
-      "amplitude": 0.01973396146816071,
-      "phase": 81.94745595287259
+      "amplitude": 0.02,
+      "phase": 81.95
     },
     {
       "name": "SA",
-      "amplitude": 0.4668122390544609,
-      "phase": 327.509285381753
+      "amplitude": 0.467,
+      "phase": 327.51
     },
     {
       "name": "SSA",
-      "amplitude": 0.14170464783173173,
-      "phase": 308.6196946047512
+      "amplitude": 0.142,
+      "phase": 308.62
     },
     {
       "name": "T2",
-      "amplitude": 0.012827928711046464,
-      "phase": 310.6494684031862
+      "amplitude": 0.013,
+      "phase": 310.65
     },
     {
       "name": "J1",
-      "amplitude": 0.006572624055077703,
-      "phase": 251.78757218909303
+      "amplitude": 0.007,
+      "phase": 251.79
     },
     {
       "name": "L2",
-      "amplitude": 0.09694655229472901,
-      "phase": 144.071982282916
+      "amplitude": 0.097,
+      "phase": 144.07
     },
     {
       "name": "R2",
-      "amplitude": 0.03206574322754598,
-      "phase": 275.4761129319191
+      "amplitude": 0.032,
+      "phase": 275.48
     },
     {
       "name": "2Q1",
-      "amplitude": 0.004492050096679304,
-      "phase": 201.00146304138994
+      "amplitude": 0.004,
+      "phase": 201
     },
     {
       "name": "MSF",
-      "amplitude": 0.0833494412804548,
-      "phase": 65.89603273716472
+      "amplitude": 0.083,
+      "phase": 65.9
     },
     {
       "name": "MSQM",
-      "amplitude": 0.006402451366766266,
-      "phase": 31.806642879271692
+      "amplitude": 0.006,
+      "phase": 31.81
     },
     {
       "name": "EP2",
-      "amplitude": 0.02514639481355084,
-      "phase": 182.7822800732171
+      "amplitude": 0.025,
+      "phase": 182.78
     },
     {
       "name": "M3",
-      "amplitude": 0.0038425728492172636,
-      "phase": 214.86620352425922
+      "amplitude": 0.004,
+      "phase": 214.87
     },
     {
       "name": "MU2",
-      "amplitude": 0.13552438430849573,
-      "phase": 212.81127639997965
+      "amplitude": 0.136,
+      "phase": 212.81
     },
     {
       "name": "MTM",
-      "amplitude": 0.0007227764028530454,
-      "phase": 291.1695115400262
+      "amplitude": 0.001,
+      "phase": 291.17
     },
     {
       "name": "NU2",
-      "amplitude": 0.06861924378858435,
-      "phase": 81.09583785715324
+      "amplitude": 0.069,
+      "phase": 81.1
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04336401476313056,
-      "phase": 148.42661240758224
+      "amplitude": 0.043,
+      "phase": 148.43
     },
     {
       "name": "MN4",
-      "amplitude": 0.06251182319905205,
-      "phase": 160.47420475993363
+      "amplitude": 0.063,
+      "phase": 160.47
     },
     {
       "name": "MS4",
-      "amplitude": 0.10127338669795537,
-      "phase": 264.6288863724567
+      "amplitude": 0.101,
+      "phase": 264.63
     },
     {
       "name": "N4",
-      "amplitude": 0.01170317754844018,
-      "phase": 139.3438562693268
+      "amplitude": 0.012,
+      "phase": 139.34
     },
     {
       "name": "M6",
-      "amplitude": 0.021836552940669055,
-      "phase": 172.43938063761505
+      "amplitude": 0.022,
+      "phase": 172.44
     },
     {
       "name": "M8",
-      "amplitude": 0.017836764734159027,
-      "phase": 161.2762440332492
+      "amplitude": 0.018,
+      "phase": 161.28
     },
     {
       "name": "S4",
-      "amplitude": 0.0070647680152248074,
-      "phase": 50.88633185489124
+      "amplitude": 0.007,
+      "phase": 50.89
     },
     {
       "name": "OO1",
-      "amplitude": 0.0023602675636473316,
-      "phase": 262.49544429313084
+      "amplitude": 0.002,
+      "phase": 262.5
     },
     {
       "name": "S3",
-      "amplitude": 0.0010660783241052622,
-      "phase": 121.61263629196509
+      "amplitude": 0.001,
+      "phase": 121.61
     },
     {
       "name": "MA2",
-      "amplitude": 0.10136652410596517,
-      "phase": 347.85589523147075
+      "amplitude": 0.101,
+      "phase": 347.86
     },
     {
       "name": "MB2",
-      "amplitude": 0.1170004309308487,
-      "phase": 278.8392734176523
+      "amplitude": 0.117,
+      "phase": 278.84
     },
     {
       "name": "T3",
-      "amplitude": 0.0017230265414824165,
-      "phase": 235.97537766389485
+      "amplitude": 0.002,
+      "phase": 235.98
     },
     {
       "name": "R3",
-      "amplitude": 0.005447184238149844,
-      "phase": 259.3391941844128
+      "amplitude": 0.005,
+      "phase": 259.34
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0038198914812604084,
-      "phase": 276.3476555534545
+      "amplitude": 0.004,
+      "phase": 276.35
     },
     {
       "name": "SGM",
-      "amplitude": 0.0049811509210170475,
-      "phase": 109.67506666876204
+      "amplitude": 0.005,
+      "phase": 109.68
     },
     {
       "name": "3L2",
-      "amplitude": 0.001400293291932309,
-      "phase": 156.60869725276075
+      "amplitude": 0.001,
+      "phase": 156.61
     },
     {
       "name": "3N2",
-      "amplitude": 0.048898514681737656,
-      "phase": 275.85898948051545
+      "amplitude": 0.049,
+      "phase": 275.86
     },
     {
       "name": "2SM2",
-      "amplitude": 0.023728878876505217,
-      "phase": 78.73040902683596
+      "amplitude": 0.024,
+      "phase": 78.73
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02018214675274471,
-      "phase": 250.83790200923227
+      "amplitude": 0.02,
+      "phase": 250.84
     },
     {
       "name": "2MK5",
-      "amplitude": 0.002268320656612727,
-      "phase": 184.7746541003325
+      "amplitude": 0.002,
+      "phase": 184.77
     },
     {
       "name": "2MO5",
-      "amplitude": 0.004794701034703753,
-      "phase": 68.92534360502538
+      "amplitude": 0.005,
+      "phase": 68.93
     }
   ],
   "epoch": {

--- a/data/ticon/werkendam_buiten-werkdbtn-nld-rws.json
+++ b/data/ticon/werkendam_buiten-werkdbtn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.13989551,
-      "phase": 181.907422
+      "amplitude": 0.145,
+      "phase": 169.28
     },
     {
       "name": "N2",
-      "amplitude": 0.02111241,
-      "phase": 153.202315
+      "amplitude": 0.023,
+      "phase": 141.27
     },
     {
       "name": "S2",
-      "amplitude": 0.031929189999999996,
-      "phase": 240.64198199999998
+      "amplitude": 0.033,
+      "phase": 227.59
     },
     {
       "name": "K2",
-      "amplitude": 0.00965118,
-      "phase": 247.032529
+      "amplitude": 0.01,
+      "phase": 232.73
     },
     {
       "name": "2N2",
-      "amplitude": 0.00270371,
-      "phase": 161.29587700000002
+      "amplitude": 0.003,
+      "phase": 149.45
     },
     {
       "name": "S1",
-      "amplitude": 0.0038323000000000003,
-      "phase": 36.91287799999998
+      "amplitude": 0.004,
+      "phase": 14.43
     },
     {
       "name": "K1",
-      "amplitude": 0.01332004,
-      "phase": 41.06346400000001
+      "amplitude": 0.013,
+      "phase": 33.67
     },
     {
       "name": "P1",
-      "amplitude": 0.00636946,
-      "phase": 89.20480800000001
+      "amplitude": 0.006,
+      "phase": 81.94
     },
     {
       "name": "O1",
-      "amplitude": 0.0227817,
-      "phase": 249.33655199999998
+      "amplitude": 0.023,
+      "phase": 243.3
     },
     {
       "name": "Q1",
-      "amplitude": 0.007401189999999999,
-      "phase": 203.685153
+      "amplitude": 0.008,
+      "phase": 198.14
     },
     {
       "name": "M1",
-      "amplitude": 0.00183057,
-      "phase": 193.630275
+      "amplitude": 0,
+      "phase": 116.72
     },
     {
       "name": "M4",
-      "amplitude": 0.038185039999999996,
-      "phase": 291.39302399999997
+      "amplitude": 0.044,
+      "phase": 267.6
     },
     {
       "name": "MM",
-      "amplitude": 0.00442133,
-      "phase": 67.32419600000003
+      "amplitude": 0.003,
+      "phase": 73.81
     },
     {
       "name": "MF",
-      "amplitude": 0.00359855,
-      "phase": 78.346634
+      "amplitude": 0.004,
+      "phase": 75.98
     },
     {
       "name": "SA",
-      "amplitude": 0.15845537,
-      "phase": 316.399503
+      "amplitude": 0.159,
+      "phase": 318.74
     },
     {
       "name": "SSA",
-      "amplitude": 0.03865904,
-      "phase": 196.311043
+      "amplitude": 0.04,
+      "phase": 202.26
     },
     {
       "name": "T2",
-      "amplitude": 0.00575498,
-      "phase": 179.18112099999996
+      "amplitude": 0.002,
+      "phase": 225.29
     },
     {
       "name": "J1",
-      "amplitude": 0.00078652,
-      "phase": 68.05926999999997
+      "amplitude": 0.001,
+      "phase": 58.83
     },
     {
       "name": "L2",
-      "amplitude": 0.0120768,
-      "phase": 210.600158
+      "amplitude": 0.013,
+      "phase": 198.52
     },
     {
       "name": "R2",
-      "amplitude": 0.0012961300000000002,
-      "phase": 321.43558
+      "amplitude": 0.002,
+      "phase": 157.39
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00140379,
-      "phase": 198.611328
+      "amplitude": 0.001,
+      "phase": 191.27
     },
     {
       "name": "MSF",
-      "amplitude": 0.03295173,
-      "phase": 57.84006999999997
+      "amplitude": 0.033,
+      "phase": 57.92
     },
     {
       "name": "MSQM",
-      "amplitude": 0.01018601,
-      "phase": 278.604175
+      "amplitude": 0.01,
+      "phase": 277.2
     },
     {
       "name": "EP2",
-      "amplitude": 0.00317183,
-      "phase": 276.67887
+      "amplitude": 0.003,
+      "phase": 264.3
     },
     {
       "name": "M3",
-      "amplitude": 0.00043929999999999994,
-      "phase": 332.458445
+      "amplitude": 0.001,
+      "phase": 130.3
     },
     {
       "name": "MU2",
-      "amplitude": 0.01563352,
-      "phase": 295.143311
+      "amplitude": 0.016,
+      "phase": 282.67
     },
     {
       "name": "MTM",
-      "amplitude": 0.007963660000000001,
-      "phase": 226.232757
+      "amplitude": 0.008,
+      "phase": 220.15
     },
     {
       "name": "NU2",
-      "amplitude": 0.008401269999999999,
-      "phase": 147.66265799999996
+      "amplitude": 0.009,
+      "phase": 135.83
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00522558,
-      "phase": 205.517046
+      "amplitude": 0.006,
+      "phase": 187.54
     },
     {
       "name": "MN4",
-      "amplitude": 0.01191566,
-      "phase": 265.59037
+      "amplitude": 0.014,
+      "phase": 241.89
     },
     {
       "name": "MS4",
-      "amplitude": 0.02134878,
-      "phase": 353.434646
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.00367819,
-      "phase": 355.527897
+      "amplitude": 0.025,
+      "phase": 329.48
     },
     {
       "name": "N4",
-      "amplitude": 0.00282548,
-      "phase": 256.788278
+      "amplitude": 0.003,
+      "phase": 235.55
     },
     {
       "name": "M6",
-      "amplitude": 0.0060455199999999995,
-      "phase": 13.768237999999997
+      "amplitude": 0.008,
+      "phase": 339.53
     },
     {
       "name": "M8",
-      "amplitude": 0.00188347,
-      "phase": 87.92627299999998
+      "amplitude": 0.004,
+      "phase": 40.52
     },
     {
       "name": "S4",
-      "amplitude": 0.0007562399999999999,
-      "phase": 134.141797
+      "amplitude": 0.001,
+      "phase": 113.76
     },
     {
       "name": "OO1",
-      "amplitude": 0.00056284,
-      "phase": 251.713463
+      "amplitude": 0.001,
+      "phase": 251.96
     },
     {
       "name": "S3",
-      "amplitude": 0.00031855,
-      "phase": 96.74021900000002
+      "amplitude": 0,
+      "phase": 243.66
     },
     {
       "name": "MA2",
-      "amplitude": 0.019984349999999998,
-      "phase": 187.03905
+      "amplitude": 0.004,
+      "phase": 241.89
     },
     {
       "name": "MB2",
-      "amplitude": 0.016308160000000002,
-      "phase": 6.777646000000004
+      "amplitude": 0.004,
+      "phase": 221.89
     },
     {
       "name": "T3",
-      "amplitude": 0.00021163,
-      "phase": 12.635648000000003
+      "amplitude": 0,
+      "phase": 202.03
     },
     {
       "name": "R3",
-      "amplitude": 0.00038115,
-      "phase": 41.41422399999999
+      "amplitude": 0,
+      "phase": 112.09
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00202123,
-      "phase": 196.352498
+      "amplitude": 0.002,
+      "phase": 189.28
     },
     {
       "name": "SGM",
-      "amplitude": 0.0017502599999999998,
-      "phase": 179.89587499999993
+      "amplitude": 0.002,
+      "phase": 345.73
     },
     {
       "name": "3L2",
-      "amplitude": 0.0008628199999999999,
-      "phase": 340.087253
+      "amplitude": 0.001,
+      "phase": 133.26
     },
     {
       "name": "3N2",
-      "amplitude": 0.00096369,
-      "phase": 352.279779
+      "amplitude": 0.002,
+      "phase": 2.95
     },
     {
       "name": "2SM2",
-      "amplitude": 0.0037731199999999996,
-      "phase": 112.58603900000003
+      "amplitude": 0.004,
+      "phase": 99.62
     },
     {
       "name": "2MS6",
-      "amplitude": 0.00534048,
-      "phase": 72.189254
+      "amplitude": 0.007,
+      "phase": 38.99
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0017462600000000001,
-      "phase": 67.12128999999999
+      "amplitude": 0.002,
+      "phase": 117.25
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00175018,
-      "phase": 87.06070499999998
+      "amplitude": 0.002,
+      "phase": 327.66
     }
   ],
   "epoch": {

--- a/data/ticon/weserwehruw-4910040-deu-wsv.json
+++ b/data/ticon/weserwehruw-4910040-deu-wsv.json
@@ -1,6 +1,6 @@
 {
   "name": "Weserwehruw",
-  "region": "City state Bremen",
+  "region": "Bremen",
   "country": "Germany",
   "continent": "Europe",
   "latitude": 53.061745,
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.6917163267325335,
-      "phase": 41.291291808394305
+      "amplitude": 1.692,
+      "phase": 41.29
     },
     {
       "name": "N2",
-      "amplitude": 0.25640665712366423,
-      "phase": 17.169390701490386
+      "amplitude": 0.256,
+      "phase": 17.17
     },
     {
       "name": "S2",
-      "amplitude": 0.42312718368894864,
-      "phase": 122.20610735791212
+      "amplitude": 0.423,
+      "phase": 122.21
     },
     {
       "name": "K2",
-      "amplitude": 0.12388918157895643,
-      "phase": 123.03916677101756
+      "amplitude": 0.124,
+      "phase": 123.04
     },
     {
       "name": "2N2",
-      "amplitude": 0.026394557936473086,
-      "phase": 357.2980137794647
+      "amplitude": 0.026,
+      "phase": 357.3
     },
     {
       "name": "S1",
-      "amplitude": 0.014778884352103512,
-      "phase": 90.82066307050172
+      "amplitude": 0.015,
+      "phase": 90.82
     },
     {
       "name": "K1",
-      "amplitude": 0.06608405153078985,
-      "phase": 77.4190371041625
+      "amplitude": 0.066,
+      "phase": 77.42
     },
     {
       "name": "P1",
-      "amplitude": 0.027962861206557662,
-      "phase": 83.61663005784897
+      "amplitude": 0.028,
+      "phase": 83.62
     },
     {
       "name": "O1",
-      "amplitude": 0.08356308346125327,
-      "phase": 282.3886702730949
+      "amplitude": 0.084,
+      "phase": 282.39
     },
     {
       "name": "Q1",
-      "amplitude": 0.02232347012513121,
-      "phase": 220.1689256660338
+      "amplitude": 0.022,
+      "phase": 220.17
     },
     {
       "name": "M1",
-      "amplitude": 0.002339294482611827,
-      "phase": 135.21719259355007
+      "amplitude": 0.002,
+      "phase": 135.22
     },
     {
       "name": "M4",
-      "amplitude": 0.18647417769626984,
-      "phase": 354.230812292301
+      "amplitude": 0.186,
+      "phase": 354.23
     },
     {
       "name": "MM",
-      "amplitude": 0.010820567873042228,
-      "phase": 84.50021315639054
+      "amplitude": 0.011,
+      "phase": 84.5
     },
     {
       "name": "MF",
-      "amplitude": 0.012982849653742178,
-      "phase": 85.17234739597035
+      "amplitude": 0.013,
+      "phase": 85.17
     },
     {
       "name": "SA",
-      "amplitude": 0.20828887225580195,
-      "phase": 311.12591292716223
+      "amplitude": 0.208,
+      "phase": 311.13
     },
     {
       "name": "SSA",
-      "amplitude": 0.10286796947793224,
-      "phase": 257.0865946792631
+      "amplitude": 0.103,
+      "phase": 257.09
     },
     {
       "name": "T2",
-      "amplitude": 0.011907511090108291,
-      "phase": 100.1297210801149
+      "amplitude": 0.012,
+      "phase": 100.13
     },
     {
       "name": "J1",
-      "amplitude": 0.004131099700179733,
-      "phase": 199.29394341618004
+      "amplitude": 0.004,
+      "phase": 199.29
     },
     {
       "name": "L2",
-      "amplitude": 0.15389947133980633,
-      "phase": 54.462907029850214
+      "amplitude": 0.154,
+      "phase": 54.46
     },
     {
       "name": "R2",
-      "amplitude": 0.020419109645522026,
-      "phase": 191.12889961017262
+      "amplitude": 0.02,
+      "phase": 191.13
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0048355230407257435,
-      "phase": 159.6552126856019
+      "amplitude": 0.005,
+      "phase": 159.66
     },
     {
       "name": "MSF",
-      "amplitude": 0.060985540219487606,
-      "phase": 67.27819623402337
+      "amplitude": 0.061,
+      "phase": 67.28
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007644753519917828,
-      "phase": 27.53611511598001
+      "amplitude": 0.008,
+      "phase": 27.54
     },
     {
       "name": "EP2",
-      "amplitude": 0.04630082687130983,
-      "phase": 95.78250993868375
+      "amplitude": 0.046,
+      "phase": 95.78
     },
     {
       "name": "M3",
-      "amplitude": 0.004976957656490748,
-      "phase": 120.35951622364729
+      "amplitude": 0.005,
+      "phase": 120.36
     },
     {
       "name": "MU2",
-      "amplitude": 0.23337064624630596,
-      "phase": 120.87857900310541
+      "amplitude": 0.233,
+      "phase": 120.88
     },
     {
       "name": "MTM",
-      "amplitude": 0.002719719972361329,
-      "phase": 203.91017922229196
+      "amplitude": 0.003,
+      "phase": 203.91
     },
     {
       "name": "NU2",
-      "amplitude": 0.11126883344260534,
-      "phase": 352.1398831653613
+      "amplitude": 0.111,
+      "phase": 352.14
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.07264987281048743,
-      "phase": 56.14559879860485
+      "amplitude": 0.073,
+      "phase": 56.15
     },
     {
       "name": "MN4",
-      "amplitude": 0.06104858757825906,
-      "phase": 330.70230282051864
+      "amplitude": 0.061,
+      "phase": 330.7
     },
     {
       "name": "MS4",
-      "amplitude": 0.1155758681971919,
-      "phase": 71.88833322991854
+      "amplitude": 0.116,
+      "phase": 71.89
     },
     {
       "name": "N4",
-      "amplitude": 0.012587219076657719,
-      "phase": 309.83282876772665
+      "amplitude": 0.013,
+      "phase": 309.83
     },
     {
       "name": "M6",
-      "amplitude": 0.08855081732880606,
-      "phase": 190.74491469053243
+      "amplitude": 0.089,
+      "phase": 190.74
     },
     {
       "name": "M8",
-      "amplitude": 0.03719502825043062,
-      "phase": 160.75620543464106
+      "amplitude": 0.037,
+      "phase": 160.76
     },
     {
       "name": "S4",
-      "amplitude": 0.0142488781319226,
-      "phase": 215.77417837750173
+      "amplitude": 0.014,
+      "phase": 215.77
     },
     {
       "name": "OO1",
-      "amplitude": 0.0023198621881232785,
-      "phase": 227.80711574275375
+      "amplitude": 0.002,
+      "phase": 227.81
     },
     {
       "name": "S3",
-      "amplitude": 0.0016124048922575443,
-      "phase": 16.922819175862287
+      "amplitude": 0.002,
+      "phase": 16.92
     },
     {
       "name": "MA2",
-      "amplitude": 0.06926533704243888,
-      "phase": 327.36329048659854
+      "amplitude": 0.069,
+      "phase": 327.36
     },
     {
       "name": "MB2",
-      "amplitude": 0.06661087467623167,
-      "phase": 196.718615450517
+      "amplitude": 0.067,
+      "phase": 196.72
     },
     {
       "name": "T3",
-      "amplitude": 0.0022491052645055407,
-      "phase": 87.8077194505168
+      "amplitude": 0.002,
+      "phase": 87.81
     },
     {
       "name": "R3",
-      "amplitude": 0.006234716002635678,
-      "phase": 128.69292986836325
+      "amplitude": 0.006,
+      "phase": 128.69
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0048710160754695244,
-      "phase": 231.9742902687936
+      "amplitude": 0.005,
+      "phase": 231.97
     },
     {
       "name": "SGM",
-      "amplitude": 0.006457344372310502,
-      "phase": 56.4591464434659
+      "amplitude": 0.006,
+      "phase": 56.46
     },
     {
       "name": "3L2",
-      "amplitude": 0.004142086081658285,
-      "phase": 8.460328184707805
+      "amplitude": 0.004,
+      "phase": 8.46
     },
     {
       "name": "3N2",
-      "amplitude": 0.03716289633278487,
-      "phase": 170.72743277205836
+      "amplitude": 0.037,
+      "phase": 170.73
     },
     {
       "name": "2SM2",
-      "amplitude": 0.045812664421503474,
-      "phase": 343.582136001399
+      "amplitude": 0.046,
+      "phase": 343.58
     },
     {
       "name": "2MS6",
-      "amplitude": 0.08820990025058882,
-      "phase": 268.4795787800838
+      "amplitude": 0.088,
+      "phase": 268.48
     },
     {
       "name": "2MK5",
-      "amplitude": 0.009239465878177864,
-      "phase": 185.23135930974345
+      "amplitude": 0.009,
+      "phase": 185.23
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00618774796490939,
-      "phase": 3.646971100823123
+      "amplitude": 0.006,
+      "phase": 3.65
     }
   ],
   "epoch": {

--- a/data/ticon/west_terschelling-westtslg-nld-rws.json
+++ b/data/ticon/west_terschelling-westtslg-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.7459425199999999,
-      "phase": 230.35846
+      "amplitude": 0.768,
+      "phase": 223.28
     },
     {
       "name": "N2",
-      "amplitude": 0.11949161999999999,
-      "phase": 208.664819
+      "amplitude": 0.123,
+      "phase": 202.22
     },
     {
       "name": "S2",
-      "amplitude": 0.19897682,
-      "phase": 293.703412
+      "amplitude": 0.205,
+      "phase": 286.68
     },
     {
       "name": "K2",
-      "amplitude": 0.05775156,
-      "phase": 292.084201
+      "amplitude": 0.061,
+      "phase": 284.14
     },
     {
       "name": "2N2",
-      "amplitude": 0.016236,
-      "phase": 182.30804
+      "amplitude": 0.017,
+      "phase": 175.57
     },
     {
       "name": "S1",
-      "amplitude": 0.00636346,
-      "phase": 342.023786
+      "amplitude": 0.009,
+      "phase": 311.9
     },
     {
       "name": "K1",
-      "amplitude": 0.06515299,
-      "phase": 9.959292000000005
+      "amplitude": 0.065,
+      "phase": 6.32
     },
     {
       "name": "P1",
-      "amplitude": 0.02810181,
-      "phase": 4.632020000000011
+      "amplitude": 0.028,
+      "phase": 1.23
     },
     {
       "name": "O1",
-      "amplitude": 0.08959557,
-      "phase": 210.555636
+      "amplitude": 0.09,
+      "phase": 207.56
     },
     {
       "name": "Q1",
-      "amplitude": 0.03109684,
-      "phase": 153.77547900000002
+      "amplitude": 0.031,
+      "phase": 150.62
     },
     {
       "name": "M1",
-      "amplitude": 0.00153805,
-      "phase": 231.986023
+      "amplitude": 0.002,
+      "phase": 35.26
     },
     {
       "name": "M4",
-      "amplitude": 0.051209990000000004,
-      "phase": 261.551955
+      "amplitude": 0.061,
+      "phase": 249.41
     },
     {
       "name": "MM",
-      "amplitude": 0.005532120000000001,
-      "phase": 191.525686
+      "amplitude": 0.005,
+      "phase": 191.41
     },
     {
       "name": "MF",
-      "amplitude": 0.01047186,
-      "phase": 176.305749
+      "amplitude": 0.011,
+      "phase": 178.17
     },
     {
       "name": "SA",
-      "amplitude": 0.11471784,
-      "phase": 223.414322
+      "amplitude": 0.12,
+      "phase": 223.74
     },
     {
       "name": "SSA",
-      "amplitude": 0.027268659999999997,
-      "phase": 164.74665900000002
+      "amplitude": 0.029,
+      "phase": 158.87
     },
     {
       "name": "T2",
-      "amplitude": 0.026957270000000002,
-      "phase": 220.575132
+      "amplitude": 0.01,
+      "phase": 258.16
     },
     {
       "name": "J1",
-      "amplitude": 0.0030383500000000004,
-      "phase": 123.95344599999999
+      "amplitude": 0.003,
+      "phase": 119.32
     },
     {
       "name": "L2",
-      "amplitude": 0.0570654,
-      "phase": 241.74344000000002
+      "amplitude": 0.059,
+      "phase": 234.71
     },
     {
       "name": "R2",
-      "amplitude": 0.01708829,
-      "phase": 57.06714999999997
+      "amplitude": 0.005,
+      "phase": 100.1
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00649205,
-      "phase": 93.704455
+      "amplitude": 0.006,
+      "phase": 92.05
     },
     {
       "name": "MSF",
-      "amplitude": 0.02324689,
-      "phase": 44.45607699999999
+      "amplitude": 0.024,
+      "phase": 44.4
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0035129700000000002,
-      "phase": 302.24008200000003
+      "amplitude": 0.003,
+      "phase": 299
     },
     {
       "name": "EP2",
-      "amplitude": 0.01540159,
-      "phase": 300.588679
+      "amplitude": 0.016,
+      "phase": 293.9
     },
     {
       "name": "M3",
-      "amplitude": 0.00257212,
-      "phase": 10.447062000000017
+      "amplitude": 0.003,
+      "phase": 180.69
     },
     {
       "name": "MU2",
-      "amplitude": 0.07774222,
-      "phase": 319.917776
+      "amplitude": 0.08,
+      "phase": 312.31
     },
     {
       "name": "MTM",
-      "amplitude": 0.0058965,
-      "phase": 278.128418
+      "amplitude": 0.005,
+      "phase": 270.9
     },
     {
       "name": "NU2",
-      "amplitude": 0.04263238999999999,
-      "phase": 191.702772
+      "amplitude": 0.045,
+      "phase": 183.7
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.02817895,
-      "phase": 233.66298999999998
+      "amplitude": 0.029,
+      "phase": 228.63
     },
     {
       "name": "MN4",
-      "amplitude": 0.01784637,
-      "phase": 239.219223
+      "amplitude": 0.021,
+      "phase": 227.42
     },
     {
       "name": "MS4",
-      "amplitude": 0.03161519,
-      "phase": 328.454588
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.01408873,
-      "phase": 35.26412099999999
+      "amplitude": 0.037,
+      "phase": 317
     },
     {
       "name": "N4",
-      "amplitude": 0.00446478,
-      "phase": 217.276323
+      "amplitude": 0.005,
+      "phase": 205.09
     },
     {
       "name": "M6",
-      "amplitude": 0.03438777,
-      "phase": 13.928099999999972
+      "amplitude": 0.048,
+      "phase": 354.78
     },
     {
       "name": "M8",
-      "amplitude": 0.0061446999999999995,
-      "phase": 83.12600099999997
+      "amplitude": 0.01,
+      "phase": 57.56
     },
     {
       "name": "S4",
-      "amplitude": 0.0031588500000000004,
-      "phase": 108.420707
+      "amplitude": 0.003,
+      "phase": 87.61
     },
     {
       "name": "OO1",
-      "amplitude": 0.00317475,
-      "phase": 157.44234000000006
+      "amplitude": 0.003,
+      "phase": 145.1
     },
     {
       "name": "S3",
-      "amplitude": 0.00015081,
-      "phase": 99.72154599999999
+      "amplitude": 0,
+      "phase": 278.97
     },
     {
       "name": "MA2",
-      "amplitude": 0.08758231,
-      "phase": 208.720982
+      "amplitude": 0.02,
+      "phase": 171.04
     },
     {
       "name": "MB2",
-      "amplitude": 0.07113162,
-      "phase": 75.93165699999997
+      "amplitude": 0.009,
+      "phase": 168.33
     },
     {
       "name": "T3",
-      "amplitude": 0.00104003,
-      "phase": 161.99259600000005
+      "amplitude": 0.001,
+      "phase": 332.89
     },
     {
       "name": "R3",
-      "amplitude": 0.00118456,
-      "phase": 188.933228
+      "amplitude": 0.001,
+      "phase": 258.07
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00662385,
-      "phase": 150.146526
+      "amplitude": 0.007,
+      "phase": 148.45
     },
     {
       "name": "SGM",
-      "amplitude": 0.0012372,
-      "phase": 257.85476800000004
+      "amplitude": 0.001,
+      "phase": 77.3
     },
     {
       "name": "3L2",
-      "amplitude": 0.005276070000000001,
-      "phase": 19.78447799999998
+      "amplitude": 0.004,
+      "phase": 148.19
     },
     {
       "name": "3N2",
-      "amplitude": 0.00540913,
-      "phase": 126.64397500000001
+      "amplitude": 0.006,
+      "phase": 40.89
     },
     {
       "name": "2SM2",
-      "amplitude": 0.01912912,
-      "phase": 135.65508699999998
+      "amplitude": 0.02,
+      "phase": 130.05
     },
     {
       "name": "2MS6",
-      "amplitude": 0.03248627,
-      "phase": 73.70529599999998
+      "amplitude": 0.044,
+      "phase": 54.8
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0031782,
-      "phase": 38.08819599999998
+      "amplitude": 0.004,
+      "phase": 108.31
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0045478,
-      "phase": 81.638327
+      "amplitude": 0.005,
+      "phase": 335.82
     }
   ],
   "epoch": {

--- a/data/ticon/westkapelle-westkple-nld-rws.json
+++ b/data/ticon/westkapelle-westkple-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.4810497200000001,
-      "phase": 37.08334300000001
+      "amplitude": 1.531,
+      "phase": 24.69
     },
     {
       "name": "N2",
-      "amplitude": 0.24384604,
-      "phase": 11.513033000000007
+      "amplitude": 0.253,
+      "phase": 359.36
     },
     {
       "name": "S2",
-      "amplitude": 0.41176462,
-      "phase": 91.98547100000002
+      "amplitude": 0.424,
+      "phase": 79.58
     },
     {
       "name": "K2",
-      "amplitude": 0.11911667,
-      "phase": 93.96526399999999
+      "amplitude": 0.125,
+      "phase": 79.76
     },
     {
       "name": "2N2",
-      "amplitude": 0.027793429999999997,
-      "phase": 343.83549
+      "amplitude": 0.032,
+      "phase": 333.03
     },
     {
       "name": "S1",
-      "amplitude": 0.00612127,
-      "phase": 348.60743
+      "amplitude": 0.009,
+      "phase": 296.19
     },
     {
       "name": "K1",
-      "amplitude": 0.06409753,
-      "phase": 355.941931
+      "amplitude": 0.064,
+      "phase": 349.35
     },
     {
       "name": "P1",
-      "amplitude": 0.03101489,
-      "phase": 337.616136
+      "amplitude": 0.031,
+      "phase": 331.44
     },
     {
       "name": "O1",
-      "amplitude": 0.10294826,
-      "phase": 180.128857
+      "amplitude": 0.103,
+      "phase": 173.91
     },
     {
       "name": "Q1",
-      "amplitude": 0.03637443,
-      "phase": 125.14676700000001
+      "amplitude": 0.036,
+      "phase": 118.77
     },
     {
       "name": "M1",
-      "amplitude": 0.0020415,
-      "phase": 120.092534
+      "amplitude": 0.003,
+      "phase": 346.07
     },
     {
       "name": "M4",
-      "amplitude": 0.11735955,
-      "phase": 63.80776800000001
+      "amplitude": 0.136,
+      "phase": 38.63
     },
     {
       "name": "MM",
-      "amplitude": 0.014179269999999999,
-      "phase": 129.549145
+      "amplitude": 0.014,
+      "phase": 126
     },
     {
       "name": "MF",
-      "amplitude": 0.00152365,
-      "phase": 199.46188
+      "amplitude": 0.002,
+      "phase": 204.52
     },
     {
       "name": "SA",
-      "amplitude": 0.08816666,
-      "phase": 218.543353
+      "amplitude": 0.096,
+      "phase": 218.99
     },
     {
       "name": "SSA",
-      "amplitude": 0.027868,
-      "phase": 161.927194
+      "amplitude": 0.03,
+      "phase": 153.23
     },
     {
       "name": "T2",
-      "amplitude": 0.06639794,
-      "phase": 21.198489999999993
+      "amplitude": 0.024,
+      "phase": 66.22
     },
     {
       "name": "J1",
-      "amplitude": 0.0042799100000000005,
-      "phase": 85.18874700000003
+      "amplitude": 0.004,
+      "phase": 76.15
     },
     {
       "name": "L2",
-      "amplitude": 0.09960855,
-      "phase": 55.15725900000001
+      "amplitude": 0.103,
+      "phase": 44.29
     },
     {
       "name": "R2",
-      "amplitude": 0.04251158,
-      "phase": 187.206518
+      "amplitude": 0.007,
+      "phase": 115.28
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00657846,
-      "phase": 75.803742
+      "amplitude": 0.007,
+      "phase": 69.96
     },
     {
       "name": "MSF",
-      "amplitude": 0.03708736,
-      "phase": 44.40502200000003
+      "amplitude": 0.037,
+      "phase": 43.63
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00447601,
-      "phase": 289.537286
+      "amplitude": 0.004,
+      "phase": 289.49
     },
     {
       "name": "EP2",
-      "amplitude": 0.02216187,
-      "phase": 130.42960600000004
+      "amplitude": 0.023,
+      "phase": 118.56
     },
     {
       "name": "M3",
-      "amplitude": 0.00821624,
-      "phase": 118.367347
+      "amplitude": 0.009,
+      "phase": 275.86
     },
     {
       "name": "MU2",
-      "amplitude": 0.10335556,
-      "phase": 151.37152600000002
+      "amplitude": 0.106,
+      "phase": 137.84
     },
     {
       "name": "MTM",
-      "amplitude": 0.0022509699999999997,
-      "phase": 232.717079
+      "amplitude": 0.002,
+      "phase": 205.47
     },
     {
       "name": "NU2",
-      "amplitude": 0.0755093,
-      "phase": 7.0516830000000255
+      "amplitude": 0.083,
+      "phase": 354.65
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04510365,
-      "phase": 50.18665199999998
+      "amplitude": 0.048,
+      "phase": 41.63
     },
     {
       "name": "MN4",
-      "amplitude": 0.03981408,
-      "phase": 40.47127499999999
+      "amplitude": 0.046,
+      "phase": 15.58
     },
     {
       "name": "MS4",
-      "amplitude": 0.07934685,
-      "phase": 123.95076399999999
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.031687280000000005,
-      "phase": 182.492489
+      "amplitude": 0.091,
+      "phase": 99.8
     },
     {
       "name": "N4",
-      "amplitude": 0.00823299,
-      "phase": 18.756999000000008
+      "amplitude": 0.01,
+      "phase": 349.23
     },
     {
       "name": "M6",
-      "amplitude": 0.06494275,
-      "phase": 30.394450000000006
+      "amplitude": 0.091,
+      "phase": 354.04
     },
     {
       "name": "M8",
-      "amplitude": 0.013804190000000001,
-      "phase": 16.158451000000014
+      "amplitude": 0.028,
+      "phase": 330.06
     },
     {
       "name": "S4",
-      "amplitude": 0.0072742399999999995,
-      "phase": 223.200671
+      "amplitude": 0.008,
+      "phase": 197.92
     },
     {
       "name": "OO1",
-      "amplitude": 0.00364924,
-      "phase": 135.990008
+      "amplitude": 0.003,
+      "phase": 140.43
     },
     {
       "name": "S3",
-      "amplitude": 0.00202765,
-      "phase": 38.47944799999999
+      "amplitude": 0,
+      "phase": 201.25
     },
     {
       "name": "MA2",
-      "amplitude": 0.209472,
-      "phase": 24.224503000000027
+      "amplitude": 0.024,
+      "phase": 359.73
     },
     {
       "name": "MB2",
-      "amplitude": 0.19257569,
-      "phase": 225.908107
+      "amplitude": 0.023,
+      "phase": 142.8
     },
     {
       "name": "T3",
-      "amplitude": 0.00155481,
-      "phase": 11.340841000000012
+      "amplitude": 0.002,
+      "phase": 187.92
     },
     {
       "name": "R3",
-      "amplitude": 0.00776637,
-      "phase": 235.562355
+      "amplitude": 0.009,
+      "phase": 304.71
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00736271,
-      "phase": 114.89516800000001
+      "amplitude": 0.008,
+      "phase": 111.04
     },
     {
       "name": "SGM",
-      "amplitude": 0.0009528300000000001,
-      "phase": 171.338297
+      "amplitude": 0.001,
+      "phase": 262.74
     },
     {
       "name": "3L2",
-      "amplitude": 0.00508444,
-      "phase": 202.735255
+      "amplitude": 0.008,
+      "phase": 345.3
     },
     {
       "name": "3N2",
-      "amplitude": 0.008531450000000001,
-      "phase": 331.58975399999997
+      "amplitude": 0.01,
+      "phase": 181.16
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03298089,
-      "phase": 321.754006
+      "amplitude": 0.034,
+      "phase": 309.41
     },
     {
       "name": "2MS6",
-      "amplitude": 0.06531005000000001,
-      "phase": 81.275869
+      "amplitude": 0.091,
+      "phase": 45.25
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00466085,
-      "phase": 102.68027699999999
+      "amplitude": 0.006,
+      "phase": 161.67
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00417778,
-      "phase": 154.167638
+      "amplitude": 0.006,
+      "phase": 35.59
     }
   ],
   "epoch": {

--- a/data/ticon/whvaltervorhafen-9440020-deu-wsv.json
+++ b/data/ticon/whvaltervorhafen-9440020-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.7335524795794204,
-      "phase": 330.01494414917056
+      "amplitude": 1.734,
+      "phase": 330.01
     },
     {
       "name": "N2",
-      "amplitude": 0.2733313301055897,
-      "phase": 305.3247317607038
+      "amplitude": 0.273,
+      "phase": 305.32
     },
     {
       "name": "S2",
-      "amplitude": 0.4619695907859043,
-      "phase": 43.09127645249788
+      "amplitude": 0.462,
+      "phase": 43.09
     },
     {
       "name": "K2",
-      "amplitude": 0.1366501306721215,
-      "phase": 40.382297340669254
+      "amplitude": 0.137,
+      "phase": 40.38
     },
     {
       "name": "2N2",
-      "amplitude": 0.029880840379730666,
-      "phase": 284.68093979087797
+      "amplitude": 0.03,
+      "phase": 284.68
     },
     {
       "name": "S1",
-      "amplitude": 0.013573195738184366,
-      "phase": 40.384977932308175
+      "amplitude": 0.014,
+      "phase": 40.38
     },
     {
       "name": "K1",
-      "amplitude": 0.07345719525845998,
-      "phase": 33.71678097462291
+      "amplitude": 0.073,
+      "phase": 33.72
     },
     {
       "name": "P1",
-      "amplitude": 0.032078393445370106,
-      "phase": 38.53032976763478
+      "amplitude": 0.032,
+      "phase": 38.53
     },
     {
       "name": "O1",
-      "amplitude": 0.09450254094607874,
-      "phase": 241.80207901984915
+      "amplitude": 0.095,
+      "phase": 241.8
     },
     {
       "name": "Q1",
-      "amplitude": 0.029206313376072244,
-      "phase": 182.50478974686692
+      "amplitude": 0.029,
+      "phase": 182.5
     },
     {
       "name": "M1",
-      "amplitude": 0.0019431933058093,
-      "phase": 94.63793868611583
+      "amplitude": 0.002,
+      "phase": 94.64
     },
     {
       "name": "M4",
-      "amplitude": 0.09232748791913559,
-      "phase": 113.12624765069154
+      "amplitude": 0.092,
+      "phase": 113.13
     },
     {
       "name": "MM",
-      "amplitude": 0.01886484125518137,
-      "phase": 168.05135214041775
+      "amplitude": 0.019,
+      "phase": 168.05
     },
     {
       "name": "MF",
-      "amplitude": 0.009242034395943939,
-      "phase": 167.3607685994458
+      "amplitude": 0.009,
+      "phase": 167.36
     },
     {
       "name": "SA",
-      "amplitude": 0.08878915093879036,
-      "phase": 220.34514594531743
+      "amplitude": 0.089,
+      "phase": 220.35
     },
     {
       "name": "SSA",
-      "amplitude": 0.034651507485147025,
-      "phase": 205.8388569877778
+      "amplitude": 0.035,
+      "phase": 205.84
     },
     {
       "name": "T2",
-      "amplitude": 0.023370211871763594,
-      "phase": 17.868668064876147
+      "amplitude": 0.023,
+      "phase": 17.87
     },
     {
       "name": "J1",
-      "amplitude": 0.0022145256419556256,
-      "phase": 163.1816658719165
+      "amplitude": 0.002,
+      "phase": 163.18
     },
     {
       "name": "L2",
-      "amplitude": 0.1420997512097471,
-      "phase": 345.6233808736551
+      "amplitude": 0.142,
+      "phase": 345.62
     },
     {
       "name": "R2",
-      "amplitude": 0.0014022737350194005,
-      "phase": 58.82391915074817
+      "amplitude": 0.001,
+      "phase": 58.82
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005857150347946279,
-      "phase": 126.65472989368334
+      "amplitude": 0.006,
+      "phase": 126.65
     },
     {
       "name": "MSF",
-      "amplitude": 0.00912199030171022,
-      "phase": 45.429362354975694
+      "amplitude": 0.009,
+      "phase": 45.43
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00827776790019222,
-      "phase": 63.76765452376742
+      "amplitude": 0.008,
+      "phase": 63.77
     },
     {
       "name": "EP2",
-      "amplitude": 0.04106414697976304,
-      "phase": 29.646202496662625
+      "amplitude": 0.041,
+      "phase": 29.65
     },
     {
       "name": "M3",
-      "amplitude": 0.00614182399402271,
-      "phase": 22.15377617124227
+      "amplitude": 0.006,
+      "phase": 22.15
     },
     {
       "name": "MU2",
-      "amplitude": 0.18451573043101846,
-      "phase": 51.82975007834489
+      "amplitude": 0.185,
+      "phase": 51.83
     },
     {
       "name": "MTM",
-      "amplitude": 0.003957713290287222,
-      "phase": 247.08763862090893
+      "amplitude": 0.004,
+      "phase": 247.09
     },
     {
       "name": "NU2",
-      "amplitude": 0.10036408511576803,
-      "phase": 285.42395007383516
+      "amplitude": 0.1,
+      "phase": 285.42
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06722068343010218,
-      "phase": 340.8655250679397
+      "amplitude": 0.067,
+      "phase": 340.87
     },
     {
       "name": "MN4",
-      "amplitude": 0.025931006654507302,
-      "phase": 88.12015648386671
+      "amplitude": 0.026,
+      "phase": 88.12
     },
     {
       "name": "MS4",
-      "amplitude": 0.06554376192953659,
-      "phase": 200.65618102467306
+      "amplitude": 0.066,
+      "phase": 200.66
     },
     {
       "name": "N4",
-      "amplitude": 0.0050112920028335724,
-      "phase": 71.49715482770222
+      "amplitude": 0.005,
+      "phase": 71.5
     },
     {
       "name": "M6",
-      "amplitude": 0.040927753516321774,
-      "phase": 328.61255719517754
+      "amplitude": 0.041,
+      "phase": 328.61
     },
     {
       "name": "M8",
-      "amplitude": 0.0018051403068801118,
-      "phase": 225.77140082414383
+      "amplitude": 0.002,
+      "phase": 225.77
     },
     {
       "name": "S4",
-      "amplitude": 0.008725527800741326,
-      "phase": 349.07928502623594
+      "amplitude": 0.009,
+      "phase": 349.08
     },
     {
       "name": "OO1",
-      "amplitude": 0.002739072804484459,
-      "phase": 199.47906619031994
+      "amplitude": 0.003,
+      "phase": 199.48
     },
     {
       "name": "S3",
-      "amplitude": 0.0003251755903321673,
-      "phase": 253.52469100783708
+      "amplitude": 0,
+      "phase": 253.52
     },
     {
       "name": "MA2",
-      "amplitude": 0.06245121467211332,
-      "phase": 276.6312632613007
+      "amplitude": 0.062,
+      "phase": 276.63
     },
     {
       "name": "MB2",
-      "amplitude": 0.023673979764933552,
-      "phase": 66.46057389766554
+      "amplitude": 0.024,
+      "phase": 66.46
     },
     {
       "name": "T3",
-      "amplitude": 0.0006271983517982633,
-      "phase": 92.16373454960444
+      "amplitude": 0.001,
+      "phase": 92.16
     },
     {
       "name": "R3",
-      "amplitude": 0.0041024721199853405,
-      "phase": 49.12543161169822
+      "amplitude": 0.004,
+      "phase": 49.13
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005868554590173475,
-      "phase": 187.67729424623099
+      "amplitude": 0.006,
+      "phase": 187.68
     },
     {
       "name": "SGM",
-      "amplitude": 0.002606034666127196,
-      "phase": 43.73439843802788
+      "amplitude": 0.003,
+      "phase": 43.73
     },
     {
       "name": "3L2",
-      "amplitude": 0.004701358308384456,
-      "phase": 241.31789644085407
+      "amplitude": 0.005,
+      "phase": 241.32
     },
     {
       "name": "3N2",
-      "amplitude": 0.022606156840702118,
-      "phase": 131.91136007952917
+      "amplitude": 0.023,
+      "phase": 131.91
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04643948439171821,
-      "phase": 262.9729549926311
+      "amplitude": 0.046,
+      "phase": 262.97
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04446724508147815,
-      "phase": 40.17848965245304
+      "amplitude": 0.044,
+      "phase": 40.18
     },
     {
       "name": "2MK5",
-      "amplitude": 0.007915462545044523,
-      "phase": 349.91205066796726
+      "amplitude": 0.008,
+      "phase": 349.91
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00602645692584292,
-      "phase": 165.48901603523245
+      "amplitude": 0.006,
+      "phase": 165.49
     }
   ],
   "epoch": {

--- a/data/ticon/whvneuervorhafen-9440030-deu-wsv.json
+++ b/data/ticon/whvneuervorhafen-9440030-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.6857872310093625,
-      "phase": 328.7374979300337
+      "amplitude": 1.686,
+      "phase": 328.74
     },
     {
       "name": "N2",
-      "amplitude": 0.26552394651202027,
-      "phase": 303.9600987898708
+      "amplitude": 0.266,
+      "phase": 303.96
     },
     {
       "name": "S2",
-      "amplitude": 0.44743842923156985,
-      "phase": 41.54773077882044
+      "amplitude": 0.447,
+      "phase": 41.55
     },
     {
       "name": "K2",
-      "amplitude": 0.13253186158419616,
-      "phase": 38.98175662348143
+      "amplitude": 0.133,
+      "phase": 38.98
     },
     {
       "name": "2N2",
-      "amplitude": 0.028939241639959395,
-      "phase": 283.65015500361756
+      "amplitude": 0.029,
+      "phase": 283.65
     },
     {
       "name": "S1",
-      "amplitude": 0.012937972980738389,
-      "phase": 37.3432038386332
+      "amplitude": 0.013,
+      "phase": 37.34
     },
     {
       "name": "K1",
-      "amplitude": 0.0726830153957271,
-      "phase": 32.05352128266691
+      "amplitude": 0.073,
+      "phase": 32.05
     },
     {
       "name": "P1",
-      "amplitude": 0.03146314130742465,
-      "phase": 37.565530449262496
+      "amplitude": 0.031,
+      "phase": 37.57
     },
     {
       "name": "O1",
-      "amplitude": 0.09352507377106496,
-      "phase": 240.78672505280858
+      "amplitude": 0.094,
+      "phase": 240.79
     },
     {
       "name": "Q1",
-      "amplitude": 0.028972912468734298,
-      "phase": 181.66593852918086
+      "amplitude": 0.029,
+      "phase": 181.67
     },
     {
       "name": "M1",
-      "amplitude": 0.0018641708158454052,
-      "phase": 94.93324192563563
+      "amplitude": 0.002,
+      "phase": 94.93
     },
     {
       "name": "M4",
-      "amplitude": 0.08470760838778066,
-      "phase": 118.95239242476447
+      "amplitude": 0.085,
+      "phase": 118.95
     },
     {
       "name": "MM",
-      "amplitude": 0.020296105302296655,
-      "phase": 171.27313162255643
+      "amplitude": 0.02,
+      "phase": 171.27
     },
     {
       "name": "MF",
-      "amplitude": 0.009529951035577083,
-      "phase": 171.311981013293
+      "amplitude": 0.01,
+      "phase": 171.31
     },
     {
       "name": "SA",
-      "amplitude": 0.08981807088174025,
-      "phase": 221.36495167686348
+      "amplitude": 0.09,
+      "phase": 221.36
     },
     {
       "name": "SSA",
-      "amplitude": 0.03427702029104302,
-      "phase": 205.09098274489486
+      "amplitude": 0.034,
+      "phase": 205.09
     },
     {
       "name": "T2",
-      "amplitude": 0.02313727881017503,
-      "phase": 15.933956078510903
+      "amplitude": 0.023,
+      "phase": 15.93
     },
     {
       "name": "J1",
-      "amplitude": 0.0021277649732891297,
-      "phase": 161.99815970514533
+      "amplitude": 0.002,
+      "phase": 162
     },
     {
       "name": "L2",
-      "amplitude": 0.13779953932553746,
-      "phase": 344.64828094592707
+      "amplitude": 0.138,
+      "phase": 344.65
     },
     {
       "name": "R2",
-      "amplitude": 0.0014191470570750098,
-      "phase": 58.95320891323496
+      "amplitude": 0.001,
+      "phase": 58.95
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005843246000606247,
-      "phase": 125.26943575925941
+      "amplitude": 0.006,
+      "phase": 125.27
     },
     {
       "name": "MSF",
-      "amplitude": 0.005597186573777368,
-      "phase": 28.561049578694394
+      "amplitude": 0.006,
+      "phase": 28.56
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008283604569852101,
-      "phase": 65.93671524755894
+      "amplitude": 0.008,
+      "phase": 65.94
     },
     {
       "name": "EP2",
-      "amplitude": 0.03971561705811859,
-      "phase": 28.887110936666602
+      "amplitude": 0.04,
+      "phase": 28.89
     },
     {
       "name": "M3",
-      "amplitude": 0.005579046599794873,
-      "phase": 18.092803444321532
+      "amplitude": 0.006,
+      "phase": 18.09
     },
     {
       "name": "MU2",
-      "amplitude": 0.1782178320935951,
-      "phase": 51.21952312793388
+      "amplitude": 0.178,
+      "phase": 51.22
     },
     {
       "name": "MTM",
-      "amplitude": 0.004254913267095532,
-      "phase": 248.5834468793076
+      "amplitude": 0.004,
+      "phase": 248.58
     },
     {
       "name": "NU2",
-      "amplitude": 0.09758873569345945,
-      "phase": 284.5992215220725
+      "amplitude": 0.098,
+      "phase": 284.6
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.06511300182757339,
-      "phase": 339.85683608003103
+      "amplitude": 0.065,
+      "phase": 339.86
     },
     {
       "name": "MN4",
-      "amplitude": 0.02390430720307901,
-      "phase": 95.7520333334935
+      "amplitude": 0.024,
+      "phase": 95.75
     },
     {
       "name": "MS4",
-      "amplitude": 0.06177359117270585,
-      "phase": 204.643998279742
+      "amplitude": 0.062,
+      "phase": 204.64
     },
     {
       "name": "N4",
-      "amplitude": 0.004771492210210916,
-      "phase": 79.56220248970908
+      "amplitude": 0.005,
+      "phase": 79.56
     },
     {
       "name": "M6",
-      "amplitude": 0.04525275482958163,
-      "phase": 323.7387739332494
+      "amplitude": 0.045,
+      "phase": 323.74
     },
     {
       "name": "M8",
-      "amplitude": 0.001019005348971494,
-      "phase": 149.69731356047623
+      "amplitude": 0.001,
+      "phase": 149.7
     },
     {
       "name": "S4",
-      "amplitude": 0.008563933184353719,
-      "phase": 349.506618373792
+      "amplitude": 0.009,
+      "phase": 349.51
     },
     {
       "name": "OO1",
-      "amplitude": 0.0027020428547025895,
-      "phase": 199.61841810251778
+      "amplitude": 0.003,
+      "phase": 199.62
     },
     {
       "name": "S3",
-      "amplitude": 0.0003733438747027006,
-      "phase": 246.67153754041502
+      "amplitude": 0,
+      "phase": 246.67
     },
     {
       "name": "MA2",
-      "amplitude": 0.06081691426171352,
-      "phase": 276.8281458465746
+      "amplitude": 0.061,
+      "phase": 276.83
     },
     {
       "name": "MB2",
-      "amplitude": 0.023146874459001012,
-      "phase": 64.07902858659929
+      "amplitude": 0.023,
+      "phase": 64.08
     },
     {
       "name": "T3",
-      "amplitude": 0.0005350725725264602,
-      "phase": 87.8967189839534
+      "amplitude": 0.001,
+      "phase": 87.9
     },
     {
       "name": "R3",
-      "amplitude": 0.0039592851965241736,
-      "phase": 45.34730976149524
+      "amplitude": 0.004,
+      "phase": 45.35
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005834376494153549,
-      "phase": 187.1914768418149
+      "amplitude": 0.006,
+      "phase": 187.19
     },
     {
       "name": "SGM",
-      "amplitude": 0.0025215856266897997,
-      "phase": 42.52569212002578
+      "amplitude": 0.003,
+      "phase": 42.53
     },
     {
       "name": "3L2",
-      "amplitude": 0.004630054810598665,
-      "phase": 239.33610684386878
+      "amplitude": 0.005,
+      "phase": 239.34
     },
     {
       "name": "3N2",
-      "amplitude": 0.021981218664807144,
-      "phase": 130.38022354835442
+      "amplitude": 0.022,
+      "phase": 130.38
     },
     {
       "name": "2SM2",
-      "amplitude": 0.045069085631982565,
-      "phase": 262.02075169613266
+      "amplitude": 0.045,
+      "phase": 262.02
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04791152095397828,
-      "phase": 33.99204558406683
+      "amplitude": 0.048,
+      "phase": 33.99
     },
     {
       "name": "2MK5",
-      "amplitude": 0.007345630129662636,
-      "phase": 349.0966445126439
+      "amplitude": 0.007,
+      "phase": 349.1
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005474904417286599,
-      "phase": 168.12324093759935
+      "amplitude": 0.005,
+      "phase": 168.12
     }
   ],
   "epoch": {

--- a/data/ticon/wierumergronden-wiermgdn-nld-rws.json
+++ b/data/ticon/wierumergronden-wiermgdn-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.9175732000000001,
-      "phase": 247.302233
+      "amplitude": 0.953,
+      "phase": 231.68
     },
     {
       "name": "N2",
-      "amplitude": 0.15389728,
-      "phase": 223.709049
+      "amplitude": 0.159,
+      "phase": 207.98
     },
     {
       "name": "S2",
-      "amplitude": 0.25540669,
-      "phase": 308.040793
+      "amplitude": 0.263,
+      "phase": 292.52
     },
     {
       "name": "K2",
-      "amplitude": 0.0766605,
-      "phase": 309.280066
+      "amplitude": 0.078,
+      "phase": 293.14
     },
     {
       "name": "2N2",
-      "amplitude": 0.02297424,
-      "phase": 181.54523
+      "amplitude": 0.022,
+      "phase": 169.94
     },
     {
       "name": "S1",
-      "amplitude": 0.00637061,
-      "phase": 22.72752600000001
+      "amplitude": 0.008,
+      "phase": 314.54
     },
     {
       "name": "K1",
-      "amplitude": 0.06718962,
-      "phase": 0.7299380000000042
+      "amplitude": 0.067,
+      "phase": 352.71
     },
     {
       "name": "P1",
-      "amplitude": 0.026390349999999996,
-      "phase": 2.3782340000000204
+      "amplitude": 0.027,
+      "phase": 354.67
     },
     {
       "name": "O1",
-      "amplitude": 0.09012957,
-      "phase": 206.927799
+      "amplitude": 0.09,
+      "phase": 199.91
     },
     {
       "name": "Q1",
-      "amplitude": 0.03157737,
-      "phase": 148.113674
+      "amplitude": 0.031,
+      "phase": 141.33
     },
     {
       "name": "M1",
-      "amplitude": 0.00497529,
-      "phase": 88.30117999999999
+      "amplitude": 0.002,
+      "phase": 63.85
     },
     {
       "name": "M4",
-      "amplitude": 0.08033369,
-      "phase": 343.955567
+      "amplitude": 0.095,
+      "phase": 310.71
     },
     {
       "name": "MM",
-      "amplitude": 0.011785589999999999,
-      "phase": 320.328029
+      "amplitude": 0.013,
+      "phase": 320.25
     },
     {
       "name": "MF",
-      "amplitude": 0.008466399999999999,
-      "phase": 236.90160400000002
+      "amplitude": 0.008,
+      "phase": 234.55
     },
     {
       "name": "SA",
-      "amplitude": 0.10639355,
-      "phase": 223.360308
+      "amplitude": 0.113,
+      "phase": 223.15
     },
     {
       "name": "SSA",
-      "amplitude": 0.03046052,
-      "phase": 153.824746
+      "amplitude": 0.033,
+      "phase": 148.64
     },
     {
       "name": "T2",
-      "amplitude": 0.05246632,
-      "phase": 229.677799
+      "amplitude": 0.011,
+      "phase": 261.72
     },
     {
       "name": "J1",
-      "amplitude": 0.00296382,
-      "phase": 45.95532000000003
+      "amplitude": 0.003,
+      "phase": 42.01
     },
     {
       "name": "L2",
-      "amplitude": 0.06221181,
-      "phase": 262.934898
+      "amplitude": 0.065,
+      "phase": 247.6
     },
     {
       "name": "R2",
-      "amplitude": 0.029674649999999997,
-      "phase": 33.71382599999998
+      "amplitude": 0.003,
+      "phase": 337.05
     },
     {
       "name": "2Q1",
-      "amplitude": 0.007102270000000001,
-      "phase": 94.68524300000001
+      "amplitude": 0.007,
+      "phase": 93.46
     },
     {
       "name": "MSF",
-      "amplitude": 0.01723123,
-      "phase": 38.99253599999997
+      "amplitude": 0.018,
+      "phase": 40.32
     },
     {
       "name": "MSQM",
-      "amplitude": 0.00444884,
-      "phase": 88.55475100000001
+      "amplitude": 0.004,
+      "phase": 98.07
     },
     {
       "name": "EP2",
-      "amplitude": 0.01513201,
-      "phase": 326.620045
+      "amplitude": 0.016,
+      "phase": 304.57
     },
     {
       "name": "M3",
-      "amplitude": 0.00364726,
-      "phase": 24.381095000000016
+      "amplitude": 0.004,
+      "phase": 184.86
     },
     {
       "name": "MU2",
-      "amplitude": 0.07513626999999999,
-      "phase": 344.942332
+      "amplitude": 0.075,
+      "phase": 328.26
     },
     {
       "name": "MTM",
-      "amplitude": 0.01091156,
-      "phase": 267.01148
+      "amplitude": 0.011,
+      "phase": 265.66
     },
     {
       "name": "NU2",
-      "amplitude": 0.05156827,
-      "phase": 213.600112
+      "amplitude": 0.052,
+      "phase": 192.08
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.03387366,
-      "phase": 250.002721
+      "amplitude": 0.031,
+      "phase": 239.95
     },
     {
       "name": "MN4",
-      "amplitude": 0.02596234,
-      "phase": 318.71193800000003
+      "amplitude": 0.03,
+      "phase": 285.24
     },
     {
       "name": "MS4",
-      "amplitude": 0.05706327,
-      "phase": 50.88162999999997
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.01992899,
-      "phase": 63.83565399999998
+      "amplitude": 0.067,
+      "phase": 21.17
     },
     {
       "name": "N4",
-      "amplitude": 0.00617629,
-      "phase": 281.107418
+      "amplitude": 0.008,
+      "phase": 247.68
     },
     {
       "name": "M6",
-      "amplitude": 0.025897009999999998,
-      "phase": 128.11310200000003
+      "amplitude": 0.04,
+      "phase": 76.4
     },
     {
       "name": "M8",
-      "amplitude": 0.00574256,
-      "phase": 303.156384
+      "amplitude": 0.013,
+      "phase": 232.53
     },
     {
       "name": "S4",
-      "amplitude": 0.006060060000000001,
-      "phase": 171.79300999999998
+      "amplitude": 0.007,
+      "phase": 148.52
     },
     {
       "name": "OO1",
-      "amplitude": 0.00275817,
-      "phase": 176.11687900000004
+      "amplitude": 0.003,
+      "phase": 143.21
     },
     {
       "name": "S3",
-      "amplitude": 0.0007181800000000001,
-      "phase": 302.19341
+      "amplitude": 0.001,
+      "phase": 57.05
     },
     {
       "name": "MA2",
-      "amplitude": 0.17768421,
-      "phase": 231.356271
+      "amplitude": 0.031,
+      "phase": 197.34
     },
     {
       "name": "MB2",
-      "amplitude": 0.15338166,
-      "phase": 71.82032400000003
+      "amplitude": 0.015,
+      "phase": 341.87
     },
     {
       "name": "T3",
-      "amplitude": 0.00148636,
-      "phase": 125.67284799999999
+      "amplitude": 0.002,
+      "phase": 291.14
     },
     {
       "name": "R3",
-      "amplitude": 0.00260314,
-      "phase": 198.414821
+      "amplitude": 0.003,
+      "phase": 245.96
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00473479,
-      "phase": 160.64993000000004
+      "amplitude": 0.004,
+      "phase": 156.06
     },
     {
       "name": "SGM",
-      "amplitude": 0.00303445,
-      "phase": 242.535156
+      "amplitude": 0.003,
+      "phase": 66.2
     },
     {
       "name": "3L2",
-      "amplitude": 0.01036921,
-      "phase": 123.89907399999998
+      "amplitude": 0.006,
+      "phase": 192.99
     },
     {
       "name": "3N2",
-      "amplitude": 0.0012352399999999999,
-      "phase": 102.60372899999999
+      "amplitude": 0.01,
+      "phase": 61.42
     },
     {
       "name": "2SM2",
-      "amplitude": 0.021330110000000003,
-      "phase": 162.26485200000002
+      "amplitude": 0.022,
+      "phase": 151.19
     },
     {
       "name": "2MS6",
-      "amplitude": 0.02500311,
-      "phase": 184.569656
+      "amplitude": 0.038,
+      "phase": 135.29
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00180278,
-      "phase": 72.33347400000002
+      "amplitude": 0.002,
+      "phase": 104.69
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00210849,
-      "phase": 219.03814
+      "amplitude": 0.003,
+      "phase": 87.38
     }
   ],
   "epoch": {

--- a/data/ticon/wittdn-9570010-deu-wsv.json
+++ b/data/ticon/wittdn-9570010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2060568204269921,
-      "phase": 351.7666458123817
+      "amplitude": 1.206,
+      "phase": 351.77
     },
     {
       "name": "N2",
-      "amplitude": 0.19319457943597376,
-      "phase": 326.13179839150666
+      "amplitude": 0.193,
+      "phase": 326.13
     },
     {
       "name": "S2",
-      "amplitude": 0.30678410969624387,
-      "phase": 62.2354973824352
+      "amplitude": 0.307,
+      "phase": 62.24
     },
     {
       "name": "K2",
-      "amplitude": 0.09184487675248992,
-      "phase": 60.95589484341747
+      "amplitude": 0.092,
+      "phase": 60.96
     },
     {
       "name": "2N2",
-      "amplitude": 0.02207846082267996,
-      "phase": 304.10429730023367
+      "amplitude": 0.022,
+      "phase": 304.1
     },
     {
       "name": "S1",
-      "amplitude": 0.009662475748580377,
-      "phase": 11.033397839434826
+      "amplitude": 0.01,
+      "phase": 11.03
     },
     {
       "name": "K1",
-      "amplitude": 0.06662664152353714,
-      "phase": 41.97123125728103
+      "amplitude": 0.067,
+      "phase": 41.97
     },
     {
       "name": "P1",
-      "amplitude": 0.028316899069687533,
-      "phase": 45.6020694156407
+      "amplitude": 0.028,
+      "phase": 45.6
     },
     {
       "name": "O1",
-      "amplitude": 0.09144827802450024,
-      "phase": 251.63193130274703
+      "amplitude": 0.091,
+      "phase": 251.63
     },
     {
       "name": "Q1",
-      "amplitude": 0.02925865257417034,
-      "phase": 193.1119610455751
+      "amplitude": 0.029,
+      "phase": 193.11
     },
     {
       "name": "M1",
-      "amplitude": 0.0017678201257317243,
-      "phase": 109.78530899624172
+      "amplitude": 0.002,
+      "phase": 109.79
     },
     {
       "name": "M4",
-      "amplitude": 0.09849622259807987,
-      "phase": 193.3940446278402
+      "amplitude": 0.098,
+      "phase": 193.39
     },
     {
       "name": "MM",
-      "amplitude": 0.02672621569338801,
-      "phase": 178.17634518005832
+      "amplitude": 0.027,
+      "phase": 178.18
     },
     {
       "name": "MF",
-      "amplitude": 0.010319700701064773,
-      "phase": 169.19682526148927
+      "amplitude": 0.01,
+      "phase": 169.2
     },
     {
       "name": "SA",
-      "amplitude": 0.12231703676154355,
-      "phase": 231.31746791592184
+      "amplitude": 0.122,
+      "phase": 231.32
     },
     {
       "name": "SSA",
-      "amplitude": 0.043016336968944455,
-      "phase": 206.61217181170525
+      "amplitude": 0.043,
+      "phase": 206.61
     },
     {
       "name": "T2",
-      "amplitude": 0.01600522626483326,
-      "phase": 40.42771617144575
+      "amplitude": 0.016,
+      "phase": 40.43
     },
     {
       "name": "J1",
-      "amplitude": 0.002489716845728305,
-      "phase": 176.02428436050343
+      "amplitude": 0.002,
+      "phase": 176.02
     },
     {
       "name": "L2",
-      "amplitude": 0.09702979057867606,
-      "phase": 10.498599970807447
+      "amplitude": 0.097,
+      "phase": 10.5
     },
     {
       "name": "R2",
-      "amplitude": 0.0028980647496918395,
-      "phase": 14.842655755030137
+      "amplitude": 0.003,
+      "phase": 14.84
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005624167896270066,
-      "phase": 133.2244616204647
+      "amplitude": 0.006,
+      "phase": 133.22
     },
     {
       "name": "MSF",
-      "amplitude": 0.012554107628528243,
-      "phase": 48.03919998895606
+      "amplitude": 0.013,
+      "phase": 48.04
     },
     {
       "name": "MSQM",
-      "amplitude": 0.007163843530195066,
-      "phase": 57.13209619672722
+      "amplitude": 0.007,
+      "phase": 57.13
     },
     {
       "name": "EP2",
-      "amplitude": 0.029520302120149163,
-      "phase": 56.8412758410816
+      "amplitude": 0.03,
+      "phase": 56.84
     },
     {
       "name": "M3",
-      "amplitude": 0.0017370773768803315,
-      "phase": 11.012580670056423
+      "amplitude": 0.002,
+      "phase": 11.01
     },
     {
       "name": "MU2",
-      "amplitude": 0.1272191594442854,
-      "phase": 80.21308945755743
+      "amplitude": 0.127,
+      "phase": 80.21
     },
     {
       "name": "MTM",
-      "amplitude": 0.006663264047579226,
-      "phase": 232.02020688099572
+      "amplitude": 0.007,
+      "phase": 232.02
     },
     {
       "name": "NU2",
-      "amplitude": 0.07087229038555147,
-      "phase": 310.9409394794762
+      "amplitude": 0.071,
+      "phase": 310.94
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.046114535083026,
-      "phase": 4.316771281632953
+      "amplitude": 0.046,
+      "phase": 4.32
     },
     {
       "name": "MN4",
-      "amplitude": 0.03353550923908141,
-      "phase": 167.58270754666546
+      "amplitude": 0.034,
+      "phase": 167.58
     },
     {
       "name": "MS4",
-      "amplitude": 0.05714926055396152,
-      "phase": 263.74083692253197
+      "amplitude": 0.057,
+      "phase": 263.74
     },
     {
       "name": "N4",
-      "amplitude": 0.007064365740523236,
-      "phase": 146.09682879426612
+      "amplitude": 0.007,
+      "phase": 146.1
     },
     {
       "name": "M6",
-      "amplitude": 0.03396287804385339,
-      "phase": 41.24328514062154
+      "amplitude": 0.034,
+      "phase": 41.24
     },
     {
       "name": "M8",
-      "amplitude": 0.010234397310207546,
-      "phase": 242.91578796357675
+      "amplitude": 0.01,
+      "phase": 242.92
     },
     {
       "name": "S4",
-      "amplitude": 0.004306316536421424,
-      "phase": 26.305776543385093
+      "amplitude": 0.004,
+      "phase": 26.31
     },
     {
       "name": "OO1",
-      "amplitude": 0.0024700281717943444,
-      "phase": 224.82208997641035
+      "amplitude": 0.002,
+      "phase": 224.82
     },
     {
       "name": "S3",
-      "amplitude": 0.0003779351153583341,
-      "phase": 178.12669331783354
+      "amplitude": 0,
+      "phase": 178.13
     },
     {
       "name": "MA2",
-      "amplitude": 0.03834666808777161,
-      "phase": 297.09744136721423
+      "amplitude": 0.038,
+      "phase": 297.1
     },
     {
       "name": "MB2",
-      "amplitude": 0.021316536946953048,
-      "phase": 58.3074782646425
+      "amplitude": 0.021,
+      "phase": 58.31
     },
     {
       "name": "T3",
-      "amplitude": 0.0003398415455538534,
-      "phase": 215.66142090158212
+      "amplitude": 0,
+      "phase": 215.66
     },
     {
       "name": "R3",
-      "amplitude": 0.0015539048077734753,
-      "phase": 19.99519442088831
+      "amplitude": 0.002,
+      "phase": 20
     },
     {
       "name": "RHO1",
-      "amplitude": 0.006303564974412436,
-      "phase": 197.72274579590731
+      "amplitude": 0.006,
+      "phase": 197.72
     },
     {
       "name": "SGM",
-      "amplitude": 0.0021966553004298707,
-      "phase": 60.56170975332225
+      "amplitude": 0.002,
+      "phase": 60.56
     },
     {
       "name": "3L2",
-      "amplitude": 0.003225584553160422,
-      "phase": 265.05850210019173
+      "amplitude": 0.003,
+      "phase": 265.06
     },
     {
       "name": "3N2",
-      "amplitude": 0.013223690106388459,
-      "phase": 146.4099379244841
+      "amplitude": 0.013,
+      "phase": 146.41
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03061304408359451,
-      "phase": 285.92637186400617
+      "amplitude": 0.031,
+      "phase": 285.93
     },
     {
       "name": "2MS6",
-      "amplitude": 0.0303828396049182,
-      "phase": 107.09867407622255
+      "amplitude": 0.03,
+      "phase": 107.1
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00424022395055873,
-      "phase": 99.56860570240906
+      "amplitude": 0.004,
+      "phase": 99.57
     },
     {
       "name": "2MO5",
-      "amplitude": 0.005033364697458093,
-      "phase": 310.5452931376428
+      "amplitude": 0.005,
+      "phase": 310.55
     }
   ],
   "epoch": {

--- a/data/ticon/wittowerfhre-9670055-deu-wsv.json
+++ b/data/ticon/wittowerfhre-9670055-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.006089753179702242,
-      "phase": 272.82021020008983
+      "amplitude": 0.006,
+      "phase": 272.82
     },
     {
       "name": "N2",
-      "amplitude": 0.0013748994987275898,
-      "phase": 238.54045708376572
+      "amplitude": 0.001,
+      "phase": 238.54
     },
     {
       "name": "S2",
-      "amplitude": 0.0023416244523138006,
-      "phase": 260.56229265400304
+      "amplitude": 0.002,
+      "phase": 260.56
     },
     {
       "name": "K2",
-      "amplitude": 0.000590568947325511,
-      "phase": 243.71014592638042
+      "amplitude": 0.001,
+      "phase": 243.71
     },
     {
       "name": "2N2",
-      "amplitude": 0.00014305179824020546,
-      "phase": 217.2779427842211
+      "amplitude": 0,
+      "phase": 217.28
     },
     {
       "name": "S1",
-      "amplitude": 0.0008173882449222694,
-      "phase": 83.31239589215517
+      "amplitude": 0.001,
+      "phase": 83.31
     },
     {
       "name": "K1",
-      "amplitude": 0.004885860398870059,
-      "phase": 211.01498483778587
+      "amplitude": 0.005,
+      "phase": 211.01
     },
     {
       "name": "P1",
-      "amplitude": 0.0012097394830603227,
-      "phase": 218.16347816961397
+      "amplitude": 0.001,
+      "phase": 218.16
     },
     {
       "name": "O1",
-      "amplitude": 0.007637974854410346,
-      "phase": 184.37778682976185
+      "amplitude": 0.008,
+      "phase": 184.38
     },
     {
       "name": "Q1",
-      "amplitude": 0.0009700835532359567,
-      "phase": 131.6005135258498
+      "amplitude": 0.001,
+      "phase": 131.6
     },
     {
       "name": "M1",
-      "amplitude": 0.00025513254443791704,
-      "phase": 93.35833371802897
+      "amplitude": 0,
+      "phase": 93.36
     },
     {
       "name": "M4",
-      "amplitude": 0.0002448996278720475,
-      "phase": 248.60898305557606
+      "amplitude": 0,
+      "phase": 248.61
     },
     {
       "name": "MM",
-      "amplitude": 0.009913030905048727,
-      "phase": 272.94056910819273
+      "amplitude": 0.01,
+      "phase": 272.94
     },
     {
       "name": "MF",
-      "amplitude": 0.0063339717645013085,
-      "phase": 267.2593748767214
+      "amplitude": 0.006,
+      "phase": 267.26
     },
     {
       "name": "SA",
-      "amplitude": 0.04476953637153409,
-      "phase": 205.15954344714828
+      "amplitude": 0.045,
+      "phase": 205.16
     },
     {
       "name": "SSA",
-      "amplitude": 0.038357870043576534,
-      "phase": 241.77115636860947
+      "amplitude": 0.038,
+      "phase": 241.77
     },
     {
       "name": "T2",
-      "amplitude": 0.00003309009409767299,
-      "phase": 265.9168744966754
+      "amplitude": 0,
+      "phase": 265.92
     },
     {
       "name": "J1",
-      "amplitude": 0.00028580193129980656,
-      "phase": 218.0596317588805
+      "amplitude": 0,
+      "phase": 218.06
     },
     {
       "name": "L2",
-      "amplitude": 0.0003630557981019134,
-      "phase": 16.41413146484274
+      "amplitude": 0,
+      "phase": 16.41
     },
     {
       "name": "R2",
-      "amplitude": 0.0002253357179494188,
-      "phase": 327.78943630957053
+      "amplitude": 0,
+      "phase": 327.79
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00006598003499035147,
-      "phase": 114.98754017918691
+      "amplitude": 0,
+      "phase": 114.99
     },
     {
       "name": "MSF",
-      "amplitude": 0.0019924524473432137,
-      "phase": 273.39744992389654
+      "amplitude": 0.002,
+      "phase": 273.4
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0026064443706800486,
-      "phase": 200.33005331666195
+      "amplitude": 0.003,
+      "phase": 200.33
     },
     {
       "name": "EP2",
-      "amplitude": 0.00019015706264174448,
-      "phase": 50.27552098909052
+      "amplitude": 0,
+      "phase": 50.28
     },
     {
       "name": "M3",
-      "amplitude": 0.00014897698500142888,
-      "phase": 236.50651852956307
+      "amplitude": 0,
+      "phase": 236.51
     },
     {
       "name": "MU2",
-      "amplitude": 0.0005524220395608489,
-      "phase": 98.16470053295569
+      "amplitude": 0.001,
+      "phase": 98.16
     },
     {
       "name": "MTM",
-      "amplitude": 0.0024814370644138262,
-      "phase": 336.653124304597
+      "amplitude": 0.002,
+      "phase": 336.65
     },
     {
       "name": "NU2",
-      "amplitude": 0.000493608292748102,
-      "phase": 278.2824404150299
+      "amplitude": 0,
+      "phase": 278.28
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00018530825482948764,
-      "phase": 21.05266918058294
+      "amplitude": 0,
+      "phase": 21.05
     },
     {
       "name": "MN4",
-      "amplitude": 0.00007798357457412273,
-      "phase": 195.9791678057043
+      "amplitude": 0,
+      "phase": 195.98
     },
     {
       "name": "MS4",
-      "amplitude": 0.00011706092658202462,
-      "phase": 34.990823810289385
+      "amplitude": 0,
+      "phase": 34.99
     },
     {
       "name": "N4",
-      "amplitude": 0.000041889165693827336,
-      "phase": 198.55877390125178
+      "amplitude": 0,
+      "phase": 198.56
     },
     {
       "name": "M6",
-      "amplitude": 0.000042171357211357804,
-      "phase": 273.3863173243693
+      "amplitude": 0,
+      "phase": 273.39
     },
     {
       "name": "M8",
-      "amplitude": 0.000027409565021386498,
-      "phase": 276.3950517622705
+      "amplitude": 0,
+      "phase": 276.4
     },
     {
       "name": "S4",
-      "amplitude": 7.566797674663404e-7,
-      "phase": 280.7778726222725
+      "amplitude": 0,
+      "phase": 280.78
     },
     {
       "name": "OO1",
-      "amplitude": 0.0002572861694671221,
-      "phase": 189.5772608781828
+      "amplitude": 0,
+      "phase": 189.58
     },
     {
       "name": "S3",
-      "amplitude": 0.0001289641906978643,
-      "phase": 289.9700501610827
+      "amplitude": 0,
+      "phase": 289.97
     },
     {
       "name": "MA2",
-      "amplitude": 0.00039526658352437554,
-      "phase": 201.62385610928138
+      "amplitude": 0,
+      "phase": 201.62
     },
     {
       "name": "MB2",
-      "amplitude": 0.0008946165987876549,
-      "phase": 62.08991043096489
+      "amplitude": 0.001,
+      "phase": 62.09
     },
     {
       "name": "T3",
-      "amplitude": 0.00016178088639320185,
-      "phase": 224.75063856813497
+      "amplitude": 0,
+      "phase": 224.75
     },
     {
       "name": "R3",
-      "amplitude": 0.00019406957072671502,
-      "phase": 336.54024461740624
+      "amplitude": 0,
+      "phase": 336.54
     },
     {
       "name": "RHO1",
-      "amplitude": 0.0001467948114437269,
-      "phase": 140.0343862759068
+      "amplitude": 0,
+      "phase": 140.03
     },
     {
       "name": "SGM",
-      "amplitude": 0.0006267525786493626,
-      "phase": 289.5459706892631
+      "amplitude": 0.001,
+      "phase": 289.55
     },
     {
       "name": "3L2",
-      "amplitude": 0.00008981314921126616,
-      "phase": 158.17354866354503
+      "amplitude": 0,
+      "phase": 158.17
     },
     {
       "name": "3N2",
-      "amplitude": 0.00009582532050916283,
-      "phase": 143.95647406984972
+      "amplitude": 0,
+      "phase": 143.96
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00023055316058494195,
-      "phase": 14.079397385596849
+      "amplitude": 0,
+      "phase": 14.08
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000042069418909139805,
-      "phase": 221.13112969908912
+      "amplitude": 0,
+      "phase": 221.13
     },
     {
       "name": "2MK5",
-      "amplitude": 0.000006577221296559092,
-      "phase": 140.27043674510378
+      "amplitude": 0,
+      "phase": 140.27
     },
     {
       "name": "2MO5",
-      "amplitude": 0.000060702898176038125,
-      "phase": 156.23247044192215
+      "amplitude": 0,
+      "phase": 156.23
     }
   ],
   "epoch": {

--- a/data/ticon/wolgast-9650080-deu-wsv.json
+++ b/data/ticon/wolgast-9650080-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 0.0045266362543980075,
-      "phase": 341.3204709619753
+      "amplitude": 0.005,
+      "phase": 341.32
     },
     {
       "name": "N2",
-      "amplitude": 0.0013522963073233046,
-      "phase": 295.5959971762467
+      "amplitude": 0.001,
+      "phase": 295.6
     },
     {
       "name": "S2",
-      "amplitude": 0.0007071640597257232,
-      "phase": 308.0742495915375
+      "amplitude": 0.001,
+      "phase": 308.07
     },
     {
       "name": "K2",
-      "amplitude": 0.00048071176545723014,
-      "phase": 274.53385652381354
+      "amplitude": 0,
+      "phase": 274.53
     },
     {
       "name": "2N2",
-      "amplitude": 0.0002366740544341063,
-      "phase": 309.1524742150175
+      "amplitude": 0,
+      "phase": 309.15
     },
     {
       "name": "S1",
-      "amplitude": 0.002771956684138725,
-      "phase": 76.99424251110395
+      "amplitude": 0.003,
+      "phase": 76.99
     },
     {
       "name": "K1",
-      "amplitude": 0.003623183965066869,
-      "phase": 183.35505695207425
+      "amplitude": 0.004,
+      "phase": 183.36
     },
     {
       "name": "P1",
-      "amplitude": 0.0005084387980980695,
-      "phase": 151.06926488637941
+      "amplitude": 0.001,
+      "phase": 151.07
     },
     {
       "name": "O1",
-      "amplitude": 0.006407438545764676,
-      "phase": 179.17075818126
+      "amplitude": 0.006,
+      "phase": 179.17
     },
     {
       "name": "Q1",
-      "amplitude": 0.0010589230841998884,
-      "phase": 141.35731088575312
+      "amplitude": 0.001,
+      "phase": 141.36
     },
     {
       "name": "M1",
-      "amplitude": 0.000218840254612632,
-      "phase": 64.19143453441131
+      "amplitude": 0,
+      "phase": 64.19
     },
     {
       "name": "M4",
-      "amplitude": 0.0002770479418079839,
-      "phase": 16.317705670092096
+      "amplitude": 0,
+      "phase": 16.32
     },
     {
       "name": "MM",
-      "amplitude": 0.010982475524032663,
-      "phase": 287.3534023997528
+      "amplitude": 0.011,
+      "phase": 287.35
     },
     {
       "name": "MF",
-      "amplitude": 0.007763657067816296,
-      "phase": 282.45951435369534
+      "amplitude": 0.008,
+      "phase": 282.46
     },
     {
       "name": "SA",
-      "amplitude": 0.03427060081567568,
-      "phase": 204.5987630212461
+      "amplitude": 0.034,
+      "phase": 204.6
     },
     {
       "name": "SSA",
-      "amplitude": 0.034012475757401434,
-      "phase": 250.99421042539106
+      "amplitude": 0.034,
+      "phase": 250.99
     },
     {
       "name": "T2",
-      "amplitude": 0.00043500506362671,
-      "phase": 263.79682000789194
+      "amplitude": 0,
+      "phase": 263.8
     },
     {
       "name": "J1",
-      "amplitude": 0.00040179473721988233,
-      "phase": 229.55112252174038
+      "amplitude": 0,
+      "phase": 229.55
     },
     {
       "name": "L2",
-      "amplitude": 0.0005091508723359492,
-      "phase": 98.86232142502922
+      "amplitude": 0.001,
+      "phase": 98.86
     },
     {
       "name": "R2",
-      "amplitude": 0.00043573323603047267,
-      "phase": 62.31405609987581
+      "amplitude": 0,
+      "phase": 62.31
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00013182543016988186,
-      "phase": 92.97456893629163
+      "amplitude": 0,
+      "phase": 92.97
     },
     {
       "name": "MSF",
-      "amplitude": 0.0010363175097318643,
-      "phase": 270.81334931760676
+      "amplitude": 0.001,
+      "phase": 270.81
     },
     {
       "name": "MSQM",
-      "amplitude": 0.003170983050363766,
-      "phase": 210.1861621400396
+      "amplitude": 0.003,
+      "phase": 210.19
     },
     {
       "name": "EP2",
-      "amplitude": 0.00018211879969472154,
-      "phase": 113.01652754413686
+      "amplitude": 0,
+      "phase": 113.02
     },
     {
       "name": "M3",
-      "amplitude": 0.00023324134793566717,
-      "phase": 322.3454079435476
+      "amplitude": 0,
+      "phase": 322.35
     },
     {
       "name": "MU2",
-      "amplitude": 0.0008890732071829238,
-      "phase": 169.2132860948402
+      "amplitude": 0.001,
+      "phase": 169.21
     },
     {
       "name": "MTM",
-      "amplitude": 0.0032603701470373192,
-      "phase": 9.88800293080169
+      "amplitude": 0.003,
+      "phase": 9.89
     },
     {
       "name": "NU2",
-      "amplitude": 0.0004700636030162381,
-      "phase": 348.62966974430594
+      "amplitude": 0,
+      "phase": 348.63
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.00018252718363986878,
-      "phase": 104.51628062845384
+      "amplitude": 0,
+      "phase": 104.52
     },
     {
       "name": "MN4",
-      "amplitude": 0.00013933163827271883,
-      "phase": 305.34150775615194
+      "amplitude": 0,
+      "phase": 305.34
     },
     {
       "name": "MS4",
-      "amplitude": 0.00015625540689134267,
-      "phase": 174.1762371590031
+      "amplitude": 0,
+      "phase": 174.18
     },
     {
       "name": "N4",
-      "amplitude": 0.0000394923971003219,
-      "phase": 269.3992263876166
+      "amplitude": 0,
+      "phase": 269.4
     },
     {
       "name": "M6",
-      "amplitude": 0.000019220689167743536,
-      "phase": 210.47902842726305
+      "amplitude": 0,
+      "phase": 210.48
     },
     {
       "name": "M8",
-      "amplitude": 0.00003458694766263818,
-      "phase": 258.74509670895293
+      "amplitude": 0,
+      "phase": 258.75
     },
     {
       "name": "S4",
-      "amplitude": 0.00003435409647122608,
-      "phase": 76.91654393281163
+      "amplitude": 0,
+      "phase": 76.92
     },
     {
       "name": "OO1",
-      "amplitude": 0.00021737359592209537,
-      "phase": 180.60753008339466
+      "amplitude": 0,
+      "phase": 180.61
     },
     {
       "name": "S3",
-      "amplitude": 0.0003275892784341731,
-      "phase": 10.998212742942485
+      "amplitude": 0,
+      "phase": 11
     },
     {
       "name": "MA2",
-      "amplitude": 0.0005795796925889764,
-      "phase": 354.50788914542295
+      "amplitude": 0.001,
+      "phase": 354.51
     },
     {
       "name": "MB2",
-      "amplitude": 0.00046637920086316584,
-      "phase": 141.3005074207653
+      "amplitude": 0,
+      "phase": 141.3
     },
     {
       "name": "T3",
-      "amplitude": 0.0002715906471269591,
-      "phase": 270.7027329498359
+      "amplitude": 0,
+      "phase": 270.7
     },
     {
       "name": "R3",
-      "amplitude": 0.0002431773984640227,
-      "phase": 15.518574521016433
+      "amplitude": 0,
+      "phase": 15.52
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00003406883423588125,
-      "phase": 227.4612166977351
+      "amplitude": 0,
+      "phase": 227.46
     },
     {
       "name": "SGM",
-      "amplitude": 0.000518094135092807,
-      "phase": 260.0554344957155
+      "amplitude": 0.001,
+      "phase": 260.06
     },
     {
       "name": "3L2",
-      "amplitude": 0.00007239900506922687,
-      "phase": 241.52903741228315
+      "amplitude": 0,
+      "phase": 241.53
     },
     {
       "name": "3N2",
-      "amplitude": 0.0001228407385610277,
-      "phase": 280.3211149540516
+      "amplitude": 0,
+      "phase": 280.32
     },
     {
       "name": "2SM2",
-      "amplitude": 0.00021834586703820834,
-      "phase": 71.60191336423736
+      "amplitude": 0,
+      "phase": 71.6
     },
     {
       "name": "2MS6",
-      "amplitude": 0.000023730886935652673,
-      "phase": 178.14999335507378
+      "amplitude": 0,
+      "phase": 178.15
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00001721434659811335,
-      "phase": 87.42255552096287
+      "amplitude": 0,
+      "phase": 87.42
     },
     {
       "name": "2MO5",
-      "amplitude": 0.000015631558467282747,
-      "phase": 334.62875339022935
+      "amplitude": 0,
+      "phase": 334.63
     }
   ],
   "epoch": {

--- a/data/ticon/yerseke-yerske-nld-rws.json
+++ b/data/ticon/yerseke-yerske-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.39806692,
-      "phase": 82.36237
+      "amplitude": 1.448,
+      "phase": 65.43
     },
     {
       "name": "N2",
-      "amplitude": 0.21639963,
-      "phase": 57.82748600000002
+      "amplitude": 0.224,
+      "phase": 41.72
     },
     {
       "name": "S2",
-      "amplitude": 0.35350629,
-      "phase": 146.96313299999997
+      "amplitude": 0.364,
+      "phase": 129.34
     },
     {
       "name": "K2",
-      "amplitude": 0.10162022,
-      "phase": 153.266115
+      "amplitude": 0.108,
+      "phase": 129.39
     },
     {
       "name": "2N2",
-      "amplitude": 0.033238699999999996,
-      "phase": 34.92629499999998
+      "amplitude": 0.035,
+      "phase": 23.06
     },
     {
       "name": "S1",
-      "amplitude": 0.00816447,
-      "phase": 50.92880200000002
+      "amplitude": 0.008,
+      "phase": 334.05
     },
     {
       "name": "K1",
-      "amplitude": 0.07045204,
-      "phase": 23.08436499999999
+      "amplitude": 0.071,
+      "phase": 14.41
     },
     {
       "name": "P1",
-      "amplitude": 0.03919473,
-      "phase": 6.546737000000007
+      "amplitude": 0.039,
+      "phase": 359.73
     },
     {
       "name": "O1",
-      "amplitude": 0.10257428,
-      "phase": 206.734296
+      "amplitude": 0.103,
+      "phase": 198.39
     },
     {
       "name": "Q1",
-      "amplitude": 0.03524977,
-      "phase": 149.75775
+      "amplitude": 0.035,
+      "phase": 141.58
     },
     {
       "name": "M1",
-      "amplitude": 0.00427995,
-      "phase": 26.67620199999999
+      "amplitude": 0.003,
+      "phase": 48.64
     },
     {
       "name": "M4",
-      "amplitude": 0.09109952,
-      "phase": 189.24848
+      "amplitude": 0.105,
+      "phase": 154.33
     },
     {
       "name": "MM",
-      "amplitude": 0.01294246,
-      "phase": 49.85144100000002
+      "amplitude": 0.013,
+      "phase": 49.11
     },
     {
       "name": "MF",
-      "amplitude": 0.00723425,
-      "phase": 34.97421300000002
+      "amplitude": 0.007,
+      "phase": 35.6
     },
     {
       "name": "SA",
-      "amplitude": 0.06851375,
-      "phase": 219.654201
+      "amplitude": 0.07,
+      "phase": 219.32
     },
     {
       "name": "SSA",
-      "amplitude": 0.01815313,
-      "phase": 249.975507
+      "amplitude": 0.017,
+      "phase": 249.64
     },
     {
       "name": "T2",
-      "amplitude": 0.06271087,
-      "phase": 66.286181
+      "amplitude": 0.022,
+      "phase": 121.97
     },
     {
       "name": "J1",
-      "amplitude": 0.00512841,
-      "phase": 156.53310399999998
+      "amplitude": 0.005,
+      "phase": 146.05
     },
     {
       "name": "L2",
-      "amplitude": 0.11248030999999999,
-      "phase": 101.15487100000001
+      "amplitude": 0.117,
+      "phase": 82.71
     },
     {
       "name": "R2",
-      "amplitude": 0.047246800000000005,
-      "phase": 245.56962900000002
+      "amplitude": 0.005,
+      "phase": 177.29
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00521223,
-      "phase": 104.814975
+      "amplitude": 0.005,
+      "phase": 99.51
     },
     {
       "name": "MSF",
-      "amplitude": 0.0321331,
-      "phase": 49.996939
+      "amplitude": 0.032,
+      "phase": 50.65
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0059732,
-      "phase": 79.850254
+      "amplitude": 0.006,
+      "phase": 82.36
     },
     {
       "name": "EP2",
-      "amplitude": 0.02977251,
-      "phase": 163.29162599999995
+      "amplitude": 0.03,
+      "phase": 148.04
     },
     {
       "name": "M3",
-      "amplitude": 0.0046764400000000005,
-      "phase": 201.389503
+      "amplitude": 0.005,
+      "phase": 356.39
     },
     {
       "name": "MU2",
-      "amplitude": 0.14880986999999998,
-      "phase": 183.915581
+      "amplitude": 0.155,
+      "phase": 167.57
     },
     {
       "name": "MTM",
-      "amplitude": 0.00571495,
-      "phase": 223.217199
+      "amplitude": 0.006,
+      "phase": 218.09
     },
     {
       "name": "NU2",
-      "amplitude": 0.08691135,
-      "phase": 45.02946400000002
+      "amplitude": 0.088,
+      "phase": 28.73
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05471805,
-      "phase": 97.63222100000002
+      "amplitude": 0.057,
+      "phase": 78.41
     },
     {
       "name": "MN4",
-      "amplitude": 0.030572339999999996,
-      "phase": 163.60625099999993
+      "amplitude": 0.036,
+      "phase": 129.11
     },
     {
       "name": "MS4",
-      "amplitude": 0.05691563,
-      "phase": 243.720068
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.061292650000000004,
-      "phase": 219.451537
+      "amplitude": 0.065,
+      "phase": 209.83
     },
     {
       "name": "N4",
-      "amplitude": 0.00757835,
-      "phase": 146.900146
+      "amplitude": 0.009,
+      "phase": 111.17
     },
     {
       "name": "M6",
-      "amplitude": 0.051214300000000004,
-      "phase": 230.662328
+      "amplitude": 0.073,
+      "phase": 175.97
     },
     {
       "name": "M8",
-      "amplitude": 0.00145838,
-      "phase": 227.379111
+      "amplitude": 0.002,
+      "phase": 158.45
     },
     {
       "name": "S4",
-      "amplitude": 0.0033274,
-      "phase": 355.630071
+      "amplitude": 0.004,
+      "phase": 317.57
     },
     {
       "name": "OO1",
-      "amplitude": 0.00451096,
-      "phase": 173.91584699999999
+      "amplitude": 0.004,
+      "phase": 148.45
     },
     {
       "name": "S3",
-      "amplitude": 0.00147847,
-      "phase": 125.38612899999998
+      "amplitude": 0,
+      "phase": 134.12
     },
     {
       "name": "MA2",
-      "amplitude": 0.24774560999999998,
-      "phase": 60.82537400000001
+      "amplitude": 0.022,
+      "phase": 46.28
     },
     {
       "name": "MB2",
-      "amplitude": 0.23349678999999998,
-      "phase": 274.905287
+      "amplitude": 0.019,
+      "phase": 205.68
     },
     {
       "name": "T3",
-      "amplitude": 0.0020088700000000003,
-      "phase": 111.06446499999998
+      "amplitude": 0.003,
+      "phase": 280.34
     },
     {
       "name": "R3",
-      "amplitude": 0.0047037699999999995,
-      "phase": 342.58351
+      "amplitude": 0.005,
+      "phase": 38.46
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00607695,
-      "phase": 140.836316
+      "amplitude": 0.006,
+      "phase": 139.75
     },
     {
       "name": "SGM",
-      "amplitude": 0.00342001,
-      "phase": 109.21162099999998
+      "amplitude": 0.004,
+      "phase": 281.81
     },
     {
       "name": "3L2",
-      "amplitude": 0.0078883,
-      "phase": 253.747769
+      "amplitude": 0.011,
+      "phase": 341.28
     },
     {
       "name": "3N2",
-      "amplitude": 0.0030792999999999997,
-      "phase": 110.50659100000001
+      "amplitude": 0.014,
+      "phase": 229.23
     },
     {
       "name": "2SM2",
-      "amplitude": 0.04066694,
-      "phase": 8.180354000000023
+      "amplitude": 0.041,
+      "phase": 353.26
     },
     {
       "name": "2MS6",
-      "amplitude": 0.04513686,
-      "phase": 283.533385
+      "amplitude": 0.063,
+      "phase": 228.36
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0027751300000000002,
-      "phase": 175.63073199999997
+      "amplitude": 0.004,
+      "phase": 209.24
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00186938,
-      "phase": 65.41853800000001
+      "amplitude": 0.002,
+      "phase": 300.27
     }
   ],
   "epoch": {

--- a/data/ticon/zeelandbrug_noord-zeelbnd-nld-rws.json
+++ b/data/ticon/zeelandbrug_noord-zeelbnd-nld-rws.json
@@ -34,253 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.31222363,
-      "phase": 73.74570900000003
+      "amplitude": 1.358,
+      "phase": 58.92
     },
     {
       "name": "N2",
-      "amplitude": 0.21009397,
-      "phase": 50.09124099999997
+      "amplitude": 0.214,
+      "phase": 35.19
     },
     {
       "name": "S2",
-      "amplitude": 0.32761904999999997,
-      "phase": 135.121262
+      "amplitude": 0.34,
+      "phase": 120.43
     },
     {
       "name": "K2",
-      "amplitude": 0.09320243,
-      "phase": 135.83950800000002
+      "amplitude": 0.096,
+      "phase": 121.11
     },
     {
       "name": "2N2",
-      "amplitude": 0.02876041,
-      "phase": 23.479804
+      "amplitude": 0.03,
+      "phase": 7.92
     },
     {
       "name": "S1",
-      "amplitude": 0.0073402699999999994,
-      "phase": 46.949454
+      "amplitude": 0.008,
+      "phase": 325.46
     },
     {
       "name": "K1",
-      "amplitude": 0.06681625000000001,
-      "phase": 15.865511000000026
+      "amplitude": 0.067,
+      "phase": 8.32
     },
     {
       "name": "P1",
-      "amplitude": 0.034883069999999995,
-      "phase": 1.9781679999999824
+      "amplitude": 0.035,
+      "phase": 353.36
     },
     {
       "name": "O1",
-      "amplitude": 0.10051121,
-      "phase": 198.236531
+      "amplitude": 0.101,
+      "phase": 190.99
     },
     {
       "name": "Q1",
-      "amplitude": 0.03519775,
-      "phase": 147.864508
+      "amplitude": 0.035,
+      "phase": 141.3
     },
     {
       "name": "M1",
-      "amplitude": 0.008718759999999999,
-      "phase": 40.178675
+      "amplitude": 0.001,
+      "phase": 97.58
     },
     {
       "name": "M4",
-      "amplitude": 0.054191539999999996,
-      "phase": 151.852887
+      "amplitude": 0.063,
+      "phase": 122.6
     },
     {
       "name": "MM",
-      "amplitude": 0.0118232,
-      "phase": 152.298181
+      "amplitude": 0.012,
+      "phase": 152.9
     },
     {
       "name": "MF",
-      "amplitude": 0.00347912,
-      "phase": 113.38162
+      "amplitude": 0.003,
+      "phase": 113.01
     },
     {
       "name": "SA",
-      "amplitude": 0.07467107,
-      "phase": 214.023119
+      "amplitude": 0.074,
+      "phase": 213.98
     },
     {
       "name": "SSA",
-      "amplitude": 0.0112315,
-      "phase": 139.839248
+      "amplitude": 0.011,
+      "phase": 139.71
     },
     {
       "name": "T2",
-      "amplitude": 0.06690457,
-      "phase": 63.849155999999994
+      "amplitude": 0.015,
+      "phase": 116.63
     },
     {
       "name": "J1",
-      "amplitude": 0.00410126,
-      "phase": 125.848184
+      "amplitude": 0.004,
+      "phase": 117.25
     },
     {
       "name": "L2",
-      "amplitude": 0.10139811,
-      "phase": 89.57395700000001
+      "amplitude": 0.103,
+      "phase": 75.19
     },
     {
       "name": "R2",
-      "amplitude": 0.03918856,
-      "phase": 221.558153
+      "amplitude": 0.003,
+      "phase": 192.99
     },
     {
       "name": "2Q1",
-      "amplitude": 0.00741284,
-      "phase": 117.532531
+      "amplitude": 0.007,
+      "phase": 111.94
     },
     {
       "name": "MSF",
-      "amplitude": 0.05094161,
-      "phase": 33.09512599999999
+      "amplitude": 0.052,
+      "phase": 33.2
     },
     {
       "name": "MSQM",
-      "amplitude": 0.0028276,
-      "phase": 210.889483
+      "amplitude": 0.003,
+      "phase": 214.7
     },
     {
       "name": "EP2",
-      "amplitude": 0.02851818,
-      "phase": 158.07005100000003
+      "amplitude": 0.029,
+      "phase": 145.84
     },
     {
       "name": "M3",
-      "amplitude": 0.00224238,
-      "phase": 181.898313
+      "amplitude": 0.002,
+      "phase": 339.01
     },
     {
       "name": "MU2",
-      "amplitude": 0.13558751000000002,
-      "phase": 175.92128100000002
+      "amplitude": 0.141,
+      "phase": 162.57
     },
     {
       "name": "MTM",
-      "amplitude": 0.00414076,
-      "phase": 85.408322
+      "amplitude": 0.004,
+      "phase": 92.16
     },
     {
       "name": "NU2",
-      "amplitude": 0.07967225,
-      "phase": 37.800501999999994
+      "amplitude": 0.082,
+      "phase": 22.97
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.04876697,
-      "phase": 89.97206499999999
+      "amplitude": 0.053,
+      "phase": 77.62
     },
     {
       "name": "MN4",
-      "amplitude": 0.01753064,
-      "phase": 128.65257399999996
+      "amplitude": 0.02,
+      "phase": 99.56
     },
     {
       "name": "MS4",
-      "amplitude": 0.03612492,
-      "phase": 203.639482
-    },
-    {
-      "name": "MKS2",
-      "amplitude": 0.02228017,
-      "phase": 257.56726100000003
+      "amplitude": 0.043,
+      "phase": 174.81
     },
     {
       "name": "N4",
-      "amplitude": 0.0031972899999999998,
-      "phase": 117.682882
+      "amplitude": 0.004,
+      "phase": 78.89
     },
     {
       "name": "M6",
-      "amplitude": 0.01527575,
-      "phase": 138.00338899999997
+      "amplitude": 0.023,
+      "phase": 88.6
     },
     {
       "name": "M8",
-      "amplitude": 0.00571577,
-      "phase": 101.27834899999999
+      "amplitude": 0.012,
+      "phase": 37.43
     },
     {
       "name": "S4",
-      "amplitude": 0.00282604,
-      "phase": 289.568461
+      "amplitude": 0.003,
+      "phase": 259.3
     },
     {
       "name": "OO1",
-      "amplitude": 0.005476450000000001,
-      "phase": 169.319429
+      "amplitude": 0.004,
+      "phase": 156.67
     },
     {
       "name": "S3",
-      "amplitude": 0.00242898,
-      "phase": 107.52857499999999
+      "amplitude": 0.001,
+      "phase": 240.13
     },
     {
       "name": "MA2",
-      "amplitude": 0.23460241,
-      "phase": 63.408544000000006
+      "amplitude": 0.024,
+      "phase": 6.64
     },
     {
       "name": "MB2",
-      "amplitude": 0.21999248999999998,
-      "phase": 254.99356799999998
+      "amplitude": 0.015,
+      "phase": 156.22
     },
     {
       "name": "T3",
-      "amplitude": 0.00150156,
-      "phase": 81.31333999999998
+      "amplitude": 0.002,
+      "phase": 251.4
     },
     {
       "name": "R3",
-      "amplitude": 0.005095420000000001,
-      "phase": 305.063775
+      "amplitude": 0.005,
+      "phase": 5.3
     },
     {
       "name": "RHO1",
-      "amplitude": 0.00994012,
-      "phase": 142.311938
+      "amplitude": 0.009,
+      "phase": 137.22
     },
     {
       "name": "SGM",
-      "amplitude": 0.00767389,
-      "phase": 83.96002399999998
+      "amplitude": 0.008,
+      "phase": 263.35
     },
     {
       "name": "3L2",
-      "amplitude": 0.00775585,
-      "phase": 229.273023
+      "amplitude": 0.006,
+      "phase": 290.68
     },
     {
       "name": "3N2",
-      "amplitude": 0.01629132,
-      "phase": 337.328037
+      "amplitude": 0.02,
+      "phase": 238.6
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03952911,
-      "phase": 3.999656000000016
+      "amplitude": 0.042,
+      "phase": 350.71
     },
     {
       "name": "2MS6",
-      "amplitude": 0.014278949999999999,
-      "phase": 180.545821
+      "amplitude": 0.022,
+      "phase": 133.82
     },
     {
       "name": "2MK5",
-      "amplitude": 0.00234372,
-      "phase": 158.38653799999997
+      "amplitude": 0.003,
+      "phase": 206.64
     },
     {
       "name": "2MO5",
-      "amplitude": 0.00033441,
-      "phase": 182.403768
+      "amplitude": 0,
+      "phase": 49.11
     }
   ],
   "epoch": {

--- a/data/ticon/zehnerloch-9510010-deu-wsv.json
+++ b/data/ticon/zehnerloch-9510010-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.3924425643534264,
-      "phase": 329.9487164794689
+      "amplitude": 1.392,
+      "phase": 329.95
     },
     {
       "name": "N2",
-      "amplitude": 0.22160297814199767,
-      "phase": 304.68878699579415
+      "amplitude": 0.222,
+      "phase": 304.69
     },
     {
       "name": "S2",
-      "amplitude": 0.36634938372133086,
-      "phase": 39.5789966723396
+      "amplitude": 0.366,
+      "phase": 39.58
     },
     {
       "name": "K2",
-      "amplitude": 0.10964111698337001,
-      "phase": 37.69106507285812
+      "amplitude": 0.11,
+      "phase": 37.69
     },
     {
       "name": "2N2",
-      "amplitude": 0.024738486926844522,
-      "phase": 283.35400681934436
+      "amplitude": 0.025,
+      "phase": 283.35
     },
     {
       "name": "S1",
-      "amplitude": 0.011995237178771186,
-      "phase": 30.28261922521267
+      "amplitude": 0.012,
+      "phase": 30.28
     },
     {
       "name": "K1",
-      "amplitude": 0.07074394787671852,
-      "phase": 33.36336562209726
+      "amplitude": 0.071,
+      "phase": 33.36
     },
     {
       "name": "P1",
-      "amplitude": 0.029573663384881176,
-      "phase": 38.12862031454432
+      "amplitude": 0.03,
+      "phase": 38.13
     },
     {
       "name": "O1",
-      "amplitude": 0.09291957555401742,
-      "phase": 243.3448215736057
+      "amplitude": 0.093,
+      "phase": 243.34
     },
     {
       "name": "Q1",
-      "amplitude": 0.029140138371220294,
-      "phase": 184.56741896023823
+      "amplitude": 0.029,
+      "phase": 184.57
     },
     {
       "name": "M1",
-      "amplitude": 0.0018319620514003771,
-      "phase": 96.13114631866677
+      "amplitude": 0.002,
+      "phase": 96.13
     },
     {
       "name": "M4",
-      "amplitude": 0.08264950901819113,
-      "phase": 184.90348910417364
+      "amplitude": 0.083,
+      "phase": 184.9
     },
     {
       "name": "MM",
-      "amplitude": 0.025631388204711437,
-      "phase": 170.62364918299318
+      "amplitude": 0.026,
+      "phase": 170.62
     },
     {
       "name": "MF",
-      "amplitude": 0.010640436572573995,
-      "phase": 157.33336695239404
+      "amplitude": 0.011,
+      "phase": 157.33
     },
     {
       "name": "SA",
-      "amplitude": 0.10034383892231215,
-      "phase": 219.05726596036078
+      "amplitude": 0.1,
+      "phase": 219.06
     },
     {
       "name": "SSA",
-      "amplitude": 0.04138200497538255,
-      "phase": 205.24203291748
+      "amplitude": 0.041,
+      "phase": 205.24
     },
     {
       "name": "T2",
-      "amplitude": 0.018774574228801407,
-      "phase": 19.715621415163014
+      "amplitude": 0.019,
+      "phase": 19.72
     },
     {
       "name": "J1",
-      "amplitude": 0.0026318427360546926,
-      "phase": 175.19468531837333
+      "amplitude": 0.003,
+      "phase": 175.19
     },
     {
       "name": "L2",
-      "amplitude": 0.11102181748173,
-      "phase": 347.6751458649696
+      "amplitude": 0.111,
+      "phase": 347.68
     },
     {
       "name": "R2",
-      "amplitude": 0.002529940894602449,
-      "phase": 359.13325128210863
+      "amplitude": 0.003,
+      "phase": 359.13
     },
     {
       "name": "2Q1",
-      "amplitude": 0.0064669112823751655,
-      "phase": 127.58646319842677
+      "amplitude": 0.006,
+      "phase": 127.59
     },
     {
       "name": "MSF",
-      "amplitude": 0.013164996947053465,
-      "phase": 46.535125534172096
+      "amplitude": 0.013,
+      "phase": 46.54
     },
     {
       "name": "MSQM",
-      "amplitude": 0.008908490005537398,
-      "phase": 65.47272974767804
+      "amplitude": 0.009,
+      "phase": 65.47
     },
     {
       "name": "EP2",
-      "amplitude": 0.03172262171086376,
-      "phase": 34.27906853827449
+      "amplitude": 0.032,
+      "phase": 34.28
     },
     {
       "name": "M3",
-      "amplitude": 0.004185270577516294,
-      "phase": 353.32058206434624
+      "amplitude": 0.004,
+      "phase": 353.32
     },
     {
       "name": "MU2",
-      "amplitude": 0.14129447435882933,
-      "phase": 58.451758989613154
+      "amplitude": 0.141,
+      "phase": 58.45
     },
     {
       "name": "MTM",
-      "amplitude": 0.004865667935429962,
-      "phase": 221.99000731217768
+      "amplitude": 0.005,
+      "phase": 221.99
     },
     {
       "name": "NU2",
-      "amplitude": 0.08070942059613283,
-      "phase": 289.48525153412805
+      "amplitude": 0.081,
+      "phase": 289.49
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.0531721847602771,
-      "phase": 341.105674892883
+      "amplitude": 0.053,
+      "phase": 341.11
     },
     {
       "name": "MN4",
-      "amplitude": 0.029708949667703502,
-      "phase": 165.4114641653763
+      "amplitude": 0.03,
+      "phase": 165.41
     },
     {
       "name": "MS4",
-      "amplitude": 0.05719668094755006,
-      "phase": 247.86844639121546
+      "amplitude": 0.057,
+      "phase": 247.87
     },
     {
       "name": "N4",
-      "amplitude": 0.006650107554828136,
-      "phase": 145.43128897634352
+      "amplitude": 0.007,
+      "phase": 145.43
     },
     {
       "name": "M6",
-      "amplitude": 0.05884701501754496,
-      "phase": 28.392318335879736
+      "amplitude": 0.059,
+      "phase": 28.39
     },
     {
       "name": "M8",
-      "amplitude": 0.009591460658104208,
-      "phase": 247.3859266880409
+      "amplitude": 0.01,
+      "phase": 247.39
     },
     {
       "name": "S4",
-      "amplitude": 0.007383755947633868,
-      "phase": 359.8964398503086
+      "amplitude": 0.007,
+      "phase": 359.9
     },
     {
       "name": "OO1",
-      "amplitude": 0.002596375253658601,
-      "phase": 189.7172170384443
+      "amplitude": 0.003,
+      "phase": 189.72
     },
     {
       "name": "S3",
-      "amplitude": 0.0006836122938929509,
-      "phase": 196.0324644089609
+      "amplitude": 0.001,
+      "phase": 196.03
     },
     {
       "name": "MA2",
-      "amplitude": 0.044270663015333694,
-      "phase": 272.3745459200147
+      "amplitude": 0.044,
+      "phase": 272.37
     },
     {
       "name": "MB2",
-      "amplitude": 0.02620724525060387,
-      "phase": 41.616352015892744
+      "amplitude": 0.026,
+      "phase": 41.62
     },
     {
       "name": "T3",
-      "amplitude": 0.00021812994721511845,
-      "phase": 48.33642395052158
+      "amplitude": 0,
+      "phase": 48.34
     },
     {
       "name": "R3",
-      "amplitude": 0.002360147227853485,
-      "phase": 17.99126852974365
+      "amplitude": 0.002,
+      "phase": 17.99
     },
     {
       "name": "RHO1",
-      "amplitude": 0.005961068931883732,
-      "phase": 195.38987105740233
+      "amplitude": 0.006,
+      "phase": 195.39
     },
     {
       "name": "SGM",
-      "amplitude": 0.002093140233816059,
-      "phase": 34.294617019523855
+      "amplitude": 0.002,
+      "phase": 34.29
     },
     {
       "name": "3L2",
-      "amplitude": 0.003910833450154923,
-      "phase": 245.09647461741804
+      "amplitude": 0.004,
+      "phase": 245.1
     },
     {
       "name": "3N2",
-      "amplitude": 0.016101014048847548,
-      "phase": 130.40854368518364
+      "amplitude": 0.016,
+      "phase": 130.41
     },
     {
       "name": "2SM2",
-      "amplitude": 0.03566073683177629,
-      "phase": 261.34448838841337
+      "amplitude": 0.036,
+      "phase": 261.34
     },
     {
       "name": "2MS6",
-      "amplitude": 0.05709404125656896,
-      "phase": 89.04029534100243
+      "amplitude": 0.057,
+      "phase": 89.04
     },
     {
       "name": "2MK5",
-      "amplitude": 0.0033603586828112497,
-      "phase": 56.33279077549895
+      "amplitude": 0.003,
+      "phase": 56.33
     },
     {
       "name": "2MO5",
-      "amplitude": 0.0037023720841638974,
-      "phase": 314.68159179289285
+      "amplitude": 0.004,
+      "phase": 314.68
     }
   ],
   "epoch": {

--- a/data/ticon/zollenspieker-5930090-deu-wsv.json
+++ b/data/ticon/zollenspieker-5930090-deu-wsv.json
@@ -34,248 +34,248 @@
   "harmonic_constituents": [
     {
       "name": "M2",
-      "amplitude": 1.2001221108297224,
-      "phase": 118.01851165659974
+      "amplitude": 1.2,
+      "phase": 118.02
     },
     {
       "name": "N2",
-      "amplitude": 0.1767544479989339,
-      "phase": 91.57012198537626
+      "amplitude": 0.177,
+      "phase": 91.57
     },
     {
       "name": "S2",
-      "amplitude": 0.271120638086702,
-      "phase": 198.18059677914576
+      "amplitude": 0.271,
+      "phase": 198.18
     },
     {
       "name": "K2",
-      "amplitude": 0.07742658795832254,
-      "phase": 199.03225923969117
+      "amplitude": 0.077,
+      "phase": 199.03
     },
     {
       "name": "2N2",
-      "amplitude": 0.018059761261226662,
-      "phase": 70.24309079132917
+      "amplitude": 0.018,
+      "phase": 70.24
     },
     {
       "name": "S1",
-      "amplitude": 0.018974586359907657,
-      "phase": 109.7098071438702
+      "amplitude": 0.019,
+      "phase": 109.71
     },
     {
       "name": "K1",
-      "amplitude": 0.06409186857307439,
-      "phase": 126.37085651092241
+      "amplitude": 0.064,
+      "phase": 126.37
     },
     {
       "name": "P1",
-      "amplitude": 0.02536738288594069,
-      "phase": 113.29158962566322
+      "amplitude": 0.025,
+      "phase": 113.29
     },
     {
       "name": "O1",
-      "amplitude": 0.0783566959382078,
-      "phase": 327.79967920586915
+      "amplitude": 0.078,
+      "phase": 327.8
     },
     {
       "name": "Q1",
-      "amplitude": 0.02095483882174602,
-      "phase": 264.77431121988013
+      "amplitude": 0.021,
+      "phase": 264.77
     },
     {
       "name": "M1",
-      "amplitude": 0.0021161022903315326,
-      "phase": 172.60288580556335
+      "amplitude": 0.002,
+      "phase": 172.6
     },
     {
       "name": "M4",
-      "amplitude": 0.1818361008506818,
-      "phase": 159.26594359953958
+      "amplitude": 0.182,
+      "phase": 159.27
     },
     {
       "name": "MM",
-      "amplitude": 0.019027158381056734,
-      "phase": 86.8614197339445
+      "amplitude": 0.019,
+      "phase": 86.86
     },
     {
       "name": "MF",
-      "amplitude": 0.02092543174787474,
-      "phase": 83.27823768651837
+      "amplitude": 0.021,
+      "phase": 83.28
     },
     {
       "name": "SA",
-      "amplitude": 0.2442957662672192,
-      "phase": 323.9850143688113
+      "amplitude": 0.244,
+      "phase": 323.99
     },
     {
       "name": "SSA",
-      "amplitude": 0.07756998489018346,
-      "phase": 294.94147203510073
+      "amplitude": 0.078,
+      "phase": 294.94
     },
     {
       "name": "T2",
-      "amplitude": 0.0031526789484847546,
-      "phase": 240.03579302101258
+      "amplitude": 0.003,
+      "phase": 240.04
     },
     {
       "name": "J1",
-      "amplitude": 0.006658912144189583,
-      "phase": 253.33011258957754
+      "amplitude": 0.007,
+      "phase": 253.33
     },
     {
       "name": "L2",
-      "amplitude": 0.11475402317335773,
-      "phase": 135.7572868937558
+      "amplitude": 0.115,
+      "phase": 135.76
     },
     {
       "name": "R2",
-      "amplitude": 0.020122390980472988,
-      "phase": 280.3930525078312
+      "amplitude": 0.02,
+      "phase": 280.39
     },
     {
       "name": "2Q1",
-      "amplitude": 0.005070287764984333,
-      "phase": 199.28794641641338
+      "amplitude": 0.005,
+      "phase": 199.29
     },
     {
       "name": "MSF",
-      "amplitude": 0.09202552590456667,
-      "phase": 66.19093030032491
+      "amplitude": 0.092,
+      "phase": 66.19
     },
     {
       "name": "MSQM",
-      "amplitude": 0.009136872635889064,
-      "phase": 25.353671981188768
+      "amplitude": 0.009,
+      "phase": 25.35
     },
     {
       "name": "EP2",
-      "amplitude": 0.03314210077231191,
-      "phase": 177.598095251004
+      "amplitude": 0.033,
+      "phase": 177.6
     },
     {
       "name": "M3",
-      "amplitude": 0.003635927227326324,
-      "phase": 205.61293291332026
+      "amplitude": 0.004,
+      "phase": 205.61
     },
     {
       "name": "MU2",
-      "amplitude": 0.17150998901469047,
-      "phase": 204.45108814326014
+      "amplitude": 0.172,
+      "phase": 204.45
     },
     {
       "name": "MTM",
-      "amplitude": 0.001719084046281006,
-      "phase": 208.2423934541137
+      "amplitude": 0.002,
+      "phase": 208.24
     },
     {
       "name": "NU2",
-      "amplitude": 0.08305988102042693,
-      "phase": 71.89958654565635
+      "amplitude": 0.083,
+      "phase": 71.9
     },
     {
       "name": "LAMBDA2",
-      "amplitude": 0.05244776094738326,
-      "phase": 137.2920850920883
+      "amplitude": 0.052,
+      "phase": 137.29
     },
     {
       "name": "MN4",
-      "amplitude": 0.058336406702472206,
-      "phase": 132.157397419909
+      "amplitude": 0.058,
+      "phase": 132.16
     },
     {
       "name": "MS4",
-      "amplitude": 0.09446722682179337,
-      "phase": 237.1754746779008
+      "amplitude": 0.094,
+      "phase": 237.18
     },
     {
       "name": "N4",
-      "amplitude": 0.011045738312553743,
-      "phase": 111.46477124532407
+      "amplitude": 0.011,
+      "phase": 111.46
     },
     {
       "name": "M6",
-      "amplitude": 0.02856262519612248,
-      "phase": 81.48469034744448
+      "amplitude": 0.029,
+      "phase": 81.48
     },
     {
       "name": "M8",
-      "amplitude": 0.018541079068527148,
-      "phase": 89.26714036683495
+      "amplitude": 0.019,
+      "phase": 89.27
     },
     {
       "name": "S4",
-      "amplitude": 0.006894996324767556,
-      "phase": 26.796078825874417
+      "amplitude": 0.007,
+      "phase": 26.8
     },
     {
       "name": "OO1",
-      "amplitude": 0.0023635955120966984,
-      "phase": 255.28471892736462
+      "amplitude": 0.002,
+      "phase": 255.28
     },
     {
       "name": "S3",
-      "amplitude": 0.0008530930098667101,
-      "phase": 113.56459120888269
+      "amplitude": 0.001,
+      "phase": 113.56
     },
     {
       "name": "MA2",
-      "amplitude": 0.06386793018516514,
-      "phase": 8.370582539067868
+      "amplitude": 0.064,
+      "phase": 8.37
     },
     {
       "name": "MB2",
-      "amplitude": 0.07277809106865113,
-      "phase": 280.17916792324485
+      "amplitude": 0.073,
+      "phase": 280.18
     },
     {
       "name": "T3",
-      "amplitude": 0.0017795220023956277,
-      "phase": 209.26489842269058
+      "amplitude": 0.002,
+      "phase": 209.26
     },
     {
       "name": "R3",
-      "amplitude": 0.0055478616627420065,
-      "phase": 237.80057568277687
+      "amplitude": 0.006,
+      "phase": 237.8
     },
     {
       "name": "RHO1",
-      "amplitude": 0.004559178850090481,
-      "phase": 272.84366004543017
+      "amplitude": 0.005,
+      "phase": 272.84
     },
     {
       "name": "SGM",
-      "amplitude": 0.005421622304127647,
-      "phase": 103.41346352936137
+      "amplitude": 0.005,
+      "phase": 103.41
     },
     {
       "name": "3L2",
-      "amplitude": 0.001994934833511416,
-      "phase": 75.12529003798574
+      "amplitude": 0.002,
+      "phase": 75.13
     },
     {
       "name": "3N2",
-      "amplitude": 0.03881045653873289,
-      "phase": 268.5520393489378
+      "amplitude": 0.039,
+      "phase": 268.55
     },
     {
       "name": "2SM2",
-      "amplitude": 0.029487363534265357,
-      "phase": 68.34556291389026
+      "amplitude": 0.029,
+      "phase": 68.35
     },
     {
       "name": "2MS6",
-      "amplitude": 0.025035287762398977,
-      "phase": 158.59493567983532
+      "amplitude": 0.025,
+      "phase": 158.59
     },
     {
       "name": "2MK5",
-      "amplitude": 0.002430208576481397,
-      "phase": 76.90022382515974
+      "amplitude": 0.002,
+      "phase": 76.9
     },
     {
       "name": "2MO5",
-      "amplitude": 0.002008270621526003,
-      "phase": 4.259382487098776
+      "amplitude": 0.002,
+      "phase": 4.26
     }
   ],
   "epoch": {

--- a/test/harmonic-analysis.test.ts
+++ b/test/harmonic-analysis.test.ts
@@ -60,4 +60,29 @@ describe("parseGeslaSamplesInZone", () => {
       "2020-07-01T10:00:00.000Z",
     );
   });
+
+  test("rws convention (fixed-1h-removed) recovers true UTC via Amsterdam + 1h", () => {
+    // rws files had a flat 1 h subtracted from Dutch legal time and were then
+    // mislabeled UTC, so stored = true_UTC + Amsterdam-DST-flag: winter rows are
+    // already true UTC, summer rows are 1 h fast. The import re-references them
+    // by parsing in Europe/Amsterdam then re-adding the 1 h. See issue #98.
+    const HOUR = 3_600_000;
+    const text = [
+      "# NULL VALUE -99.9999",
+      "#",
+      "2020/01/01 12:00:00 1.0 1 1", // winter: stored == true UTC 12:00
+      "2020/07/01 11:00:00 2.0 1 1", // summer: stored is 1 h fast of true UTC 10:00
+    ].join("\n");
+
+    const corrected = parseGeslaSamplesInZone(text, "Europe/Amsterdam").map(
+      (s) => ({ t: s.t + HOUR, level: s.level }),
+    );
+    expect(corrected).toHaveLength(2);
+    expect(new Date(corrected[0]!.t).toISOString()).toBe(
+      "2020-01-01T12:00:00.000Z",
+    );
+    expect(new Date(corrected[1]!.t).toISOString()).toBe(
+      "2020-07-01T10:00:00.000Z",
+    );
+  });
 });

--- a/tools/harmonic-analysis.ts
+++ b/tools/harmonic-analysis.ts
@@ -202,10 +202,13 @@ export function fitHarmonics(
   return cons.map((co, k) => {
     const p = x[1 + 2 * k]!;
     const q = x[2 + 2 * k]!;
+    // Round to fit uncertainty: 1 mm amplitude, 0.01° phase (~1 s for M2).
     return {
       name: co.name,
-      amplitude: Math.hypot(p, q),
-      phase: (((Math.atan2(q, p) / DEG) % 360) + 360) % 360,
+      amplitude: Math.round(Math.hypot(p, q) * 1000) / 1000,
+      phase:
+        Math.round(((((Math.atan2(q, p) / DEG) % 360) + 360) % 360) * 100) /
+        100,
     };
   });
 }

--- a/tools/import-ticon.ts
+++ b/tools/import-ticon.ts
@@ -245,9 +245,28 @@ async function getDatums(
 }
 
 // GESLA sources whose files are timestamped in local legal time but mislabeled
-// "TIME ZONE HOURS 0" (UTC). Their harmonics are re-fit in the correct zone so
-// phases are UTC-referenced like the rest of the database. See issue #96.
-const LOCAL_TIME_SOURCES: Record<string, string> = { wsv: "Europe/Berlin" };
+// "TIME ZONE HOURS 0" (UTC). Their harmonics are re-fit in the correct zone
+// (then optionally shifted, see `shiftHours`) so phases are UTC-referenced like
+// the rest of the database.
+//
+// - `wsv` (pegelonline.wsv.de): files are full German legal time (MEZ/MESZ)
+//   mislabeled UTC. Reinterpret in Europe/Berlin. See issue #96.
+// - `rws` (Rijkswaterstaat/waterinfo.rws.nl): files were converted from Dutch
+//   legal time to "UTC" by subtracting a FIXED 1 h (the standard CET offset)
+//   instead of a DST-aware conversion. So winter (CET) records are already true
+//   UTC, but summer (CEST) records are left 1 h fast. Season-split re-analysis
+//   confirms it: vs a UTC-correct CMEMS neighbour, winter Δphase ≈ 0 while
+//   summer ≈ +1 h across M2/S2/N2, plus a ~3% semidiurnal amplitude loss from
+//   blending the two halves in a single fit. Invert with Amsterdam's own DST
+//   calendar: reinterpret in Europe/Amsterdam (subtracts {1,2} h) then add back
+//   the 1 h that was wrongly removed (`shiftHours: 1`), netting a DST-only
+//   correction ({0,1} h). The sibling `rws_hist` source is already UTC-correct
+//   and is deliberately not listed here. See issue #98.
+type LocalTimeSource = { zone: string; shiftHours?: number };
+const LOCAL_TIME_SOURCES: Record<string, LocalTimeSource> = {
+  wsv: { zone: "Europe/Berlin" },
+  rws: { zone: "Europe/Amsterdam", shiftHours: 1 },
+};
 
 /**
  * Resolve a station's harmonic constituents. For most sources these come
@@ -262,8 +281,8 @@ async function getHarmonics(
   id: string,
   csvHarmonics: PartialStationData["harmonic_constituents"],
 ): Promise<PartialStationData["harmonic_constituents"]> {
-  const tz = LOCAL_TIME_SOURCES[getSourceSuffix(id)];
-  if (!tz) return csvHarmonics;
+  const src = LOCAL_TIME_SOURCES[getSourceSuffix(id)];
+  if (!src) return csvHarmonics;
 
   if (!forceDatums) {
     try {
@@ -275,13 +294,19 @@ async function getHarmonics(
   }
 
   await ensureGesla();
-  const samples = parseGeslaSamplesInZone(
+  let samples = parseGeslaSamplesInZone(
     await readFile(join(GESLA_DIR, id), "utf-8"),
-    tz,
+    src.zone,
   );
+  // Undo any fixed offset baked into the source before it was mislabeled UTC
+  // (e.g. rws had a flat 1 h removed, so re-add it after the DST-aware parse).
+  if (src.shiftHours) {
+    const ms = src.shiftHours * 3_600_000;
+    samples = samples.map((s) => ({ t: s.t + ms, level: s.level }));
+  }
   const names = csvHarmonics.map((h) => h.name);
   if (!isAnalyzable(samples, names.length)) {
-    throw new Error(`record too short to re-analyze ${tz} phases`);
+    throw new Error(`record too short to re-analyze ${src.zone} phases`);
   }
   return fitHarmonics(samples, names);
 }

--- a/tools/import-ticon.ts
+++ b/tools/import-ticon.ts
@@ -30,6 +30,7 @@ const metadata = indexBy(
 );
 const data = await readFile(dataPath, "utf-8");
 const forceDatums = process.env["FORCE_DATUMS"] === "1";
+const forceHarmonics = process.env["FORCE_HARMONICS"] === "1";
 
 type TiconMetaRow = {
   "FILE NAME": string;
@@ -81,7 +82,7 @@ const ensureGesla = () => (geslaReady ??= ensureGeslaData());
  */
 async function main() {
   console.log(
-    `=== Importing TICON stations ===${forceDatums ? " (forcing datum recalculation)" : ""}\n`,
+    `=== Importing TICON stations ===${forceDatums ? " (forcing datum recalculation)" : ""}${forceHarmonics ? " (forcing harmonic re-analysis)" : ""}\n`,
   );
 
   const groups = Object.values(
@@ -274,8 +275,8 @@ const LOCAL_TIME_SOURCES: Record<string, LocalTimeSource> = {
  * sources (see LOCAL_TIME_SOURCES) the published phases are not UTC-referenced,
  * so re-fit amplitude + UTC phase from the raw GESLA water levels. Throws when a
  * mislabeled source can't be re-analyzed, so the station is skipped rather than
- * saved with wrong phases. Cached like datums (reused unless FORCE_DATUMS=1; the
- * fit is ~6s/station).
+ * saved with wrong phases. Cached like datums (reused unless FORCE_HARMONICS=1;
+ * the fit is ~6s/station).
  */
 async function getHarmonics(
   id: string,
@@ -284,7 +285,7 @@ async function getHarmonics(
   const src = LOCAL_TIME_SOURCES[getSourceSuffix(id)];
   if (!src) return csvHarmonics;
 
-  if (!forceDatums) {
+  if (!forceHarmonics) {
     try {
       const { harmonic_constituents } = await load("ticon", id);
       if (harmonic_constituents?.length) return harmonic_constituents;


### PR DESCRIPTION
Follow-up to #97, fixing the RWS time-reference offset flagged in #98.

## Problem

The current `rws` (Rijkswaterstaat) GESLA-4 files were converted from Dutch legal time to "UTC" by subtracting a fixed 1 hour — the standard CET offset — instead of a DST-aware conversion, then labeled `TIME ZONE HOURS 0`. The raw header shows it directly: `START DATE/TIME 1970/12/31 23:00:00` is local midnight (CET) minus one hour.

So winter (CET) records land on true UTC, but summer (CEST = UTC+2) records are left an hour fast. Fitting a multi-year record blends the two halves, which is why the neighbor scan in #98 saw a ~0.5 h average offset instead of a clean hour — and why the semidiurnal amplitudes drop ~3% (blending loses amplitude; a clean timestamp shift would not). The sibling `rws_hist` source was processed correctly and is already UTC.

## Evidence

Season-split fit of Cadzand against its UTC-correct CMEMS neighbor, from water levels only:

| | M2 | S2 | N2 |
|---|---|---|---|
| Winter Δphase vs CMEMS | +0.4° | +0.6° | +1.3° |
| Summer Δphase vs CMEMS | +30.6° | +31.4° | +29.6° |

Winter is already UTC; summer is a clean +1 h. That's exactly the "UTC in winter, UTC+1 in summer" behavior reported on the issue.

## Fix

Invert the error with Amsterdam's own DST calendar — which matters for pre-1996 years, when NL and UK summer-time dates differed, so a plain Europe/London reinterpretation leaves a residual. Parse the timestamps in `Europe/Amsterdam` (subtracts {1,2} h), then re-add the 1 h that was wrongly removed, for a net DST-only correction of {0,1} h.

- `tools/import-ticon.ts` — `LOCAL_TIME_SOURCES` now carries an optional `shiftHours`; `rws` maps to `{ zone: "Europe/Amsterdam", shiftHours: 1 }`. `wsv` is unchanged, `rws_hist` is not listed.
- `test/harmonic-analysis.test.ts` — a winter + summer round-trip for the RWS convention.

## Validation

Re-fit across 9 stations along the Dutch coast (Cadzand, Vlissingen, Scheveningen, IJmuiden, Terschelling, K13A, Euro Platform, Westkapelle, Lauwersoog): M2 phase error vs CMEMS drops from +12…+18° to within ~1°, and the ~3% amplitude loss comes back. Lauwersoog is the one outlier — a genuine Wadden-Sea regime difference, not a fix artifact, and the neighbor scan flags it on its own. Tests pass; `tsc` and prettier clean.

## Not in this PR

- The ~120 regenerated `-nld-rws` station JSONs. That's the bulk data step and will follow as a separate commit, as in #97.
- The UHSLC ~2.2 h pairs from #98 are a different mechanism (fast-delivery vs research-quality processing), out of scope here.
