### PR TITLE
Add seasonal-contamination QC gate

### DIFF
--- a/quality.json
+++ b/quality.json
@@ -2519,7 +2519,7 @@
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.023
+      "coverage": 0.002
     },
     "issues": []
   },
@@ -57103,8 +57103,8 @@
   },
   {
     "id": "ticon/cape_dor-240-can-meds",
-    "accepted": true,
-    "score": 62,
+    "accepted": false,
+    "score": 0,
     "factors": {
       "epoch": 0.782,
       "recency": 0.53,
@@ -57113,7 +57113,10 @@
       "amplitude": 1,
       "coverage": 0.142
     },
-    "issues": []
+    "issues": [
+      "SA amplitude (2.077m) is 23.2x the median SA of 1 same-regime neighbour(s) within 25km (0.090m): seasonal contamination"
+    ],
+    "reason": "seasonal"
   },
   {
     "id": "ticon/cape_ferguson-343a-aus-uhslc_rq",
@@ -89469,7 +89472,7 @@
   {
     "id": "ticon/mazatlan_flotador-16-mex-unam",
     "accepted": false,
-    "score": 34,
+    "score": 0,
     "factors": {
       "epoch": 0.072,
       "recency": 0.96,
@@ -89478,9 +89481,10 @@
       "amplitude": 1,
       "coverage": 0
     },
-    "issues": [],
-    "reason": "duplicate",
-    "redundant": "ticon/mazatlan-673-mex-unam_hist"
+    "issues": [
+      "SA amplitude (0.935m) is 6.8x the median SA of 3 same-regime neighbour(s) within 25km (0.138m): seasonal contamination"
+    ],
+    "reason": "seasonal"
   },
   {
     "id": "ticon/mazatlan_radar-16-mex-unam",
@@ -89811,28 +89815,28 @@
   {
     "id": "ticon/merrimack_r_03_miles_usrt_125_at_haverhillma-1100693-usa-usgs",
     "accepted": true,
-    "score": 77,
+    "score": 78,
     "factors": {
       "epoch": 0.992,
       "recency": 0.98,
       "source": 0.596,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.023
+      "coverage": 0.082
     },
     "issues": []
   },
   {
     "id": "ticon/merrimack_river_at_bates_bridge_near_haverhill_ma-11006988-usa-usgs",
     "accepted": true,
-    "score": 62,
+    "score": 61,
     "factors": {
       "epoch": 0.198,
       "recency": 0.99,
       "source": 0.596,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.071
+      "coverage": 0.002
     },
     "issues": []
   },
@@ -89846,7 +89850,7 @@
       "source": 0.596,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.18
+      "coverage": 0.19
     },
     "issues": []
   },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,9 +3,18 @@ import { readFile } from "fs/promises";
 import { join } from "path";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
-import { stations } from "../src/index.js";
+import { stations, allStations } from "../src/index.js";
 import { near } from "../src/search/index.js";
-import { MIN_TIDAL_RANGE, MIN_DEDUP_DISTANCE } from "../tools/filtering.js";
+import {
+  MIN_TIDAL_RANGE,
+  MIN_DEDUP_DISTANCE,
+  MIN_AMPLITUDE_RATIO,
+  SEASONAL_OUTLIER_RADIUS,
+  SEASONAL_OUTLIER_MIN_SA,
+  SEASONAL_OUTLIER_RATIO,
+  distance,
+} from "../tools/filtering.js";
+import quality from "../quality.json" with { type: "json" };
 
 const ROOT = new URL("..", import.meta.url).pathname;
 const SCHEMA_PATH = join(ROOT, "schemas", "station.schema.json");
@@ -161,6 +170,76 @@ stations.forEach((station) => {
             `Run tools/evaluate-quality.ts to re-filter.`,
         ).toBeGreaterThanOrEqual(MIN_TIDAL_RANGE);
       });
+    }
+  });
+});
+
+describe("seasonal-contamination gate", () => {
+  const getAmp = (
+    s: { harmonic_constituents?: { name: string; amplitude: number }[] },
+    name: string,
+  ) => s.harmonic_constituents?.find((c) => c.name === name)?.amplitude;
+  const median = (v: number[]): number => {
+    const a = [...v].sort((x, y) => x - y);
+    const m = a.length >> 1;
+    return a.length % 2 ? a[m]! : (a[m - 1]! + a[m]!) / 2;
+  };
+
+  // A short/gappy/datum-shifted record whose harmonic fit dumps spurious energy
+  // into the annual (SA) band inflates the predicted extreme range. Cape Dor is
+  // the canonical case (openwatersio/tide-database#93): SA 2.077m vs 0.090m at
+  // Spencers Island 7km away in the same tidal regime.
+  test("rejects known contaminated records", () => {
+    const byId = new Map(quality.map((r) => [r.id, r]));
+    expect(byId.get("ticon/cape_dor-240-can-meds")?.accepted).toBe(false);
+    expect(byId.get("ticon/cape_dor-240-can-meds")?.reason).toBe("seasonal");
+    expect(byId.get("ticon/mazatlan_flotador-16-mex-unam")?.accepted).toBe(
+      false,
+    );
+  });
+
+  // Shipped-data invariant: no published TICON station has an SA amplitude that
+  // grossly outstrips same-regime (similar-M2) neighbours within the radius.
+  test("no published station is a same-regime SA outlier", () => {
+    const refs = allStations.filter(
+      (s) => (s.type ?? "reference") === "reference",
+    );
+    for (const station of stations) {
+      if (!station.id.startsWith("ticon/")) continue;
+      if ((station.type ?? "reference") !== "reference") continue;
+      const sa = getAmp(station, "SA");
+      if (sa === undefined || sa < SEASONAL_OUTLIER_MIN_SA) continue;
+      const m2 = getAmp(station, "M2");
+      if (m2 === undefined || m2 <= 0) continue;
+
+      const neighbourSA: number[] = [];
+      for (const other of refs) {
+        if (other.id === station.id) continue;
+        const osa = getAmp(other, "SA");
+        if (osa === undefined) continue;
+        const om2 = getAmp(other, "M2");
+        if (om2 === undefined || om2 <= 0) continue;
+        if (Math.min(m2, om2) / Math.max(m2, om2) < MIN_AMPLITUDE_RATIO)
+          continue;
+        if (
+          distance(
+            station.latitude,
+            station.longitude,
+            other.latitude,
+            other.longitude,
+          ) <= SEASONAL_OUTLIER_RADIUS
+        )
+          neighbourSA.push(osa);
+      }
+      if (neighbourSA.length === 0) continue;
+      const med = median(neighbourSA);
+      if (med <= 0) continue;
+      expect(
+        sa / med,
+        `Station ${station.id}: SA ${sa.toFixed(3)}m is ${(sa / med).toFixed(1)}x the ` +
+          `median SA of its same-regime neighbours (${med.toFixed(3)}m). ` +
+          `Run tools/evaluate-quality.ts to re-filter.`,
+      ).toBeLessThan(SEASONAL_OUTLIER_RATIO);
     }
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -196,6 +196,11 @@ describe("seasonal-contamination gate", () => {
     expect(byId.get("ticon/mazatlan_flotador-16-mex-unam")?.accepted).toBe(
       false,
     );
+    // The seasonal gate runs before dedup, so this is the reason of record —
+    // assert it so a regression can't quietly downgrade it back to "duplicate".
+    expect(byId.get("ticon/mazatlan_flotador-16-mex-unam")?.reason).toBe(
+      "seasonal",
+    );
   });
 
   // Shipped-data invariant: no published TICON station has an SA amplitude that
@@ -216,7 +221,7 @@ describe("seasonal-contamination gate", () => {
       for (const other of refs) {
         if (other.id === station.id) continue;
         const osa = getAmp(other, "SA");
-        if (osa === undefined) continue;
+        if (osa === undefined || osa <= 0) continue;
         const om2 = getAmp(other, "M2");
         if (om2 === undefined || om2 <= 0) continue;
         if (Math.min(m2, om2) / Math.max(m2, om2) < MIN_AMPLITUDE_RATIO)

--- a/tools/evaluate-quality.ts
+++ b/tools/evaluate-quality.ts
@@ -6,7 +6,8 @@
  * Pipeline:
  *   1. Load all stations (NOAA + TICON)
  *   2. Compute quality factors for each station
- *   3. Apply hard gates (datum ordering, tidal range, superseded source)
+ *   3. Apply hard gates (datum ordering, tidal range, superseded source,
+ *      missing constituents, seasonal contamination)
  *   4. Deduplicate TICON stations by proximity
  *   5. Compute composite score and write results
  *
@@ -33,6 +34,9 @@ import {
   FALLBACK_DEDUP_DISTANCE,
   MIN_AMPLITUDE_RATIO,
   MIN_TIDAL_RANGE,
+  SEASONAL_OUTLIER_RADIUS,
+  SEASONAL_OUTLIER_MIN_SA,
+  SEASONAL_OUTLIER_RATIO,
 } from "./filtering.ts";
 import type { StationData } from "../src/types.js";
 
@@ -217,6 +221,74 @@ function checkConstituents(station: Station): string | null {
   }
 
   return null;
+}
+
+/** Median of a numeric array. Returns 0 for empty input. */
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2
+    ? sorted[mid]!
+    : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+/**
+ * Seasonal-contamination gate.
+ *
+ * A harmonic analysis of a short, gappy, or datum-shifted record can absorb
+ * spurious energy into the seasonal band (the annual SA constituent), inflating
+ * the predicted extreme range without any physical basis. SA is a
+ * meteorological/steric signal that varies smoothly along a coast, so a station
+ * whose SA amplitude grossly exceeds that of a hydraulically-connected
+ * neighbour is almost certainly contaminated rather than physically distinct.
+ *
+ * Comparison is restricted to neighbours in the same tidal regime (similar M2)
+ * so a genuine river-freshet station — large, real SA atop a small tide — is
+ * only ever compared against other such stations, not the open coast. This
+ * keeps the gate targeted at the failure mode the CHS range benchmark surfaces:
+ * strongly tidal stations whose charted range is overstated.
+ */
+function checkSeasonalContamination(
+  station: Station,
+  allStations: Station[],
+): string | null {
+  // Authoritative sources (NOAA) are trusted; this targets TICON harmonic fits.
+  if (!station.id.startsWith("ticon/")) return null;
+  if (station.type === "subordinate") return null;
+
+  const sa = getAmplitude(station, "SA");
+  if (sa < SEASONAL_OUTLIER_MIN_SA) return null;
+  if (getAmplitude(station, "M2") <= 0) return null; // no tidal regime to compare
+
+  const neighbourSA: number[] = [];
+  for (const other of allStations) {
+    if (other.id === station.id) continue;
+    if (other.type === "subordinate") continue;
+    // Only neighbours that actually resolved an SA term can vouch either way.
+    const otherSA = other.harmonic_constituents.find((c) => c.name === "SA");
+    if (otherSA === undefined) continue;
+    if (!hasSimilarM2(station, other)) continue; // same tidal regime only
+    const d = distance(
+      station.latitude,
+      station.longitude,
+      other.latitude,
+      other.longitude,
+    );
+    if (d <= SEASONAL_OUTLIER_RADIUS) neighbourSA.push(otherSA.amplitude);
+  }
+
+  if (neighbourSA.length === 0) return null; // no same-regime neighbour to check
+  const med = median(neighbourSA);
+  if (med <= 0) return null;
+  const ratio = sa / med;
+  if (ratio < SEASONAL_OUTLIER_RATIO) return null;
+
+  return (
+    `SA amplitude (${sa.toFixed(3)}m) is ${ratio.toFixed(1)}x the median SA ` +
+    `of ${neighbourSA.length} same-regime neighbour(s) within ` +
+    `${SEASONAL_OUTLIER_RADIUS}km (${med.toFixed(3)}m): seasonal contamination`
+  );
 }
 
 // ── Scored Factors (each returns 0.0–1.0) ────────────────────────────────
@@ -524,6 +596,7 @@ async function main() {
     const rangeIssue = checkTidalRange(station, stationMap);
     const supersededIssue = checkSuperseded(station);
     const constituentIssue = checkConstituents(station);
+    const seasonalIssue = checkSeasonalContamination(station, stations);
 
     // Diurnal pair warnings are non-fatal
     issues.push(...datumIssues.warnings);
@@ -541,6 +614,9 @@ async function main() {
     } else if (constituentIssue) {
       issues.push(constituentIssue);
       gateReason = "constituents";
+    } else if (seasonalIssue) {
+      issues.push(seasonalIssue);
+      gateReason = "seasonal";
     }
 
     // Scored factors

--- a/tools/evaluate-quality.ts
+++ b/tools/evaluate-quality.ts
@@ -265,9 +265,11 @@ function checkSeasonalContamination(
   for (const other of allStations) {
     if (other.id === station.id) continue;
     if (other.type === "subordinate") continue;
-    // Only neighbours that actually resolved an SA term can vouch either way.
+    // Only neighbours with a genuine (positive) SA term can vouch. Treating an
+    // SA=0 placeholder as a valid comparator would drag the median toward zero
+    // and silently disable the gate where such placeholders are common.
     const otherSA = other.harmonic_constituents.find((c) => c.name === "SA");
-    if (otherSA === undefined) continue;
+    if (otherSA === undefined || otherSA.amplitude <= 0) continue;
     if (!hasSimilarM2(station, other)) continue; // same tidal regime only
     const d = distance(
       station.latitude,

--- a/tools/filtering.ts
+++ b/tools/filtering.ts
@@ -152,3 +152,24 @@ export const FALLBACK_DEDUP_DISTANCE = 0.1; // 100 meters
 
 /** Minimum tidal range (MHW - MLW) to consider a station useful for tide prediction */
 export const MIN_TIDAL_RANGE = 0.02; // 2cm
+
+// ── Seasonal-contamination gate ──────────────────────────────────────────
+// A harmonic analysis of a short, gappy, or datum-shifted sea-level record can
+// absorb spurious energy into the seasonal band (SA and its M2 satellites),
+// inflating the predicted extreme range. SA is a meteorological/steric signal
+// that varies smoothly along a coast, so a station whose SA amplitude wildly
+// exceeds that of a hydraulically-connected neighbour in the same tidal regime
+// is almost certainly contaminated rather than physically distinct.
+
+/** Radius within which a same-regime neighbour can vouch for a station's
+ *  seasonal amplitude (in km). Kept tight so comparisons stay within one
+ *  local regime rather than across an estuary gradient. */
+export const SEASONAL_OUTLIER_RADIUS = 25;
+
+/** Only stations whose SA amplitude exceeds this (in metres) are checked. Below
+ *  it, seasonal energy is too small to meaningfully distort the range. */
+export const SEASONAL_OUTLIER_MIN_SA = 0.5;
+
+/** A station's SA must exceed the median SA of its same-regime neighbours by at
+ *  least this factor to be gated as contaminated. */
+export const SEASONAL_OUTLIER_RATIO = 5;


### PR DESCRIPTION
Fixes #93.

Cape Dor's TICON record predicts an astronomical range (HAT−LAT) of 18.58m. CHS publishes 12.40m for the same spot: a ~50% overstatement, enough to beat the world-record range at Burntcoat Head. The neaps CHS benchmark (openwatersio/neaps#272) flagged it as the worst outlier in the set.

The cause is a contaminated harmonic fit. The annual SA constituent is 2.077m, which is 23× the value at Spencers Island 7km away in the same tidal channel (0.090m), and its M2 satellites (MA2, MB2 ≈ 0.6m each) are inflated to match. SA is a meteorological/steric signal that varies smoothly along a coast, so two hydraulically-connected stations in the same regime should read close to each other. When one doesn't, the record — not the ocean — is wrong. Dropping SA alone only brings the range down to ~16m, so the whole seasonal band is over-amplified, not just the one term.

Rather than reject the one station by hand, this adds a QC gate that catches the whole class.

## The gate

`checkSeasonalContamination` rejects a TICON reference station when its SA amplitude exceeds the median SA of its same-regime neighbours (within 25km) by 5× or more. Two design choices keep it honest:

- **Same-regime only.** Neighbours are limited to stations with a similar M2 (the existing `hasSimilarM2` / 0.9 ratio used by dedup). Without this, genuine river-freshet stations (large, real seasonal SA sitting on a small tide) get compared against the open coast and falsely flagged. With it, they're only ever compared against other river stations that share the same real signal, so they pass. This is what drops Merrimack, Sacramento, Mobile, etc. from the candidate list.
- **Only meaningful SA.** Stations below 0.5m SA are left alone; that's too little seasonal energy to distort the range.

Thresholds live in `tools/filtering.ts` (`SEASONAL_OUTLIER_RADIUS`, `SEASONAL_OUTLIER_MIN_SA`, `SEASONAL_OUTLIER_RATIO`).

## What changes

Two `quality.json` entries change accept/reject status, and nothing else does:

- `ticon/cape_dor-240-can-meds`: accepted → rejected (`seasonal`). Spencers Island, 7km away, already covers the location.
- `ticon/mazatlan_flotador-16-mex-unam`: reason `duplicate` → `seasonal`. It was already being deduped out; now it's rejected for the real reason. Its co-located `-hist` sibling (SA 0.138m) still ships.

The other stations the raw SA-outlier test surfaces were already rejected by higher-priority gates (datum ordering, superseded source), so the only station leaving the published set is Cape Dor.

Regenerating also refreshes a few stale `coverage`/`score` values in the Merrimack cluster (and one NOAA coverage value). Those are not from this gate: checking out `main` and running `tools/evaluate-quality.ts` with no code changes produces the exact same coverage diff, so `main`'s committed `quality.json` was already out of sync with its own tool. The tool is deterministic (two back-to-back runs are byte-identical), so this is a stale-file correction riding along, not new churn. Happy to split it into its own commit if you'd rather keep the two clean.

## Tests

- A regression test asserting Cape Dor and the Mazatlan flotador are rejected.
- A shipped-data invariant: no published TICON station is a same-regime SA outlier. If a future import reintroduces one, the suite fails and points at `tools/evaluate-quality.ts`.

Full suite passes (31854 tests), build and prettier clean.

## Limits

The gate needs a same-regime neighbour within 25km to make the call, so an isolated contaminated station with no comparator won't be caught. This is deliberate: better to miss one than reject a legitimately unusual station with no evidence against it.

