### PR TITLE
ci: cache GeoNames data to avoid re-downloading in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
           name: npm-dist
           path: "*.tgz"
 
+      # GeoNames data (cities500 + admin1 codes) is downloaded by the geocode
+      # test on first run. Cache it so we don't re-fetch ~10MB from
+      # download.geonames.org on every run. Bump the -v1 suffix to force a refresh.
+      - name: Cache GeoNames data
+        uses: actions/cache@v4
+        with:
+          path: tmp/geonames
+          key: geonames-v1
+
       - name: Run tests
         run: npm run test
 


### PR DESCRIPTION
The geocode test pulls `cities500.zip` and `admin1CodesASCII.txt` from download.geonames.org on every CI run. The download helper already skips fetching when the files are on disk, so the only missing piece was persisting `tmp/geonames` between runs.

This adds an `actions/cache` step keyed on `geonames-v1`. On a cache hit, the ~10MB download is skipped. Bump the version suffix in the key if the data ever needs refreshing.

One caveat: Actions caches populate from the default branch, so the first real speedup lands after this merges to main and CI runs there once. After that, PRs read the cached copy.