### PR TITLE
Require matching offsets to merge subordinate stations

### DIFF
--- a/quality.json
+++ b/quality.json
@@ -22847,7 +22847,7 @@
   },
   {
     "id": "noaa/8724370",
-    "accepted": false,
+    "accepted": true,
     "score": 83,
     "factors": {
       "epoch": 1,
@@ -22857,9 +22857,7 @@
       "amplitude": 1,
       "coverage": 0
     },
-    "issues": [],
-    "reason": "duplicate",
-    "redundant": "noaa/8724369"
+    "issues": []
   },
   {
     "id": "noaa/8724373",
@@ -43618,7 +43616,7 @@
   },
   {
     "id": "noaa/TEC3447",
-    "accepted": false,
+    "accepted": true,
     "score": 83,
     "factors": {
       "epoch": 1,
@@ -43628,9 +43626,7 @@
       "amplitude": 1,
       "coverage": 0
     },
-    "issues": [],
-    "reason": "duplicate",
-    "redundant": "noaa/TEC3445"
+    "issues": []
   },
   {
     "id": "noaa/TEC3457",
@@ -45860,7 +45856,7 @@
   },
   {
     "id": "noaa/TPT2829",
-    "accepted": false,
+    "accepted": true,
     "score": 85,
     "factors": {
       "epoch": 1,
@@ -45870,9 +45866,7 @@
       "amplitude": 1,
       "coverage": 0
     },
-    "issues": [],
-    "reason": "duplicate",
-    "redundant": "noaa/TPT2837"
+    "issues": []
   },
   {
     "id": "noaa/TPT2831",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -347,6 +347,37 @@ describe("coordinate gate", () => {
   });
 });
 
+describe("subordinate offset dedup", () => {
+  const byId = new Map(quality.map((r) => [r.id, r]));
+
+  // Two subordinate stations can share (coarse or placeholder) coordinates yet
+  // predict different tides through different offsets. Suwarrow Island is
+  // mislocated on Hao Island's exact coordinates but carries a +64 min vs
+  // −315 min offset, so proximity alone must not merge them
+  // (openwatersio/tide-database#112 follow-up).
+  test("keeps distinct subordinate stations that share coordinates", () => {
+    for (const id of [
+      "noaa/TPT2829", // Suwarrow vs Hao (TPT2837)
+      "noaa/TPT2837",
+      "noaa/8724370", // Sawyer Key outside vs inside (8724369)
+      "noaa/8724369",
+      "noaa/TEC3447", // South Newport Cut vs North Newport River (TEC3445)
+      "noaa/TEC3445",
+    ]) {
+      expect(byId.get(id)?.accepted, `${id} should be kept`).toBe(true);
+    }
+  });
+
+  // A genuine subordinate duplicate — same name, same reference, offsets within
+  // tolerance — must still be merged.
+  test("still merges near-identical subordinate duplicates", () => {
+    const dup = byId.get("noaa/8724224"); // Little Torch Key (dup of 8724223)
+    expect(dup?.accepted).toBe(false);
+    expect(dup?.reason).toBe("duplicate");
+    expect(dup?.redundant).toBe("noaa/8724223");
+  });
+});
+
 test("Does not have duplicate source IDs", () => {
   const seen = new Map();
   stations.forEach((station) => {

--- a/tools/evaluate-quality.ts
+++ b/tools/evaluate-quality.ts
@@ -35,6 +35,8 @@ import {
   MAX_DEDUP_DISTANCE,
   MIN_DEDUP_DISTANCE,
   FALLBACK_DEDUP_DISTANCE,
+  MAX_OFFSET_HEIGHT_DELTA,
+  MAX_OFFSET_TIME_DELTA,
   MIN_AMPLITUDE_RATIO,
   MIN_TIDAL_RANGE,
   SEASONAL_OUTLIER_RADIUS,
@@ -515,9 +517,30 @@ function hasSimilarM2(stationA: Station, stationB: Station): boolean {
   return ratio >= MIN_AMPLITUDE_RATIO;
 }
 
+/** Check if two subordinate stations would produce the same tide prediction:
+ *  same reference station and matching height/time offsets within tolerance.
+ *  Two subordinates can share (coarse or placeholder) coordinates while
+ *  predicting entirely differently, so proximity alone must not merge them. */
+function hasSimilarOffsets(stationA: Station, stationB: Station): boolean {
+  const a = stationA.offsets;
+  const b = stationB.offsets;
+  if (!a || !b) return false;
+  if (a.reference !== b.reference) return false;
+  if (a.height.type !== b.height.type) return false;
+  return (
+    Math.abs(a.height.high - b.height.high) <= MAX_OFFSET_HEIGHT_DELTA &&
+    Math.abs(a.height.low - b.height.low) <= MAX_OFFSET_HEIGHT_DELTA &&
+    Math.abs(a.time.high - b.time.high) <= MAX_OFFSET_TIME_DELTA &&
+    Math.abs(a.time.low - b.time.low) <= MAX_OFFSET_TIME_DELTA
+  );
+}
+
 /** Check if two stations are duplicates based on distance and harmonic similarity.
  *
- *  - Within MIN_DEDUP_DISTANCE: always duplicates
+ *  - Two subordinate stations: duplicates only if within MAX_DEDUP_DISTANCE and
+ *    predicting the same tide (same reference + equivalent offsets), since
+ *    distinct subordinates can share placeholder coordinates
+ *  - Within MIN_DEDUP_DISTANCE (reference-involving pairs): always duplicates
  *  - Between MIN_DEDUP_DISTANCE and MAX_DEDUP_DISTANCE: duplicates only if
  *    both are reference stations with similar M2 amplitudes (ratio >= 0.9)
  *  - Beyond MAX_DEDUP_DISTANCE: never duplicates
@@ -529,6 +552,17 @@ function areDuplicates(
   winnerHasSubordinates = false,
 ): boolean {
   if (dist > MAX_DEDUP_DISTANCE) return false;
+
+  // Two subordinate stations at (near-)identical coordinates can still be
+  // different places — a mislocated record inherits another station's fix while
+  // keeping its own offsets. Keep the existing proximity threshold, but only
+  // merge them when they'd also predict the same tide.
+  if (stationA.type === "subordinate" && stationB.type === "subordinate") {
+    return (
+      dist <= FALLBACK_DEDUP_DISTANCE && hasSimilarOffsets(stationA, stationB)
+    );
+  }
+
   if (dist <= MIN_DEDUP_DISTANCE) return true;
 
   // For the middle range, require harmonic similarity between reference stations.

--- a/tools/evaluate-quality.ts
+++ b/tools/evaluate-quality.ts
@@ -537,10 +537,10 @@ function hasSimilarOffsets(stationA: Station, stationB: Station): boolean {
 
 /** Check if two stations are duplicates based on distance and harmonic similarity.
  *
- *  - Two subordinate stations: duplicates only if within MAX_DEDUP_DISTANCE and
+ *  - Two subordinate stations: duplicates only if within FALLBACK_DEDUP_DISTANCE and
  *    predicting the same tide (same reference + equivalent offsets), since
  *    distinct subordinates can share placeholder coordinates
- *  - Within MIN_DEDUP_DISTANCE (reference-involving pairs): always duplicates
+ *    (proximity alone is insufficient for subordinates)
  *  - Between MIN_DEDUP_DISTANCE and MAX_DEDUP_DISTANCE: duplicates only if
  *    both are reference stations with similar M2 amplitudes (ratio >= 0.9)
  *  - Beyond MAX_DEDUP_DISTANCE: never duplicates

--- a/tools/filtering.ts
+++ b/tools/filtering.ts
@@ -202,6 +202,16 @@ export const MIN_AMPLITUDE_RATIO = 0.9;
  *  accepted subordinates. Used when harmonic comparison is unavailable or inapplicable. */
 export const FALLBACK_DEDUP_DISTANCE = 0.1; // 100 meters
 
+/** Maximum offset difference for two subordinate stations to be treated as the
+ *  same station. Subordinate records predict from a reference plus height/time
+ *  offsets, so two subordinates sharing (often coarse or placeholder) coordinates
+ *  are only true duplicates when they'd produce the same prediction — same
+ *  reference, height offsets within MAX_OFFSET_HEIGHT_DELTA, and time offsets
+ *  within MAX_OFFSET_TIME_DELTA. Suwarrow Island, mislocated on Hao Island's exact
+ *  coordinates but with a +64 min vs −315 min offset, is the case this separates. */
+export const MAX_OFFSET_HEIGHT_DELTA = 0.1; // ratio (or metres for fixed offsets)
+export const MAX_OFFSET_TIME_DELTA = 10; // minutes
+
 /** Minimum tidal range (MHW - MLW) to consider a station useful for tide prediction */
 export const MIN_TIDAL_RANGE = 0.02; // 2cm
 


### PR DESCRIPTION
Follow-up to #113, from review feedback.

## The problem

`TPT2837` (Hao Island, Tuamotus) and `TPT2829` (Suwarrow Island, Cook Islands) were marked as duplicates of each other, but they're ~1,900 km apart and predict completely different tides. Both are subordinate stations referencing `noaa/1770000`:

- Hao: height ×1.05, time −315 min
- Suwarrow: height ×0.86, time **+64 min**

They collapsed because Suwarrow is **mislocated on Hao's exact coordinates** (`-18.0667, -140.9833`), and the spatial dedup treats anything within 100 m as a duplicate. That's fine for reference stations (it also checks harmonic similarity), but subordinate stations carry no harmonics — the old code merged them on proximity alone. Distinct subordinates that share coarse or placeholder coordinates get wrongly collapsed.

## The fix

Gate subordinate–subordinate merges on *prediction equivalence* instead of proximity alone: same reference station, height offsets within `MAX_OFFSET_HEIGHT_DELTA` (0.1), and time offsets within `MAX_OFFSET_TIME_DELTA` (10 min). Two subordinates only merge if they'd predict the same tide.

The proximity threshold is unchanged, and the reference/harmonic and subordinate-vs-reference paths are untouched — this only adds a requirement to the subordinate-vs-subordinate case.

## Impact

There are exactly 4 subordinate–subordinate merges in the dataset. The fix **restores 3 wrongly-merged stations**:

| Restored | Was merged into | Why they differ |
|---|---|---|
| Suwarrow Island `TPT2829` | Hao Island `TPT2837` | +64 vs −315 min |
| Sawyer Key, outside `8724370` | Sawyer Key, inside `8724369` | height 0.14 apart |
| South Newport Cut `TEC3447` | North Newport River `TEC3445` | 18 min apart |

The genuine duplicate stays merged — the two `Little Torch Key` records (`8724224` → `8724223`, same name, offsets within 0.05 / 3 min).

Net: **+3 accepted stations, no new merges.** The threshold isn't fragile — the genuine dup differs by 0.05 / 3 min while the nearest distinct pair differs by 0.14 / 18 min, a wide gap, so anywhere from 0.06/6 min to 0.1/10 min lands identically.

## Not fixed here

Suwarrow's coordinates are still wrong (it'll sit in the Tuamotus, not the Cook Islands). This PR stops the incorrect merge; correcting the coordinate is a separate data fix.

Tests cover all three restored stations plus the Little Torch Key dup staying merged. Lint and build are clean.