### PR TITLE
Re-evaluate quality.json after NOAA station update

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -35,12 +35,18 @@ jobs:
           sed -n '/^## Summary$/,$p' /tmp/noaa-update.log > /tmp/noaa-summary.md
           printf '\n### Workflow\n\n            This PR was automatically created by the monthly NOAA station update workflow.Run: %s\n' "$WORKFLOW_URL" >> /tmp/noaa-summary.md
 
+      - name: Re-evaluate station quality
+        # New/moved NOAA stations shift proximity and can supersede TICON
+        # records, so quality.json must be regenerated in the same commit or it
+        # goes stale against the data it describes.
+        run: tools/evaluate-quality.ts
+
       - name: Check for changes
         id: changes
         run: |
-          if [[ -n $(git status --porcelain data/) ]]; then
+          if [[ -n $(git status --porcelain data/ quality.json) ]]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "Changes detected in data directory"
+            echo "Changes detected in station data or quality.json"
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "No changes detected"


### PR DESCRIPTION
The monthly NOAA update job (`updates.yml`) rewrites station files under `data/` but never regenerates `quality.json`. NOAA is authoritative, so new or moved NOAA stations shift nearest-neighbour distances (the `coverage` factor) and can supersede nearby TICON records, so leaving `quality.json` untouched lets it drift out of sync with the data it's supposed to describe.

That's exactly what happened: `quality.json` was last regenerated on `main` at `e8d403ef` (Jun 15), and the `chore: update NOAA tide station data` run landed afterward with no re-eval. Running the generator on current `main` now produces coverage/score changes with no code change at all, which is how the drift surfaced during review of #108.

This adds a `Re-evaluate station quality` step that runs `tools/evaluate-quality.ts` right after the NOAA update, and folds `quality.json` into the change check so it's committed in the same PR. The generator is deterministic, so quiet months produce no diff.

Once this is in, the auto-update PR carries its own quality.json refresh and can't go stale between runs.
