### PR TITLE
Add IOC SLSMF as a derived source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ This database includes harmonic constituents for tide prediction from various so
 - ✅ [**TICON-4**](data/ticon/README.md): TIdal CONstants based on GESLA-4 sea-level records
   ~4200+ global stations - ([#16](https://github.com/openwatersio/tide-database/pull/16))
 
+- ✅ [**IOC SLSMF**](data/ioc/README.md): Sea Level Station Monitoring Facility
+  Constituents fit by this project from quality-controlled observations of real-time gauges not covered by the sources above. Non-commercial.
+
 If you know of other public sources of harmonic constituents, please [open an issue](https://github.com/openwatersio/tide-database/issues/new) to discuss adding them.
 
 ## Usage

--- a/data/ioc/BANSI.json
+++ b/data/ioc/BANSI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Port of Syahbandar, Pulau Banyak, Aceh",
+  "region": "Aceh",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": 2.294681,
+  "longitude": 97.409745,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=BANSI",
+    "id": "BANSI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.448,
+    "MHHW": 1.157,
+    "MHW": 1.038,
+    "MSL": 0.849,
+    "MTL": 0.846,
+    "MLW": 0.653,
+    "MLLW": 0.618,
+    "LAT": 0.416,
+    "MHWS": 1.131,
+    "MLWS": 0.567
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.189,
+      "phase": 332.41
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.093,
+      "phase": 4.87
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.036,
+      "phase": 322.79
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.027,
+      "phase": 0.72
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.095,
+      "phase": 178.89
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.053,
+      "phase": 155.56
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.029,
+      "phase": 176.45
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.008,
+      "phase": 128.81
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 305.45
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 150.68
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 240.9
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 151.37
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 298.38
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 322.5
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.006,
+      "phase": 341.39
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.013,
+      "phase": 337.87
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.004,
+      "phase": 359.61
+    },
+    {
+      "name": "R2",
+      "amplitude": 0,
+      "phase": 248.66
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 345.04
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 186.54
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 162.71
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 221.81
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.013,
+      "phase": 302.45
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 223.99
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 183.84
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 197.46
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 41.96
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 121.16
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 88.56
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 112.3
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 163.76
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 327.03
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 272.12
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 331.98
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 227.72
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 211.59
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 215.09
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.015,
+      "phase": 55.06
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.014,
+      "phase": 349.77
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 240.41
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 21.24
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 103.61
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.046,
+      "phase": 212.79
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.068,
+      "phase": 101.63
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 263.94
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 328.87
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 34.64
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 242.86
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 359.7
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/BETSI.json
+++ b/data/ioc/BETSI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Port of Beo, North Sulawesi",
+  "region": "North Sulawesi",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": 4.230185,
+  "longitude": 126.788043,
+  "timezone": "Asia/Makassar",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=BETSI",
+    "id": "BETSI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.04,
+    "MHHW": 2.403,
+    "MHW": 2.316,
+    "MSL": 1.657,
+    "MTL": 1.676,
+    "MLW": 1.036,
+    "MLLW": 0.856,
+    "LAT": 0.227,
+    "MHWS": 2.591,
+    "MLWS": 0.723
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.595,
+      "phase": 275.07
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.339,
+      "phase": 310.97
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.1,
+      "phase": 261.21
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.096,
+      "phase": 301.9
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.216,
+      "phase": 80.49
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.109,
+      "phase": 67.09
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.085,
+      "phase": 72.84
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.023,
+      "phase": 76.72
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 204.18
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.015,
+      "phase": 220.19
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 196.59
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 146.65
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 267.66
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.015,
+      "phase": 288.39
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.022,
+      "phase": 259.2
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.028,
+      "phase": 227.86
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.033,
+      "phase": 308.24
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 11.99
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.011,
+      "phase": 280.23
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 167.27
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.015,
+      "phase": 295.97
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.013,
+      "phase": 165.85
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.034,
+      "phase": 43.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 173.82
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.014,
+      "phase": 98.49
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 131.07
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 67.23
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 53.61
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 72.59
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 70.96
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.012,
+      "phase": 166.85
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.006,
+      "phase": 271.07
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 248.72
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 36.61
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 177.52
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 10.05
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 64.5
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.022,
+      "phase": 88.95
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 10.71
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 343.72
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 358.25
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 64.19
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.047,
+      "phase": 202.13
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.033,
+      "phase": 67.62
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 319.99
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.007,
+      "phase": 231.42
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.019,
+      "phase": 257.46
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.009,
+      "phase": 223.89
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.019,
+      "phase": 313.32
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/CETR.json
+++ b/data/ioc/CETR.json
@@ -1,0 +1,289 @@
+{
+  "name": "Cetraro",
+  "region": "Calabria",
+  "country": "Italy",
+  "continent": "Europe",
+  "latitude": 39.52677,
+  "longitude": 15.920171,
+  "timezone": "Europe/Rome",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=CETR",
+    "id": "CETR",
+    "published_harmonics": false,
+    "operator": "Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 0.571,
+    "MHHW": 0.131,
+    "MHW": 0.131,
+    "MSL": 0,
+    "MTL": -0.001,
+    "MLW": -0.133,
+    "MLLW": -0.135,
+    "LAT": -0.689,
+    "MHWS": 0.173,
+    "MLWS": -0.173
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.126,
+      "phase": 216.55
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.047,
+      "phase": 236.01
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.025,
+      "phase": 204.35
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.014,
+      "phase": 250.39
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.031,
+      "phase": 183.72
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.009,
+      "phase": 153.37
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.009,
+      "phase": 119.5
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.021,
+      "phase": 331.95
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 210.47
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 187.56
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 38.59
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 186.48
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 225.98
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.01,
+      "phase": 240.68
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.008,
+      "phase": 140.45
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 175.93
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.004,
+      "phase": 226.95
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 61.8
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 300.86
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 359.85
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 2.83
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 274.74
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 17.21
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 228.23
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 285.13
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.01,
+      "phase": 284.3
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.012,
+      "phase": 129.17
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.008,
+      "phase": 15.42
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.009,
+      "phase": 202.89
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.008,
+      "phase": 145.34
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 247.95
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 124.53
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.005,
+      "phase": 172.85
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.003,
+      "phase": 97.08
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 228.29
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 315.4
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 71.99
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.103,
+      "phase": 35.24
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.038,
+      "phase": 188.41
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.045,
+      "phase": 259.44
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.102,
+      "phase": 93.02
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.056,
+      "phase": 281.83
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.059,
+      "phase": 198.73
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.101,
+      "phase": 250.8
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.008,
+      "phase": 32.03
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 153.94
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 261.99
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 150.66
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 243.98
+    }
+  ],
+  "epoch": {
+    "start": "2022-11-24",
+    "end": "2026-05-17"
+  }
+}

--- a/data/ioc/CIDJI.json
+++ b/data/ioc/CIDJI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Jayanti Beach, West Java",
+  "region": "West Java",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -7.49917,
+  "longitude": 107.386866,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=CIDJI",
+    "id": "CIDJI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.997,
+    "MHHW": 1.473,
+    "MHW": 1.252,
+    "MSL": 0.873,
+    "MTL": 0.889,
+    "MLW": 0.526,
+    "MLLW": 0.428,
+    "LAT": -0.051,
+    "MHWS": 1.431,
+    "MLWS": 0.315
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.374,
+      "phase": 358.33
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.184,
+      "phase": 55.23
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.072,
+      "phase": 330.41
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.052,
+      "phase": 57.62
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.182,
+      "phase": 157.04
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.113,
+      "phase": 151.73
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.056,
+      "phase": 158.43
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.021,
+      "phase": 138.77
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 345.1
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 19.98
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 321.29
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 180.57
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.006,
+      "phase": 269.77
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.014,
+      "phase": 318.56
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 333.59
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 279.85
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.01,
+      "phase": 40.37
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 357.75
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 39.82
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 43.51
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 298.75
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 287.27
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.014,
+      "phase": 36.51
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.009,
+      "phase": 237.7
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.011,
+      "phase": 162.79
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.01,
+      "phase": 190.98
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 100.1
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 147.91
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 124.02
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 151.75
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.007,
+      "phase": 263.67
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.004,
+      "phase": 281.46
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 301.01
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 4.12
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 262.1
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 18.06
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 141.79
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.03,
+      "phase": 94.33
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.016,
+      "phase": 343.44
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 262.33
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 323.1
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 119.39
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.117,
+      "phase": 304.62
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.058,
+      "phase": 111.31
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 284.67
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 319.95
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.02,
+      "phase": 306.94
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 129.53
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 123.05
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ENGSI.json
+++ b/data/ioc/ENGSI.json
@@ -1,0 +1,288 @@
+{
+  "name": "Port of Malakoni, Enggano, Bengkulu",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -5.34599,
+  "longitude": 102.277817,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ENGSI",
+    "id": "ENGSI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.956,
+    "MHHW": 2.507,
+    "MHW": 2.352,
+    "MSL": 2.026,
+    "MTL": 2.029,
+    "MLW": 1.705,
+    "MLLW": 1.668,
+    "LAT": 1.37,
+    "MHWS": 2.47,
+    "MLWS": 1.582
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.313,
+      "phase": 324.5
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.131,
+      "phase": 14.25
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.064,
+      "phase": 306.6
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.035,
+      "phase": 10.32
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.153,
+      "phase": 153.83
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.092,
+      "phase": 147.33
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.042,
+      "phase": 142.49
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.018,
+      "phase": 137.43
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 324.94
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 50.86
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 282.42
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 200.53
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.006,
+      "phase": 265.58
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.011,
+      "phase": 309.73
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.013,
+      "phase": 292
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 345.26
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 37.87
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 37.19
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 304.1
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 201.84
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 346.57
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 329.32
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 322.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 226.06
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 149.29
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 197.54
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 109.9
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 116.02
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 94.96
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 119.55
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.004,
+      "phase": 239.03
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 7.89
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 270.87
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 65.68
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 297.68
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 259.73
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 117.42
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 32.76
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.014,
+      "phase": 354.17
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 50.92
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 9.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 173.66
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.073,
+      "phase": 242.51
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.051,
+      "phase": 117.35
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 303.13
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 68.65
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 215.83
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 279.34
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 69.16
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/GESJI.json
+++ b/data/ioc/GESJI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Gesing Beach, Panggang, Yogyakarta",
+  "region": "Yogyakarta",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -8.107678,
+  "longitude": 110.468404,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=GESJI",
+    "id": "GESJI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.407,
+    "MHHW": 1.745,
+    "MHW": 1.541,
+    "MSL": 1.015,
+    "MTL": 1.017,
+    "MLW": 0.493,
+    "MLLW": 0.396,
+    "LAT": -0.192,
+    "MHWS": 1.773,
+    "MLWS": 0.257
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.493,
+      "phase": 14.72
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.265,
+      "phase": 72.92
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.091,
+      "phase": 348.21
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.075,
+      "phase": 71.66
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.196,
+      "phase": 156.54
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.125,
+      "phase": 150.14
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.054,
+      "phase": 160.91
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.025,
+      "phase": 143.81
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 15.49
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 52.59
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 48.1
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 186.56
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 296.14
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.013,
+      "phase": 342.63
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 358.55
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.013,
+      "phase": 45.34
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.017,
+      "phase": 68.87
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 40.61
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 56.53
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 3.95
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 77.81
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 69.26
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 287.45
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 231.6
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.013,
+      "phase": 164.59
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 209.76
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 103.14
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 136.19
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 118.79
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 215.08
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 17.32
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 56.07
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 18.46
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 324.66
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 265.36
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 297.51
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 28.03
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.038,
+      "phase": 102.64
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.023,
+      "phase": 347.53
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 317.63
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.01,
+      "phase": 354.01
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.01,
+      "phase": 218.69
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.177,
+      "phase": 287.24
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.073,
+      "phase": 105.44
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 292.33
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 4.59
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 260.45
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 164.95
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 172.77
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/GRJJI.json
+++ b/data/ioc/GRJJI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Port of Grajagan, East Java",
+  "region": "East Java",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -8.599004,
+  "longitude": 114.22604,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=GRJJI",
+    "id": "GRJJI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.443,
+    "MHHW": 2.643,
+    "MHW": 2.456,
+    "MSL": 1.719,
+    "MTL": 1.812,
+    "MLW": 1.168,
+    "MLLW": 0.969,
+    "LAT": 0.346,
+    "MHWS": 2.503,
+    "MLWS": 0.935
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.546,
+      "phase": 53.02
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.238,
+      "phase": 119.08
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.101,
+      "phase": 32.79
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.088,
+      "phase": 116.52
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.173,
+      "phase": 184.97
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.101,
+      "phase": 181.38
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.052,
+      "phase": 197.61
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.027,
+      "phase": 175.88
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.024,
+      "phase": 26.51
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.035,
+      "phase": 88.93
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.008,
+      "phase": 2.75
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.006,
+      "phase": 208.19
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.018,
+      "phase": 357.69
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.061,
+      "phase": 148.42
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.012,
+      "phase": 351.5
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.026,
+      "phase": 100.29
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.017,
+      "phase": 184.45
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.024,
+      "phase": 89.49
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.018,
+      "phase": 34.36
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.037,
+      "phase": 338.86
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.024,
+      "phase": 83.95
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.029,
+      "phase": 347.19
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.037,
+      "phase": 82.08
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.015,
+      "phase": 276.74
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 49.36
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.02,
+      "phase": 318.61
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.018,
+      "phase": 38.77
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 272.74
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.025,
+      "phase": 177.41
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.013,
+      "phase": 225.71
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.012,
+      "phase": 120.24
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.015,
+      "phase": 202.25
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.011,
+      "phase": 37.33
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.004,
+      "phase": 358.69
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.012,
+      "phase": 293.36
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.016,
+      "phase": 235.98
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.012,
+      "phase": 333.81
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.041,
+      "phase": 140.52
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.038,
+      "phase": 54.85
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.046,
+      "phase": 81.08
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.081,
+      "phase": 132.26
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.066,
+      "phase": 224.11
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.419,
+      "phase": 296.08
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.158,
+      "phase": 233.47
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.014,
+      "phase": 111.11
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.009,
+      "phase": 256.32
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.017,
+      "phase": 236.35
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.014,
+      "phase": 345.36
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.032,
+      "phase": 172.76
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/KMMSI.json
+++ b/data/ioc/KMMSI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Port of Kema Fishing, North Sulawesi",
+  "region": "North Sulawesi",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": 1.357959,
+  "longitude": 125.076832,
+  "timezone": "Asia/Makassar",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=KMMSI",
+    "id": "KMMSI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.31,
+    "MHHW": 1.839,
+    "MHW": 1.668,
+    "MSL": 1.267,
+    "MTL": 1.265,
+    "MLW": 0.861,
+    "MLLW": 0.761,
+    "LAT": 0.418,
+    "MHWS": 1.823,
+    "MLWS": 0.711
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.331,
+      "phase": 257.96
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.225,
+      "phase": 294.43
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.049,
+      "phase": 247.94
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.067,
+      "phase": 288.85
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.208,
+      "phase": 120.33
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.114,
+      "phase": 101.98
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.068,
+      "phase": 117.8
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.023,
+      "phase": 102.23
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 131.82
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 217.79
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 116.61
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 157.64
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 276.83
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.011,
+      "phase": 286.53
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 233.01
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.019,
+      "phase": 278.77
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.012,
+      "phase": 329.13
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 234.18
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 218.09
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 144.16
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 3.28
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 130.5
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.013,
+      "phase": 95.4
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.008,
+      "phase": 185.73
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.012,
+      "phase": 147.74
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 196.15
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 78.2
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 97.66
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 90.74
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 30.9
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.005,
+      "phase": 172.14
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 243.5
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 339.09
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 103.4
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 290.41
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 203.5
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 70.82
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 94.99
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 6.41
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 346.62
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 335.34
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 108.36
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.088,
+      "phase": 295.85
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.033,
+      "phase": 74.4
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 290.12
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 305.89
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.009,
+      "phase": 18.75
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 141.58
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 263.49
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/KUTBI.json
+++ b/data/ioc/KUTBI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Pier of PPI Kedonganan, Bali",
+  "region": "Bali",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -8.757512,
+  "longitude": 115.166372,
+  "timezone": "Asia/Makassar",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=KUTBI",
+    "id": "KUTBI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.899,
+    "MHHW": 2.103,
+    "MHW": 1.934,
+    "MSL": 1.148,
+    "MTL": 1.152,
+    "MLW": 0.371,
+    "MLLW": 0.195,
+    "LAT": -0.543,
+    "MHWS": 2.245,
+    "MLWS": 0.051
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.71,
+      "phase": 35.69
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.387,
+      "phase": 88.78
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.124,
+      "phase": 10.16
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.112,
+      "phase": 86.12
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.225,
+      "phase": 162.44
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.142,
+      "phase": 154.57
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.066,
+      "phase": 157.36
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 145.44
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 230.49
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 337.16
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 115.42
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 163.58
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 342.5
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.013,
+      "phase": 347.8
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.03,
+      "phase": 16.47
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.027,
+      "phase": 57.7
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.019,
+      "phase": 100.1
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.012,
+      "phase": 95.98
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.009,
+      "phase": 48.69
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 346.67
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 173.91
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.009,
+      "phase": 25.18
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.018,
+      "phase": 288.08
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.008,
+      "phase": 227.72
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.013,
+      "phase": 171.91
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.011,
+      "phase": 202.15
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 119.1
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 143.09
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 133.41
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 195.15
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 275.81
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 41.1
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 205.19
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 58.68
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 202.55
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 165.45
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 166.09
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.026,
+      "phase": 115.75
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.019,
+      "phase": 353.89
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 68.42
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 351.32
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 137.22
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.227,
+      "phase": 290.25
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.067,
+      "phase": 125.56
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 341.83
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.006,
+      "phase": 311.95
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 198.99
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 110.54
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 160.65
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-20",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/LAMSI.json
+++ b/data/ioc/LAMSI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Public Pier of Lamteng, Aceh",
+  "region": "Aceh",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": 5.640443,
+  "longitude": 95.159167,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=LAMSI",
+    "id": "LAMSI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.61,
+    "MHHW": 2.221,
+    "MHW": 2.114,
+    "MSL": 1.653,
+    "MTL": 1.664,
+    "MLW": 1.213,
+    "MLLW": 1.133,
+    "LAT": 0.693,
+    "MHWS": 2.28,
+    "MLWS": 1.026
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.425,
+      "phase": 74
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.202,
+      "phase": 106.64
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.088,
+      "phase": 64.64
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.052,
+      "phase": 99.99
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.102,
+      "phase": 209.89
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.043,
+      "phase": 173.27
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.032,
+      "phase": 203.99
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.007,
+      "phase": 160.79
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 146.73
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 157.79
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 95.38
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 56.24
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 50.36
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.014,
+      "phase": 117.54
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 67.48
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.051,
+      "phase": 71.09
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.016,
+      "phase": 123.19
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.005,
+      "phase": 119.96
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 56.57
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 272.03
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.019,
+      "phase": 180.84
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.007,
+      "phase": 17.56
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.017,
+      "phase": 292.58
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 240.35
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 207.13
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 214.21
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 64.93
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 110.89
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 329.39
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 137.1
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 111.4
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 114.29
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 282.29
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 280.14
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 88.67
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 237.25
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 241.01
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 145.41
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.014,
+      "phase": 349.42
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 302.18
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 37.66
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 97.32
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.042,
+      "phase": 164.13
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.064,
+      "phase": 84.43
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 137.44
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 187.75
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.036,
+      "phase": 133.43
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 292.58
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 301.49
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/MRTM.json
+++ b/data/ioc/MRTM.json
@@ -1,0 +1,289 @@
+{
+  "name": "Marettimo",
+  "region": "Sicily",
+  "country": "Italy",
+  "continent": "Europe",
+  "latitude": 37.966238,
+  "longitude": 12.076653,
+  "timezone": "Europe/Rome",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=MRTM",
+    "id": "MRTM",
+    "published_harmonics": false,
+    "operator": "Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.637,
+    "MHHW": 0.022,
+    "MHW": -0.026,
+    "MSL": -0.107,
+    "MTL": -0.105,
+    "MLW": -0.184,
+    "MLLW": -0.244,
+    "LAT": -1.219,
+    "MHWS": 0.005,
+    "MLWS": -0.219
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.087,
+      "phase": 210.25
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.025,
+      "phase": 249.3
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.017,
+      "phase": 209.46
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.008,
+      "phase": 258.57
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.028,
+      "phase": 163.06
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.015,
+      "phase": 92.38
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.011,
+      "phase": 122.57
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.004,
+      "phase": 117.35
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 109.37
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 196.77
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 116
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 273.44
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 161.53
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.003,
+      "phase": 186.7
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 75.56
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 261.91
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 159.13
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.009,
+      "phase": 86.74
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 156.64
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 8.81
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 290.46
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.008,
+      "phase": 254.52
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 90.95
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 267.98
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.002,
+      "phase": 208.2
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 351.5
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 121.44
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 244.67
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 199.87
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 141.56
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 253.29
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 136.74
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 226.39
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 220.25
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 28.4
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 32.8
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 100.62
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.031,
+      "phase": 217.13
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.013,
+      "phase": 174.06
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.038,
+      "phase": 330.83
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.021,
+      "phase": 46.1
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.028,
+      "phase": 251.71
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.642,
+      "phase": 339.39
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.276,
+      "phase": 140.68
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 198.47
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 82.97
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 240.28
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 253.04
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 334.28
+    }
+  ],
+  "epoch": {
+    "start": "2022-11-24",
+    "end": "2026-01-19"
+  }
+}

--- a/data/ioc/MRTMI.json
+++ b/data/ioc/MRTMI.json
@@ -1,0 +1,288 @@
+{
+  "name": "Port of Bere-Bere, North Maluku",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": 2.388924,
+  "longitude": 128.666864,
+  "timezone": "Asia/Jayapura",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=MRTMI",
+    "id": "MRTMI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.547,
+    "MHHW": 2.079,
+    "MHW": 1.936,
+    "MSL": 1.373,
+    "MTL": 1.39,
+    "MLW": 0.844,
+    "MLLW": 0.771,
+    "LAT": 0.095,
+    "MHWS": 2.139,
+    "MLWS": 0.607
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.532,
+      "phase": 271.58
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.234,
+      "phase": 303.85
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.101,
+      "phase": 256.92
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.066,
+      "phase": 304.8
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.2,
+      "phase": 87.11
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.146,
+      "phase": 70.47
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.066,
+      "phase": 84.5
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.032,
+      "phase": 59.01
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 84.89
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 87.38
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 84.82
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 194.9
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 253.97
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.011,
+      "phase": 273.03
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 262.17
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.034,
+      "phase": 277.03
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.024,
+      "phase": 303.73
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 253.36
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 295.84
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 191.77
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 240.79
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.011,
+      "phase": 72.65
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 321.89
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 142.79
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.013,
+      "phase": 99.7
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 115.11
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 53
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 71.66
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 53.1
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 8.76
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 149.64
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 219.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 259.11
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 115.65
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 274.64
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 190.81
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 151.73
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 69.95
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 24.3
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 337.68
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 357.02
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 83.81
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.055,
+      "phase": 272.47
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 60.48
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 266.2
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 245.21
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.02,
+      "phase": 333.77
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 48.08
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 113.41
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/PAYJI.json
+++ b/data/ioc/PAYJI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Teluk Love, Payangan Beach, East Java",
+  "region": "East Java",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -8.438192,
+  "longitude": 113.580529,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=PAYJI",
+    "id": "PAYJI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 23.699,
+    "MHHW": 1.753,
+    "MHW": 1.708,
+    "MSL": 0,
+    "MTL": 0.329,
+    "MLW": -1.05,
+    "MLLW": -1.767,
+    "LAT": -34.658,
+    "MHWS": 1.196,
+    "MLWS": -1.196
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.515,
+      "phase": 33.93
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.681,
+      "phase": 39.18
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.126,
+      "phase": 157.69
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.383,
+      "phase": 116.12
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.322,
+      "phase": 347
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.044,
+      "phase": 41
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.652,
+      "phase": 70.62
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.131,
+      "phase": 356.1
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.062,
+      "phase": 129.48
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.106,
+      "phase": 106.36
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.052,
+      "phase": 21.38
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.057,
+      "phase": 321.94
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.216,
+      "phase": 229.58
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.178,
+      "phase": 332.07
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.185,
+      "phase": 272.66
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.857,
+      "phase": 51.12
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.18,
+      "phase": 254.14
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.621,
+      "phase": 331.55
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.098,
+      "phase": 203.63
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.021,
+      "phase": 165.27
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.134,
+      "phase": 111.44
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.143,
+      "phase": 330.22
+    },
+    {
+      "name": "S1",
+      "amplitude": 1.013,
+      "phase": 25.04
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.084,
+      "phase": 142.85
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.031,
+      "phase": 200.96
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.064,
+      "phase": 56.66
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.091,
+      "phase": 120.88
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.1,
+      "phase": 118.58
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.113,
+      "phase": 176.46
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.024,
+      "phase": 89.15
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.381,
+      "phase": 175.98
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.073,
+      "phase": 181.94
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.049,
+      "phase": 347.16
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.013,
+      "phase": 279.76
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.046,
+      "phase": 208.94
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.038,
+      "phase": 63.57
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.036,
+      "phase": 323.37
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.688,
+      "phase": 86.2
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.023,
+      "phase": 353.44
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.077,
+      "phase": 311.28
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.132,
+      "phase": 346.77
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.642,
+      "phase": 137.37
+    },
+    {
+      "name": "SA",
+      "amplitude": 20.01,
+      "phase": 155.47
+    },
+    {
+      "name": "SSA",
+      "amplitude": 9.571,
+      "phase": 148.4
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.068,
+      "phase": 7.42
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.053,
+      "phase": 20.89
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.894,
+      "phase": 110.43
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.269,
+      "phase": 322.72
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.165,
+      "phase": 303.56
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-25",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/PEISI.json
+++ b/data/ioc/PEISI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Pier of Pei-pei, West Sumatra",
+  "region": "West Sumatra",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -1.778939,
+  "longitude": 99.247019,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=PEISI",
+    "id": "PEISI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.866,
+    "MHHW": 1.449,
+    "MHW": 1.3,
+    "MSL": 0.989,
+    "MTL": 0.984,
+    "MLW": 0.667,
+    "MLLW": 0.639,
+    "LAT": 0.35,
+    "MHWS": 1.426,
+    "MLWS": 0.552
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.305,
+      "phase": 314.18
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.132,
+      "phase": 355.22
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.065,
+      "phase": 299.99
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.035,
+      "phase": 352.84
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.127,
+      "phase": 161.16
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.075,
+      "phase": 147.67
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.039,
+      "phase": 154.36
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.014,
+      "phase": 135.82
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.01,
+      "phase": 349.49
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 102.35
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 291.51
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 140.62
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 258.29
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.014,
+      "phase": 309.68
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.01,
+      "phase": 298.06
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.012,
+      "phase": 344.36
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 331.35
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 7.28
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 337.05
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 176.02
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 227.83
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 207.94
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.011,
+      "phase": 292.31
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 211.67
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 161.04
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 194.18
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 92.09
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 120.82
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 105.7
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 114.09
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 246.04
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 348.66
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 238.58
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 277.25
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 58.37
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 288.51
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 161.91
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.018,
+      "phase": 61.54
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 348.48
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 42.55
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.01,
+      "phase": 340.81
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 106.53
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.048,
+      "phase": 217.94
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.072,
+      "phase": 108.65
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 291.15
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 51.93
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 140.79
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 238.65
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 4.12
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/PSCA.json
+++ b/data/ioc/PSCA.json
@@ -1,0 +1,289 @@
+{
+  "name": "Pantelleria (Scauri)",
+  "region": "Sicily",
+  "country": "Italy",
+  "continent": "Europe",
+  "latitude": 36.76863,
+  "longitude": 11.96355,
+  "timezone": "Europe/Rome",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=PSCA",
+    "id": "PSCA",
+    "published_harmonics": false,
+    "operator": "Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 0.619,
+    "MHHW": 0.053,
+    "MHW": 0.04,
+    "MSL": 0,
+    "MTL": -0.003,
+    "MLW": -0.046,
+    "MLLW": -0.052,
+    "LAT": -0.495,
+    "MHWS": 0.045,
+    "MLWS": -0.045
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.022,
+      "phase": 39.35
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.023,
+      "phase": 38.43
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.002,
+      "phase": 25.73
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.015,
+      "phase": 55.66
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.01,
+      "phase": 72.78
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.01,
+      "phase": 102.81
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.013,
+      "phase": 309.35
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.013,
+      "phase": 304.42
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 235.33
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 276.79
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 234.57
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 189.49
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 210.03
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.003,
+      "phase": 122.74
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 3.12
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 214.54
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.013,
+      "phase": 140.29
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 71.68
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 25.11
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 138
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 298.67
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 233.6
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.015,
+      "phase": 205.37
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.009,
+      "phase": 3
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 355.55
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 209.38
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.012,
+      "phase": 78.59
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.021,
+      "phase": 189.78
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 194.72
+    },
+    {
+      "name": "M3",
+      "amplitude": 0,
+      "phase": 357.4
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.004,
+      "phase": 76.19
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.008,
+      "phase": 330.69
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.008,
+      "phase": 165.49
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.003,
+      "phase": 252.47
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 15.36
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 263.68
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 148.3
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.121,
+      "phase": 340.34
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.018,
+      "phase": 99.9
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.052,
+      "phase": 115.68
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.033,
+      "phase": 36.19
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.016,
+      "phase": 161.92
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.228,
+      "phase": 197.08
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.098,
+      "phase": 82.25
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.011,
+      "phase": 28.38
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 131.36
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.008,
+      "phase": 272.13
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 68.22
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 218.11
+    }
+  ],
+  "epoch": {
+    "start": "2022-11-26",
+    "end": "2026-07-26"
+  }
+}

--- a/data/ioc/RCCL.json
+++ b/data/ioc/RCCL.json
@@ -1,0 +1,289 @@
+{
+  "name": "Roccella Jonica",
+  "region": "Calabria",
+  "country": "Italy",
+  "continent": "Europe",
+  "latitude": 38.327075,
+  "longitude": 16.43233,
+  "timezone": "Europe/Rome",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=RCCL",
+    "id": "RCCL",
+    "published_harmonics": false,
+    "operator": "Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 0.43,
+    "MHHW": 0.082,
+    "MHW": 0.077,
+    "MSL": 0,
+    "MTL": -0.001,
+    "MLW": -0.079,
+    "MLLW": -0.09,
+    "LAT": -0.352,
+    "MHWS": 0.099,
+    "MLWS": -0.099
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.07,
+      "phase": 57.97
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.029,
+      "phase": 39.03
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.01,
+      "phase": 68.58
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.005,
+      "phase": 24.11
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.023,
+      "phase": 30.45
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.025,
+      "phase": 10.27
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.016,
+      "phase": 144.56
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.016,
+      "phase": 348.38
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 143.43
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 290.23
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 206.18
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 338.85
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.016,
+      "phase": 54.33
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 139.16
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 81.95
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 267.62
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.015,
+      "phase": 31.6
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.007,
+      "phase": 2.54
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.01,
+      "phase": 170.5
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 204.13
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 285.57
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.013,
+      "phase": 298.9
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.016,
+      "phase": 228.53
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.011,
+      "phase": 21.31
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.013,
+      "phase": 184
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 331.7
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 308.41
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.009,
+      "phase": 41.37
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.01,
+      "phase": 175.25
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 158.32
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.005,
+      "phase": 34.24
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.005,
+      "phase": 120.66
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 72.56
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 44.92
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 186.08
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.003,
+      "phase": 242.77
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 105.56
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.013,
+      "phase": 343.17
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.04,
+      "phase": 242.83
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.062,
+      "phase": 158.61
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.03,
+      "phase": 255.21
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.021,
+      "phase": 342.15
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.042,
+      "phase": 165.91
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.047,
+      "phase": 141.8
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 215.93
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.008,
+      "phase": 114.5
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 271.63
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.005,
+      "phase": 37.89
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 247.17
+    }
+  ],
+  "epoch": {
+    "start": "2022-11-27",
+    "end": "2026-05-17"
+  }
+}

--- a/data/ioc/README.md
+++ b/data/ioc/README.md
@@ -1,0 +1,26 @@
+# IOC SLSMF Tide Station Data
+
+The [IOC Sea Level Station Monitoring Facility](https://www.ioc-sealevelmonitoring.org/) (SLSMF, run by the Flanders Marine Institute for UNESCO/IOC) relays ~1,600 real-time tide gauges worldwide. It publishes **relative sea level only** — no harmonic constituents and no vertical datum — so this is the database's first _derived_ source: the constituents are fit by this project from SLSMF's quality-controlled observations (`published_harmonics: false`).
+
+**Key Details:**
+
+- **Source:** [SLSMF](https://www.ioc-sealevelmonitoring.org/) via the [v2 research API](https://api.ioc-sealevelmonitoring.org/v2/doc) (API key required)
+- **Citation:** Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482
+- **License:** [IOC data policy](https://www.ioc-sealevelmonitoring.org/disclaimer.php) — non-commercial use only; commercial users should contact the data originator, recorded per station in `source.operator`. VLIZ confirmed by email (September 2026) that redistributing derived constituents with this citation is acceptable.
+- **Coverage:** only gauges that are still reporting and sit more than 3 km from every station in the other sources, so this fills gaps (Chile, Taiwan, Indonesia, Greece, island gauges) rather than duplicating them. See [#124](https://github.com/openwatersio/tide-database/issues/124).
+
+## Harmonic constituents
+
+The research endpoint returns observations with SLSMF's automatic QC applied: days flagged for low completeness, low distinctness, or a datum shift, and samples flagged out-of-range, spike, or flat-line, are nulled upstream and dropped here. The remaining record is binned to hourly means and the standard TICON-4 constituent set (50 constituents) is fit by least squares with [`tools/harmonic-analysis.ts`](../../tools/harmonic-analysis.ts) — the same fitter used to re-analyze mislabeled TICON sources. Records shorter than one year are skipped.
+
+## Tidal datums
+
+Datums follow the TICON-4 approach (see [data/ticon/README.md](../ticon/README.md) and [docs/datums.md](../../docs/datums.md)): mean datums reduced directly from the observations, astronomical and amplitude-derived datums from the harmonic side shifted into the observed MSL frame. They are in **the gauge's own relative frame** — SLSMF holds no vertical datum information — which every station's `disclaimers` notes. Good for timing and range; weak for chart-datum heights.
+
+## Regenerating
+
+```sh
+IOC_API_KEY=… node tools/import-ioc.ts
+```
+
+Register at https://www.ioc-sealevelmonitoring.org/api.php and request the "gauges API" group. Responses are cached under `tmp/IOC/` (not committed). Without `FORCE=1`, stations already in this directory keep their cached fit and only the metadata is recomputed. The default record is the last 6 years (a station-year is a ~40 MB response); set `IOC_FROM=2007` for the full datum epoch.

--- a/data/ioc/SIMSI.json
+++ b/data/ioc/SIMSI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Makam Beach, Aceh",
+  "region": "Aceh",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": 2.585085,
+  "longitude": 95.929812,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=SIMSI",
+    "id": "SIMSI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 1.948,
+    "MHHW": 0.579,
+    "MHW": 0.502,
+    "MSL": 0,
+    "MTL": -0.002,
+    "MLW": -0.507,
+    "MLLW": -0.575,
+    "LAT": -2.131,
+    "MHWS": 0.36,
+    "MLWS": -0.36
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.22,
+      "phase": 303.52
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.14,
+      "phase": 15.33
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.039,
+      "phase": 278.97
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.054,
+      "phase": 293.74
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.038,
+      "phase": 254.35
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.068,
+      "phase": 163.57
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.176,
+      "phase": 206.44
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.041,
+      "phase": 82.84
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.037,
+      "phase": 239.45
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 70.8
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.005,
+      "phase": 137.07
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 273.5
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.029,
+      "phase": 81.65
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.032,
+      "phase": 221.25
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.013,
+      "phase": 8.79
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.35,
+      "phase": 236.88
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.098,
+      "phase": 297.81
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.056,
+      "phase": 77.3
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.033,
+      "phase": 55.16
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.011,
+      "phase": 256.08
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.042,
+      "phase": 170.23
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.076,
+      "phase": 336.05
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.09,
+      "phase": 119.22
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.008,
+      "phase": 103.83
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.024,
+      "phase": 281.61
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.045,
+      "phase": 216.36
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.061,
+      "phase": 102.98
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.059,
+      "phase": 168.39
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.07,
+      "phase": 171.32
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.029,
+      "phase": 9.92
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.059,
+      "phase": 330.43
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 206.13
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.036,
+      "phase": 254.34
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.011,
+      "phase": 54.92
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.01,
+      "phase": 184.64
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.009,
+      "phase": 289.63
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.006,
+      "phase": 237.69
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.029,
+      "phase": 344.95
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.019,
+      "phase": 314.21
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.086,
+      "phase": 347.8
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.058,
+      "phase": 77.75
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 328.08
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.078,
+      "phase": 140.31
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.321,
+      "phase": 143.11
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.054,
+      "phase": 305.93
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.019,
+      "phase": 29.88
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.369,
+      "phase": 290.87
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.091,
+      "phase": 140.6
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.035,
+      "phase": 317.58
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/SRMPI.json
+++ b/data/ioc/SRMPI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Port of Sarmi, Papua",
+  "region": "Papua",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -1.85802,
+  "longitude": 138.75323,
+  "timezone": "Asia/Jayapura",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=SRMPI",
+    "id": "SRMPI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.054,
+    "MHHW": 2.781,
+    "MHW": 2.713,
+    "MSL": 2.335,
+    "MTL": 2.356,
+    "MLW": 1.999,
+    "MLLW": 1.727,
+    "LAT": 1.339,
+    "MHWS": 2.773,
+    "MLWS": 1.897
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.347,
+      "phase": 278.04
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.091,
+      "phase": 304.24
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.075,
+      "phase": 257.04
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.024,
+      "phase": 299.62
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.224,
+      "phase": 60.67
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.146,
+      "phase": 50.68
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.071,
+      "phase": 62.92
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 38.1
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 189.48
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 249.07
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 132.75
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 56.71
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 218.76
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 271.81
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.013,
+      "phase": 265.77
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.026,
+      "phase": 323.5
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 285.73
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 134.42
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 214.71
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 40.17
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 313.15
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.008,
+      "phase": 35.37
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.011,
+      "phase": 288.99
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 123.81
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 81.01
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 92.63
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 39.09
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 47.49
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 29.2
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 220.14
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 242.63
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 221.51
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 178.76
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 48.45
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 46.16
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 9.45
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 19.64
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.021,
+      "phase": 58.73
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 25.86
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.009,
+      "phase": 302.12
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 323
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 169.42
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.028,
+      "phase": 208.15
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.047,
+      "phase": 87.91
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 254.02
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 326.91
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.015,
+      "phase": 44.2
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 41.6
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 106.52
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/SUBSI.json
+++ b/data/ioc/SUBSI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Pier of Air Bangis, West Sumatra",
+  "region": "West Sumatra",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": 0.214497,
+  "longitude": 99.36575,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=SUBSI",
+    "id": "SUBSI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.285,
+    "MHHW": 1.751,
+    "MHW": 1.576,
+    "MSL": 1.21,
+    "MTL": 1.211,
+    "MLW": 0.845,
+    "MLLW": 0.777,
+    "LAT": 0.417,
+    "MHWS": 1.75,
+    "MLWS": 0.67
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.381,
+      "phase": 322.97
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.159,
+      "phase": 3.04
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.08,
+      "phase": 304.5
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.046,
+      "phase": 359.9
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.133,
+      "phase": 167.74
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.079,
+      "phase": 155.79
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.04,
+      "phase": 166.98
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.016,
+      "phase": 141.18
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.021,
+      "phase": 358.46
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.009,
+      "phase": 114.24
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.009,
+      "phase": 308.69
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 26.93
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 276.5
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.014,
+      "phase": 319.34
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.024,
+      "phase": 310.62
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.013,
+      "phase": 165.42
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.016,
+      "phase": 0.71
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 78.99
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 251.38
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 269.53
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 4.79
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 76.74
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.012,
+      "phase": 324.57
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 231.23
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 161.38
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 196.56
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 98.75
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 134.92
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 88.72
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 130.64
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 235.12
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.004,
+      "phase": 5.44
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 287.98
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 234.99
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 122.7
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 302.67
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 216.07
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 35.9
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 350.03
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 63.72
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.01,
+      "phase": 338.21
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 97.7
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.051,
+      "phase": 215.85
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.066,
+      "phase": 107.05
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 248.61
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 54.63
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.022,
+      "phase": 223.72
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.007,
+      "phase": 259.64
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 9.5
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/TASJI.json
+++ b/data/ioc/TASJI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Baron Beach, Yogyakarta",
+  "region": "Yogyakarta",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -8.131006,
+  "longitude": 110.54849,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=TASJI",
+    "id": "TASJI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.157,
+    "MHHW": 1.513,
+    "MHW": 1.183,
+    "MSL": 0.766,
+    "MTL": 0.769,
+    "MLW": 0.354,
+    "MLLW": 0.136,
+    "LAT": -0.464,
+    "MHWS": 1.521,
+    "MLWS": 0.011
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.49,
+      "phase": 15.55
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.265,
+      "phase": 74.49
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.092,
+      "phase": 349.64
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.074,
+      "phase": 72.26
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.195,
+      "phase": 157.77
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.123,
+      "phase": 149.07
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.05,
+      "phase": 160.2
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.024,
+      "phase": 140.61
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 16.3
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 70.02
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 322.73
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 205.28
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 290.34
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.014,
+      "phase": 331.85
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 1.5
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 93.24
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.016,
+      "phase": 78.99
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 102.44
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.008,
+      "phase": 55.84
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 339.71
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 29.87
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 26.07
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.03,
+      "phase": 277.14
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.008,
+      "phase": 223.09
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.013,
+      "phase": 166.89
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 209.28
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 91.77
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 144.99
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 123.75
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 222.36
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 58.84
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 124.98
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 37.28
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 318.78
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 268.94
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 113.29
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 12.96
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.038,
+      "phase": 122.64
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.017,
+      "phase": 351.68
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 100.1
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 336.32
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 186.68
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.194,
+      "phase": 290.81
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.078,
+      "phase": 110.29
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 316.73
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 349.75
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.016,
+      "phase": 246.55
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 119.8
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 251.07
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/TBSSI.json
+++ b/data/ioc/TBSSI.json
@@ -1,0 +1,289 @@
+{
+  "name": "Talengen Tourism Pier, North Sulawesi",
+  "region": "North Sulawesi",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": 3.590355,
+  "longitude": 125.566576,
+  "timezone": "Asia/Makassar",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=TBSSI",
+    "id": "TBSSI",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.556,
+    "MHHW": 2.064,
+    "MHW": 1.908,
+    "MSL": 1.34,
+    "MTL": 1.336,
+    "MLW": 0.764,
+    "MLLW": 0.679,
+    "LAT": 0.203,
+    "MHWS": 2.151,
+    "MLWS": 0.529
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.525,
+      "phase": 272.69
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.286,
+      "phase": 306.63
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.091,
+      "phase": 259.73
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.083,
+      "phase": 301.36
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.15,
+      "phase": 112.11
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.123,
+      "phase": 95.73
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 105.9
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.026,
+      "phase": 84.23
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 285.71
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 17.62
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 267.68
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 350.21
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 251.4
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.013,
+      "phase": 278.35
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 257.87
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.024,
+      "phase": 268.19
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.016,
+      "phase": 301.01
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 243.54
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.007,
+      "phase": 261.35
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 180.83
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.006,
+      "phase": 121.79
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 219.26
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.016,
+      "phase": 287.84
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 184.3
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 128.51
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 137.78
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 77.62
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 87.73
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 81.17
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 60.6
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 9.28
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 69.54
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 19.3
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 58.48
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 296.05
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 20.84
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 238.87
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.013,
+      "phase": 89.2
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 10.14
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 334.43
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.009,
+      "phase": 343.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 103.29
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.058,
+      "phase": 279
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.036,
+      "phase": 57.4
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 271.67
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 238.39
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.009,
+      "phase": 319.28
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 176.61
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 189.36
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-19",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/TEUL.json
+++ b/data/ioc/TEUL.json
@@ -1,0 +1,289 @@
+{
+  "name": "Teulada",
+  "region": "Sardinia",
+  "country": "Italy",
+  "continent": "Europe",
+  "latitude": 38.927562,
+  "longitude": 8.719502,
+  "timezone": "Europe/Rome",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=TEUL",
+    "id": "TEUL",
+    "published_harmonics": false,
+    "operator": "Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Istituto Superiore per la Protezione e la Ricerca Ambientale ( Italy )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.649,
+    "MHHW": 0.478,
+    "MHW": 0.466,
+    "MSL": 0.392,
+    "MTL": 0.391,
+    "MLW": 0.316,
+    "MLLW": 0.293,
+    "LAT": 0.122,
+    "MHWS": 0.493,
+    "MLWS": 0.291
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.074,
+      "phase": 220.13
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.027,
+      "phase": 239.38
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.015,
+      "phase": 207.65
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.008,
+      "phase": 233.95
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.034,
+      "phase": 172.1
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.017,
+      "phase": 98.41
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.012,
+      "phase": 173.76
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.002,
+      "phase": 76.36
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 301.36
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 337.15
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 188.72
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 212.87
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.003,
+      "phase": 193.64
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 178.54
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.003,
+      "phase": 219.81
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.002,
+      "phase": 196.31
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 235.21
+    },
+    {
+      "name": "R2",
+      "amplitude": 0,
+      "phase": 34.44
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 209.72
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 299.44
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0,
+      "phase": 304.04
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 348.01
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 207.16
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 0.71
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.001,
+      "phase": 177.95
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 245.07
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 72.55
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0,
+      "phase": 37.25
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 5.16
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 160.32
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 158.05
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 318.24
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 97.77
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 199.52
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 92.74
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 276.61
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 287.76
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 157.92
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 222.03
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 230.61
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 241.49
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 27.86
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.1,
+      "phase": 167.38
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.013,
+      "phase": 123.93
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 177.82
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 168.99
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 19.89
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 230.65
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 330.75
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-03-03"
+  }
+}

--- a/data/ioc/alex2.json
+++ b/data/ioc/alex2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Alexandria",
+  "region": "Alexandria",
+  "country": "Egypt",
+  "continent": "Africa",
+  "latitude": 31.212396,
+  "longitude": 29.884913,
+  "timezone": "Africa/Cairo",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=alex2",
+    "id": "alex2",
+    "published_harmonics": false,
+    "operator": "Joint Research Centre ( Europe )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Joint Research Centre ( Europe )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": -1.48,
+    "MHHW": -2.6,
+    "MHW": -2.573,
+    "MSL": -2.657,
+    "MTL": -2.694,
+    "MLW": -2.815,
+    "MLLW": -2.818,
+    "LAT": -3.472,
+    "MHWS": -2.57,
+    "MLWS": -2.744
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.068,
+      "phase": 226.42
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.019,
+      "phase": 261.63
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.012,
+      "phase": 227.57
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.025,
+      "phase": 273.91
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.062,
+      "phase": 31.83
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.009,
+      "phase": 240.41
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.086,
+      "phase": 287.53
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.007,
+      "phase": 345.31
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 255.4
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 72.49
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 212.08
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 59.71
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 218.66
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.006,
+      "phase": 291.48
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.003,
+      "phase": 181.79
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.004,
+      "phase": 266.5
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 242.42
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.034,
+      "phase": 243.85
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 139.23
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 346.43
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.006,
+      "phase": 74.34
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 27.84
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.124,
+      "phase": 163.13
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 306.28
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 113.61
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 280.5
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 145.74
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 92.4
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 35.06
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 131.26
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.025,
+      "phase": 110.49
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.018,
+      "phase": 152.82
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 60.5
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 130.77
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 344.12
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 289.63
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 98.25
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.027,
+      "phase": 272.58
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.046,
+      "phase": 357.57
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.091,
+      "phase": 11.49
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.031,
+      "phase": 353.42
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.041,
+      "phase": 240.65
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.395,
+      "phase": 334.68
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.328,
+      "phase": 262.88
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 133.31
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 3.66
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 47.78
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.02,
+      "phase": 335.42
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.014,
+      "phase": 169.38
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/alex3.json
+++ b/data/ioc/alex3.json
@@ -1,0 +1,289 @@
+{
+  "name": "alexandria",
+  "region": "Alexandria",
+  "country": "Egypt",
+  "continent": "Africa",
+  "latitude": 31.2124898,
+  "longitude": 29.8853056,
+  "timezone": "Africa/Cairo",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=alex3",
+    "id": "alex3",
+    "published_harmonics": false,
+    "operator": "National Institute of Oceanography and Fisheries, Alexandria ( Egypt )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Institute of Oceanography and Fisheries, Alexandria ( Egypt )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": -1.48,
+    "MHHW": -2.6,
+    "MHW": -2.573,
+    "MSL": -2.657,
+    "MTL": -2.694,
+    "MLW": -2.815,
+    "MLLW": -2.818,
+    "LAT": -3.472,
+    "MHWS": -2.57,
+    "MLWS": -2.744
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.068,
+      "phase": 226.42
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.019,
+      "phase": 261.63
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.012,
+      "phase": 227.57
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.025,
+      "phase": 273.91
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.062,
+      "phase": 31.83
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.009,
+      "phase": 240.41
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.086,
+      "phase": 287.53
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.007,
+      "phase": 345.31
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 255.4
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 72.49
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 212.08
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 59.71
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 218.66
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.006,
+      "phase": 291.48
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.003,
+      "phase": 181.79
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.004,
+      "phase": 266.5
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 242.42
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.034,
+      "phase": 243.85
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 139.23
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 346.43
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.006,
+      "phase": 74.34
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 27.84
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.124,
+      "phase": 163.13
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 306.28
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 113.61
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 280.5
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 145.74
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 92.4
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 35.06
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 131.26
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.025,
+      "phase": 110.49
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.018,
+      "phase": 152.82
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 60.5
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 130.77
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 344.12
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 289.63
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 98.25
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.027,
+      "phase": 272.58
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.046,
+      "phase": 357.57
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.091,
+      "phase": 11.49
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.031,
+      "phase": 353.42
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.041,
+      "phase": 240.65
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.395,
+      "phase": 334.68
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.328,
+      "phase": 262.88
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 133.31
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 3.66
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 47.78
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.02,
+      "phase": 335.42
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.014,
+      "phase": 169.38
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/ancu.json
+++ b/data/ioc/ancu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Ancud",
+  "region": "Los Lagos Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -41.867383,
+  "longitude": -73.83288,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ancu",
+    "id": "ancu",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.475,
+    "MHHW": 5.793,
+    "MHW": 5.6,
+    "MSL": 4.922,
+    "MTL": 4.925,
+    "MLW": 4.249,
+    "MLLW": 4.144,
+    "LAT": 3.613,
+    "MHWS": 5.816,
+    "MLWS": 4.028
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.65,
+      "phase": 114
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.244,
+      "phase": 130.05
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.155,
+      "phase": 87.23
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.075,
+      "phase": 126.13
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.181,
+      "phase": 53.51
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.126,
+      "phase": 10
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.056,
+      "phase": 50.81
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.024,
+      "phase": 345.54
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.01,
+      "phase": 217.83
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.009,
+      "phase": 233.05
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.005,
+      "phase": 191.17
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.021,
+      "phase": 79.03
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.021,
+      "phase": 54.82
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.016,
+      "phase": 53.54
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.029,
+      "phase": 92.35
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.021,
+      "phase": 107.27
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.011,
+      "phase": 112.71
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 158.85
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.014,
+      "phase": 88.52
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.011,
+      "phase": 329.16
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 337.57
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 248.02
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 25.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 346.29
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 91.81
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 141
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 302.66
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 341.74
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 349.71
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 320.22
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 321.68
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 249.06
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 155.06
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.003,
+      "phase": 184.24
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.027,
+      "phase": 97.39
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 354.99
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 315.61
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.007,
+      "phase": 194.82
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 161.99
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 17.18
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 63.97
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 167.86
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.132,
+      "phase": 74.58
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.028,
+      "phase": 233.98
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 26.21
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 255.42
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.011,
+      "phase": 355.58
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 119.96
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 142.24
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ancu2.json
+++ b/data/ioc/ancu2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Ancud",
+  "region": "Los Lagos Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -41.867383,
+  "longitude": -73.83288,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ancu2",
+    "id": "ancu2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.475,
+    "MHHW": 5.793,
+    "MHW": 5.6,
+    "MSL": 4.922,
+    "MTL": 4.925,
+    "MLW": 4.249,
+    "MLLW": 4.144,
+    "LAT": 3.613,
+    "MHWS": 5.816,
+    "MLWS": 4.028
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.65,
+      "phase": 114
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.244,
+      "phase": 130.05
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.155,
+      "phase": 87.23
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.075,
+      "phase": 126.13
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.181,
+      "phase": 53.51
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.126,
+      "phase": 10
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.056,
+      "phase": 50.81
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.024,
+      "phase": 345.54
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.01,
+      "phase": 217.83
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.009,
+      "phase": 233.05
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.005,
+      "phase": 191.17
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.021,
+      "phase": 79.03
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.021,
+      "phase": 54.82
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.016,
+      "phase": 53.54
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.029,
+      "phase": 92.35
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.021,
+      "phase": 107.27
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.011,
+      "phase": 112.71
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 158.85
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.014,
+      "phase": 88.52
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.011,
+      "phase": 329.16
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 337.57
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 248.02
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 25.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 346.29
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 91.81
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 141
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 302.66
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 341.74
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 349.71
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 320.22
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 321.68
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 249.06
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 155.06
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.003,
+      "phase": 184.24
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.027,
+      "phase": 97.39
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 354.99
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 315.61
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.007,
+      "phase": 194.82
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 161.99
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 17.18
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 63.97
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 167.86
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.132,
+      "phase": 74.58
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.028,
+      "phase": 233.98
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 26.21
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 255.42
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.011,
+      "phase": 355.58
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 119.96
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 142.24
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/angu.json
+++ b/data/ioc/angu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Road Bay",
+  "region": "Sandy Ground",
+  "country": "Anguilla",
+  "continent": "Americas",
+  "latitude": 18.1969967,
+  "longitude": -63.09268229,
+  "timezone": "America/Anguilla",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=angu",
+    "id": "angu",
+    "published_harmonics": false,
+    "operator": "UK Hydrographic Office ( UK )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (UK Hydrographic Office ( UK )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.573,
+    "MHHW": 0.396,
+    "MHW": 0.361,
+    "MSL": 0.277,
+    "MTL": 0.277,
+    "MLW": 0.193,
+    "MLLW": 0.137,
+    "LAT": 0.004,
+    "MHWS": 0.353,
+    "MLWS": 0.201
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.065,
+      "phase": 344.23
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.011,
+      "phase": 8.81
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.012,
+      "phase": 318.4
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.003,
+      "phase": 5.6
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.068,
+      "phase": 218.42
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.057,
+      "phase": 215.51
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.021,
+      "phase": 218.66
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 199.08
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 273.87
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 250.31
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 172.07
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 279
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.002,
+      "phase": 266.3
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 28.55
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 317.69
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.004,
+      "phase": 18.85
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 354.91
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 12.1
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 5.26
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 15.74
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 335.5
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 43.87
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 221.86
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 249.63
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 220.3
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 223.73
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 179.04
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 202.47
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 180.2
+    },
+    {
+      "name": "M3",
+      "amplitude": 0,
+      "phase": 153.01
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 75.4
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 199.49
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 133.69
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 114.01
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 22.75
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 259.07
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 228.48
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 359.04
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.013,
+      "phase": 0.34
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 3.03
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 30.12
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 58.92
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.076,
+      "phase": 189.37
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.021,
+      "phase": 52.47
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0,
+      "phase": 55.52
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 117.17
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 108.56
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 238.07
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 307.56
+    }
+  ],
+  "epoch": {
+    "start": "2024-03-22",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/aqab.json
+++ b/data/ioc/aqab.json
@@ -1,0 +1,289 @@
+{
+  "name": "Aqaba",
+  "region": "Aqaba",
+  "country": "Jordan",
+  "continent": "Asia",
+  "latitude": 29.40897,
+  "longitude": 34.97872,
+  "timezone": "Asia/Amman",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=aqab",
+    "id": "aqab",
+    "published_harmonics": false,
+    "operator": "Aqaba Marine Reserve, Research and studies division ( Jordan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Aqaba Marine Reserve, Research and studies division ( Jordan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.373,
+    "MHHW": 0.028,
+    "MHW": 0.015,
+    "MSL": -0.266,
+    "MTL": -0.269,
+    "MLW": -0.552,
+    "MLLW": -0.578,
+    "LAT": -0.879,
+    "MHWS": 0.067,
+    "MLWS": -0.599
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.254,
+      "phase": 119.2
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.079,
+      "phase": 145.15
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.082,
+      "phase": 87.33
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.024,
+      "phase": 122.07
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.021,
+      "phase": 161.05
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.009,
+      "phase": 177.72
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.005,
+      "phase": 139.68
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.002,
+      "phase": 173.1
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 291.24
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 285.2
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 273.76
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 221.44
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.016,
+      "phase": 17.19
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.007,
+      "phase": 8.73
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 73.02
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 18.12
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 277.36
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.011,
+      "phase": 23.99
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 151.81
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 340.3
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.035,
+      "phase": 4.73
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.032,
+      "phase": 127.42
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.012,
+      "phase": 33.77
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 156.94
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.002,
+      "phase": 161.75
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.002,
+      "phase": 204.03
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 325.89
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0,
+      "phase": 118.71
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 206.94
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 317.26
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 190.43
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 158.92
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 87.53
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 261.96
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 6.63
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 70.23
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 88.79
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.029,
+      "phase": 21.02
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.016,
+      "phase": 44.76
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.019,
+      "phase": 93.48
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 310.87
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 306.19
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.119,
+      "phase": 315.97
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.025,
+      "phase": 125.4
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 202.06
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.023,
+      "phase": 18.1
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.013,
+      "phase": 57.77
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 270.42
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 20.45
+    }
+  ],
+  "epoch": {
+    "start": "2024-10-29",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/arsu.json
+++ b/data/ioc/arsu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Arsuz (Hatay)",
+  "region": "Hatay",
+  "country": "Turkiye",
+  "continent": "Asia",
+  "latitude": 36.41559,
+  "longitude": 35.88519,
+  "timezone": "Europe/Istanbul",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=arsu",
+    "id": "arsu",
+    "published_harmonics": false,
+    "operator": "General Directorate of Mapping ( Turkey )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (General Directorate of Mapping ( Turkey )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.165,
+    "MHHW": 1.966,
+    "MHW": 1.929,
+    "MSL": 1.78,
+    "MTL": 1.776,
+    "MLW": 1.623,
+    "MLLW": 1.605,
+    "LAT": 1.403,
+    "MHWS": 1.971,
+    "MLWS": 1.589
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.122,
+      "phase": 217.28
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.069,
+      "phase": 231.87
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.02,
+      "phase": 216.6
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.021,
+      "phase": 226.67
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.03,
+      "phase": 266.84
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.022,
+      "phase": 246.92
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.01,
+      "phase": 277.41
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 247.34
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 261.05
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 324.48
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 279.43
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 124.12
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.002,
+      "phase": 210.15
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.003,
+      "phase": 234.71
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.004,
+      "phase": 221.27
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.005,
+      "phase": 232.73
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.004,
+      "phase": 249.54
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 226.25
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 254.93
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 146.25
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 100.84
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 118.29
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 41.26
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 263.44
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.002,
+      "phase": 267.2
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 226.15
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 164.51
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 245.07
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 277.46
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 162.46
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 228.72
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 43.34
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 155.73
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 297.98
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 222.13
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 283.05
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 356.44
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.017,
+      "phase": 316.07
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 120.08
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.011,
+      "phase": 187.81
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 6.95
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 221.02
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.114,
+      "phase": 157.39
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.027,
+      "phase": 245.69
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 182.3
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 19.18
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 317.86
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 177.21
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 279.16
+    }
+  ],
+  "epoch": {
+    "start": "2023-02-20",
+    "end": "2026-09-02"
+  }
+}

--- a/data/ioc/barc2.json
+++ b/data/ioc/barc2.json
@@ -1,0 +1,288 @@
+{
+  "name": "Port of Barcelona",
+  "region": "Catalonia",
+  "country": "Spain",
+  "continent": "Europe",
+  "latitude": 41.362977,
+  "longitude": 2.187024,
+  "timezone": "Europe/Madrid",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=barc2",
+    "id": "barc2",
+    "published_harmonics": false
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator. Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.478,
+    "MHHW": 1.078,
+    "MHW": 0.965,
+    "MSL": 0.936,
+    "MTL": 0.9,
+    "MLW": 0.836,
+    "MLLW": 0.72,
+    "LAT": 0.498,
+    "MHWS": 0.998,
+    "MLWS": 0.874
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.046,
+      "phase": 195.68
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.016,
+      "phase": 215.95
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.01,
+      "phase": 189.91
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.005,
+      "phase": 210.11
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.037,
+      "phase": 161.19
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.021,
+      "phase": 86.29
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.013,
+      "phase": 161.79
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.002,
+      "phase": 346.85
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.006,
+      "phase": 322.09
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 46.37
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 247.21
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 238.17
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.003,
+      "phase": 164.91
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.001,
+      "phase": 291.97
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.003,
+      "phase": 171.72
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.002,
+      "phase": 200.91
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 249.54
+    },
+    {
+      "name": "R2",
+      "amplitude": 0,
+      "phase": 322.79
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 203.3
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 34.42
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 66.73
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 312.49
+    },
+    {
+      "name": "S1",
+      "amplitude": 0,
+      "phase": 74.53
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 165.3
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.002,
+      "phase": 184.84
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 94.86
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.01,
+      "phase": 272.01
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 172.33
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.01,
+      "phase": 89.62
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 275.44
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 249.39
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 232.59
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 135.82
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 217.49
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 324.83
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 352.47
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 303.14
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.028,
+      "phase": 180.11
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.038,
+      "phase": 291.87
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.052,
+      "phase": 21.58
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.024,
+      "phase": 219.88
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.061,
+      "phase": 66.84
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.1,
+      "phase": 148.38
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.178,
+      "phase": 235.81
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 200.03
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 279.01
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 342.24
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 321.9
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 115.49
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/bcon.json
+++ b/data/ioc/bcon.json
@@ -1,0 +1,289 @@
+{
+  "name": "Consett Bay Jetty",
+  "region": "Saint John",
+  "country": "Barbados",
+  "continent": "Americas",
+  "latitude": 13.179314,
+  "longitude": -59.466331,
+  "timezone": "America/Barbados",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=bcon",
+    "id": "bcon",
+    "published_harmonics": false,
+    "operator": "Barbados Meteorological Services ( Barbados )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Barbados Meteorological Services ( Barbados )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.028,
+    "MHHW": 4.722,
+    "MHW": 4.659,
+    "MSL": 4.428,
+    "MTL": 4.424,
+    "MLW": 4.188,
+    "MLLW": 4.126,
+    "LAT": 3.899,
+    "MHWS": 4.733,
+    "MLWS": 4.123
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.228,
+      "phase": 19.09
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.077,
+      "phase": 43.08
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.05,
+      "phase": 3.38
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.021,
+      "phase": 41.51
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.08,
+      "phase": 51.37
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.067,
+      "phase": 41.22
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.025,
+      "phase": 51.93
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.014,
+      "phase": 28.7
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 357.82
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 54.43
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 300.01
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 10.18
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 353.35
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 331.15
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.008,
+      "phase": 0.23
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.005,
+      "phase": 101.57
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 66.8
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 63.05
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 49.84
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 237.49
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 132.8
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.008,
+      "phase": 55.77
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 20.65
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 86.7
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 53.64
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 55.17
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 29.56
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 24.67
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 355.6
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 293.15
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 257.64
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 35.67
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 119.75
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 212.86
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 240.19
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 293.45
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 7.78
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.016,
+      "phase": 138.57
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.014,
+      "phase": 179.11
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 178.8
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.008,
+      "phase": 193.81
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 231
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.058,
+      "phase": 265.62
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.012,
+      "phase": 198.69
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 308.36
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 307.45
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 219.84
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 356.38
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 83.21
+    }
+  ],
+  "epoch": {
+    "start": "2023-11-25",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/blow.json
+++ b/data/ioc/blow.json
@@ -1,0 +1,289 @@
+{
+  "name": "Blowing Point",
+  "region": "Blowing Point",
+  "country": "Anguilla",
+  "continent": "Americas",
+  "latitude": 18.1710861,
+  "longitude": -63.0926167,
+  "timezone": "America/Anguilla",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=blow",
+    "id": "blow",
+    "published_harmonics": false,
+    "operator": "Anguilla Department of Disaster Management ( Anguilla )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Anguilla Department of Disaster Management ( Anguilla )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.147,
+    "MHHW": 7.013,
+    "MHW": 6.966,
+    "MSL": 6.879,
+    "MTL": 6.88,
+    "MLW": 6.794,
+    "MLLW": 6.751,
+    "LAT": 6.605,
+    "MHWS": 6.935,
+    "MLWS": 6.823
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.049,
+      "phase": 350.94
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.007,
+      "phase": 345.21
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.01,
+      "phase": 326.43
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.002,
+      "phase": 352.77
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.076,
+      "phase": 219.04
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.06,
+      "phase": 215.24
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.023,
+      "phase": 219.35
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 201.05
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 292.39
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 244.88
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 155.13
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 274.35
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.001,
+      "phase": 292.29
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.001,
+      "phase": 56.82
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 315.02
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.002,
+      "phase": 359.83
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 348.2
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 23.28
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 11.67
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 29.78
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 276.69
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 294.79
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 215.81
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 174.51
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 217.54
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 226.38
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 173.7
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 204.4
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 195.94
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 155.73
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 68.53
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 172.46
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 25.55
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 102.39
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 15.12
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 232.5
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 173.69
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.007,
+      "phase": 352.56
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.013,
+      "phase": 2.49
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 345.17
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 7.54
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 8.91
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.069,
+      "phase": 181.09
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.015,
+      "phase": 77.53
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 53.07
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 214.34
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 50.42
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 243.98
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 324.7
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/blueb.json
+++ b/data/ioc/blueb.json
@@ -1,0 +1,289 @@
+{
+  "name": "Blue Bay",
+  "region": "Grand Port",
+  "country": "Mauritius",
+  "continent": "Africa",
+  "latitude": -20.44413333,
+  "longitude": 57.71095,
+  "timezone": "Indian/Mauritius",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=blueb",
+    "id": "blueb",
+    "published_harmonics": false,
+    "operator": "Mauritius Meteorological Services ( Mauritius )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Mauritius Meteorological Services ( Mauritius )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.392,
+    "MHHW": 2.195,
+    "MHW": 2.13,
+    "MSL": 1.754,
+    "MTL": 1.749,
+    "MLW": 1.368,
+    "MLLW": 1.298,
+    "LAT": 0.23,
+    "MHWS": 2.322,
+    "MLWS": 1.186
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.336,
+      "phase": 243.35
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.232,
+      "phase": 265.25
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.067,
+      "phase": 251.38
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.069,
+      "phase": 263.12
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.083,
+      "phase": 92.7
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.046,
+      "phase": 60.24
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.029,
+      "phase": 77.16
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.008,
+      "phase": 17.2
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.017,
+      "phase": 31.34
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.018,
+      "phase": 61.22
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 37.64
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 108.86
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 229.99
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.009,
+      "phase": 247.34
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.009,
+      "phase": 253.19
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.012,
+      "phase": 240.41
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.02,
+      "phase": 258.75
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.01,
+      "phase": 138.78
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 262.43
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 133.45
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.015,
+      "phase": 256.76
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.012,
+      "phase": 168.2
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 268.55
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 54.53
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 64.57
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 82.31
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 77.11
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 131.78
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 308.38
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 201.2
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 279.83
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.007,
+      "phase": 92.99
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 51.59
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 290.84
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.008,
+      "phase": 172.1
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 342.74
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 322.81
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 258.45
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.026,
+      "phase": 23.63
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.038,
+      "phase": 193.71
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.012,
+      "phase": 332.66
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.013,
+      "phase": 158.3
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.602,
+      "phase": 20.44
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.334,
+      "phase": 334.7
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 221.47
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.008,
+      "phase": 289.28
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 59.23
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 4.77
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 227.32
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-11",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/bmsa.json
+++ b/data/ioc/bmsa.json
@@ -1,0 +1,288 @@
+{
+  "name": "Bahia Mansa",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -40.580942,
+  "longitude": -73.737036,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=bmsa",
+    "id": "bmsa",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.557,
+    "MHHW": 5.014,
+    "MHW": 4.82,
+    "MSL": 4.369,
+    "MTL": 4.363,
+    "MLW": 3.906,
+    "MLLW": 3.857,
+    "LAT": 3.472,
+    "MHWS": 4.975,
+    "MLWS": 3.763
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.439,
+      "phase": 78.01
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.167,
+      "phase": 90.01
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.106,
+      "phase": 51.98
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.05,
+      "phase": 84.34
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.166,
+      "phase": 46.78
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.116,
+      "phase": 3.27
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.051,
+      "phase": 43.32
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.023,
+      "phase": 338.57
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 18.67
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 344.79
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 282.52
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 112.93
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.015,
+      "phase": 21.49
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 28.11
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 54.4
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 72.29
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 78.78
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 113.12
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 56.35
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 322.64
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 270.26
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 340.68
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 35.05
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 331.75
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 84.48
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 135.53
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 304.77
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 335.09
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 327.43
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 210.44
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 291.61
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 185.79
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 150.81
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 297.7
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 149.01
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 136.02
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 78.62
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 172.22
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 173.94
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 248
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 69.41
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 135.41
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.086,
+      "phase": 87.4
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.029,
+      "phase": 212.79
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 359.28
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 81.71
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 311.54
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 90.03
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 193.88
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/bmsa2.json
+++ b/data/ioc/bmsa2.json
@@ -1,0 +1,288 @@
+{
+  "name": "Bahia Mansa",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -40.580942,
+  "longitude": -73.737036,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=bmsa2",
+    "id": "bmsa2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.557,
+    "MHHW": 5.014,
+    "MHW": 4.82,
+    "MSL": 4.369,
+    "MTL": 4.363,
+    "MLW": 3.906,
+    "MLLW": 3.857,
+    "LAT": 3.472,
+    "MHWS": 4.975,
+    "MLWS": 3.763
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.439,
+      "phase": 78.01
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.167,
+      "phase": 90.01
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.106,
+      "phase": 51.98
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.05,
+      "phase": 84.34
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.166,
+      "phase": 46.78
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.116,
+      "phase": 3.27
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.051,
+      "phase": 43.32
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.023,
+      "phase": 338.57
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 18.67
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 344.79
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 282.52
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 112.93
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.015,
+      "phase": 21.49
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 28.11
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 54.4
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 72.29
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 78.78
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 113.12
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 56.35
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 322.64
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 270.26
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 340.68
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 35.05
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 331.75
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 84.48
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 135.53
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 304.77
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 335.09
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 327.43
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 210.44
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 291.61
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 185.79
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 150.81
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 297.7
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 149.01
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 136.02
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 78.62
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 172.22
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 173.94
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 248
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 69.41
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 135.41
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.086,
+      "phase": 87.4
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.029,
+      "phase": 212.79
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 359.28
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 81.71
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 311.54
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 90.03
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 193.88
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/bmso.json
+++ b/data/ioc/bmso.json
@@ -1,0 +1,289 @@
+{
+  "name": "Bermuda Somerset",
+  "region": "Sandys",
+  "country": "Bermuda",
+  "continent": "Americas",
+  "latitude": 32.278308,
+  "longitude": -64.875617,
+  "timezone": "Atlantic/Bermuda",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=bmso",
+    "id": "bmso",
+    "published_harmonics": false,
+    "operator": "UK Hydrographic Office ( UK )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (UK Hydrographic Office ( UK )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.452,
+    "MHHW": 3.119,
+    "MHW": 3.1,
+    "MSL": 2.727,
+    "MTL": 2.73,
+    "MLW": 2.36,
+    "MLLW": 2.272,
+    "LAT": 1.913,
+    "MHWS": 3.182,
+    "MLWS": 2.272
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.373,
+      "phase": 166.39
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.082,
+      "phase": 192.64
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.084,
+      "phase": 146.69
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.022,
+      "phase": 191.28
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.068,
+      "phase": 0.18
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.054,
+      "phase": 6.69
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.021,
+      "phase": 3.17
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 356.95
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 32.06
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 78.66
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 354.05
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 309.81
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.012,
+      "phase": 130.77
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.012,
+      "phase": 151.18
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 144.64
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 176.88
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 172.72
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 36.38
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 179.52
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 204.04
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 70.94
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 111
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 95.51
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 10.79
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 3.72
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 19.81
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 327.76
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 2.41
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 353.61
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 57.53
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 47.97
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 16.72
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 313.57
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 133.93
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 7.11
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 340.43
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 172.33
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 88.21
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.001,
+      "phase": 29.21
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 19.07
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 106.51
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 331.62
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.11,
+      "phase": 3.12
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.012,
+      "phase": 234.47
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 140.36
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 53.85
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 142.7
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 55.43
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 209.39
+    }
+  ],
+  "epoch": {
+    "start": "2022-01-24",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/bois.json
+++ b/data/ioc/bois.json
@@ -1,0 +1,289 @@
+{
+  "name": "Oistins Jetty",
+  "region": "Christ Church",
+  "country": "Barbados",
+  "continent": "Americas",
+  "latitude": 13.0706,
+  "longitude": -59.547,
+  "timezone": "America/Barbados",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=bois",
+    "id": "bois",
+    "published_harmonics": false,
+    "operator": "Barbados Meteorological Services ( Barbados )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Barbados Meteorological Services ( Barbados )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.638,
+    "MHHW": 5.818,
+    "MHW": 6.066,
+    "MSL": 5.297,
+    "MTL": 5.763,
+    "MLW": 5.46,
+    "MLLW": 5.01,
+    "LAT": 4.228,
+    "MHWS": 5.59,
+    "MLWS": 5.004
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.223,
+      "phase": 31.01
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.07,
+      "phase": 44.38
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.041,
+      "phase": 60.06
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.012,
+      "phase": 62.33
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.076,
+      "phase": 57.11
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.09,
+      "phase": 31.02
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.034,
+      "phase": 59.52
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.03,
+      "phase": 16.74
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.013,
+      "phase": 327.62
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 68.1
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.006,
+      "phase": 313.46
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.013,
+      "phase": 280.46
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.015,
+      "phase": 107.54
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.027,
+      "phase": 11.57
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.045,
+      "phase": 17.23
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.024,
+      "phase": 109.95
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.011,
+      "phase": 79.28
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 348.66
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.007,
+      "phase": 250.01
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.022,
+      "phase": 93.12
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 13.9
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.007,
+      "phase": 284.2
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.012,
+      "phase": 126.37
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.017,
+      "phase": 131.83
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.003,
+      "phase": 179.95
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.016,
+      "phase": 142.4
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.029,
+      "phase": 295.99
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.018,
+      "phase": 251.48
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.021,
+      "phase": 157.9
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 156.34
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.013,
+      "phase": 173.58
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.005,
+      "phase": 125.76
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.006,
+      "phase": 259.66
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.003,
+      "phase": 253.58
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.008,
+      "phase": 349.53
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.008,
+      "phase": 322.72
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.021,
+      "phase": 105.09
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.014,
+      "phase": 81.56
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.019,
+      "phase": 243.7
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.026,
+      "phase": 34.88
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.035,
+      "phase": 79.85
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.072,
+      "phase": 49.08
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.352,
+      "phase": 130.03
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.44,
+      "phase": 240.42
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.019,
+      "phase": 7.13
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.006,
+      "phase": 11.44
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.019,
+      "phase": 191.39
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.011,
+      "phase": 223.55
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.012,
+      "phase": 28.78
+    }
+  ],
+  "epoch": {
+    "start": "2023-11-13",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/boye.json
+++ b/data/ioc/boye.json
@@ -1,0 +1,289 @@
+{
+  "name": "Boyeruca",
+  "region": "O'Higgins Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -34.6873055,
+  "longitude": -72.05786,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=boye",
+    "id": "boye",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.727,
+    "MHHW": 2.04,
+    "MHW": 1.81,
+    "MSL": 1.226,
+    "MTL": 1.237,
+    "MLW": 0.665,
+    "MLLW": 0.575,
+    "LAT": 0.051,
+    "MHWS": 1.971,
+    "MLWS": 0.481
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.555,
+      "phase": 52.26
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.19,
+      "phase": 71.83
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.128,
+      "phase": 22.13
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.055,
+      "phase": 73.39
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.202,
+      "phase": 36.27
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.135,
+      "phase": 352.48
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.069,
+      "phase": 40.33
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.03,
+      "phase": 331.83
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 66.81
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 139.04
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 36.06
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 284.47
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.017,
+      "phase": 357.14
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.027,
+      "phase": 359.16
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.03,
+      "phase": 31.11
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 32.18
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 118.71
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.012,
+      "phase": 130.58
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 254.72
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 0.26
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.024,
+      "phase": 259.12
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.02,
+      "phase": 219.74
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 345.87
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 32.5
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 73.7
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 123
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 272.66
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 329.03
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 297.38
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 65.3
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 267.42
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 196.27
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 19.8
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 102.66
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 116.77
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 173.56
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 128.08
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.014,
+      "phase": 234.66
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 149.49
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 145.69
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 152.88
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 104.62
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.145,
+      "phase": 144.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.073,
+      "phase": 137.79
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 323.2
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.024,
+      "phase": 164.47
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.011,
+      "phase": 275.36
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 107.93
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 179.37
+    }
+  ],
+  "epoch": {
+    "start": "2021-10-31",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/boye2.json
+++ b/data/ioc/boye2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Boyeruca",
+  "region": "O'Higgins Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -34.6873055,
+  "longitude": -72.05786,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=boye2",
+    "id": "boye2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.727,
+    "MHHW": 2.04,
+    "MHW": 1.81,
+    "MSL": 1.226,
+    "MTL": 1.237,
+    "MLW": 0.665,
+    "MLLW": 0.575,
+    "LAT": 0.051,
+    "MHWS": 1.971,
+    "MLWS": 0.481
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.555,
+      "phase": 52.26
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.19,
+      "phase": 71.83
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.128,
+      "phase": 22.13
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.055,
+      "phase": 73.39
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.202,
+      "phase": 36.27
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.135,
+      "phase": 352.48
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.069,
+      "phase": 40.33
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.03,
+      "phase": 331.83
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 66.81
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 139.04
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 36.06
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 284.47
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.017,
+      "phase": 357.14
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.027,
+      "phase": 359.16
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.03,
+      "phase": 31.11
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 32.18
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 118.71
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.012,
+      "phase": 130.58
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 254.72
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 0.26
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.024,
+      "phase": 259.12
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.02,
+      "phase": 219.74
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 345.87
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 32.5
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 73.7
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 123
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 272.66
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 329.03
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 297.38
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 65.3
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 267.42
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 196.27
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 19.8
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 102.66
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 116.77
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 173.56
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 128.08
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.014,
+      "phase": 234.66
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 149.49
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 145.69
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 152.88
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 104.62
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.145,
+      "phase": 144.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.073,
+      "phase": 137.79
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 323.2
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.024,
+      "phase": 164.47
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.011,
+      "phase": 275.36
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 107.93
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 179.37
+    }
+  ],
+  "epoch": {
+    "start": "2021-10-31",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/bspe.json
+++ b/data/ioc/bspe.json
@@ -1,0 +1,289 @@
+{
+  "name": "Speightstown Jetty",
+  "region": "Saint Peter",
+  "country": "Barbados",
+  "continent": "Americas",
+  "latitude": 13.250253,
+  "longitude": -59.640894,
+  "timezone": "America/Barbados",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=bspe",
+    "id": "bspe",
+    "published_harmonics": false,
+    "operator": "Barbados Meteorological Services ( Barbados )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Barbados Meteorological Services ( Barbados )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.55,
+    "MHHW": 5.377,
+    "MHW": 5.277,
+    "MSL": 5.044,
+    "MTL": 5.037,
+    "MLW": 4.797,
+    "MLLW": 4.746,
+    "LAT": 4.536,
+    "MHWS": 5.249,
+    "MLWS": 4.839
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.154,
+      "phase": 293.2
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.051,
+      "phase": 316.05
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.031,
+      "phase": 290.11
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.013,
+      "phase": 296.56
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.078,
+      "phase": 5.17
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.065,
+      "phase": 0.18
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.02,
+      "phase": 10.15
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.014,
+      "phase": 348.73
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 327.71
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 16.46
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 342.78
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 33.56
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 251.75
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 257.98
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 256.98
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.015,
+      "phase": 318.8
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.013,
+      "phase": 25.85
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.014,
+      "phase": 319.24
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 131.13
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 333.46
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.032,
+      "phase": 86.67
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.034,
+      "phase": 23.41
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 277.15
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 53.94
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 14.38
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 11.39
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 325.88
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.001,
+      "phase": 346.14
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 330.8
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 135.11
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 69.73
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 8.38
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 264.5
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 180.6
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 258.58
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 67.12
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 316.9
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 134.91
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 169.92
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 246.7
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 181.63
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 18.33
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.08,
+      "phase": 275.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.014,
+      "phase": 163.9
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 212.09
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.014,
+      "phase": 197.21
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.009,
+      "phase": 45.65
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 117.33
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 333.68
+    }
+  ],
+  "epoch": {
+    "start": "2023-10-24",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/busa.json
+++ b/data/ioc/busa.json
@@ -1,0 +1,290 @@
+{
+  "name": "Busan",
+  "region": "Busan",
+  "country": "South Korea",
+  "continent": "Asia",
+  "latitude": 35.093056,
+  "longitude": 129.0375,
+  "timezone": "Asia/Seoul",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=busa",
+    "id": "busa",
+    "published_harmonics": false,
+    "operator": "Korea Hydrographic and Oceanographic Administration ( Korea )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Korea Hydrographic and Oceanographic Administration ( Korea )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 0.774,
+    "MHHW": 0.418,
+    "MHW": 0.418,
+    "MSL": 0,
+    "MTL": 0.003,
+    "MLW": -0.411,
+    "MLLW": -0.412,
+    "LAT": -1.009,
+    "MHWS": 0.544,
+    "MLWS": -0.544,
+    "ALLW": -0.591
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "ALLW",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.375,
+      "phase": 322.67
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.169,
+      "phase": 339.97
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.088,
+      "phase": 313.17
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.053,
+      "phase": 349.22
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.043,
+      "phase": 26.79
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.004,
+      "phase": 312.22
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.034,
+      "phase": 14.41
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.01,
+      "phase": 120.09
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.018,
+      "phase": 22.02
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 238.05
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 327.58
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 285.51
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 295.04
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 340.9
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.02,
+      "phase": 293.55
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.013,
+      "phase": 273.35
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.019,
+      "phase": 11.89
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.013,
+      "phase": 296.04
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.009,
+      "phase": 290.26
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.012,
+      "phase": 91.06
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 1.26
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.013,
+      "phase": 285.71
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.016,
+      "phase": 65.06
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 139.24
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 81.36
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 334.86
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.008,
+      "phase": 185.63
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 71.7
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.009,
+      "phase": 300.55
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.015,
+      "phase": 108.03
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.008,
+      "phase": 188.03
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.006,
+      "phase": 118.16
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 354.53
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 31.21
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 252.21
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 3.66
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 4.28
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.047,
+      "phase": 208.39
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.043,
+      "phase": 193.04
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.078,
+      "phase": 197.77
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.009,
+      "phase": 230.89
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.017,
+      "phase": 339.6
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.123,
+      "phase": 138.11
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.052,
+      "phase": 330.76
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 19.17
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 297.1
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 354.28
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.01,
+      "phase": 318.29
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.009,
+      "phase": 71.6
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-27",
+    "end": "2026-04-18"
+  }
+}

--- a/data/ioc/camt.json
+++ b/data/ioc/camt.json
@@ -1,0 +1,289 @@
+{
+  "name": "Lerma Campeche",
+  "region": "Campeche",
+  "country": "Mexico",
+  "continent": "Americas",
+  "latitude": 19.811985,
+  "longitude": -90.594916,
+  "timezone": "America/Merida",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=camt",
+    "id": "camt",
+    "published_harmonics": false,
+    "operator": "Universidad Nacional Autónoma de México ( Mexico )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Universidad Nacional Autónoma de México ( Mexico )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.641,
+    "MHHW": 3.317,
+    "MHW": 3.292,
+    "MSL": 3.226,
+    "MTL": 3.245,
+    "MLW": 3.198,
+    "MLLW": 3.116,
+    "LAT": 2.852,
+    "MHWS": 3.258,
+    "MLWS": 3.194
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.026,
+      "phase": 242.72
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.006,
+      "phase": 241.05
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.008,
+      "phase": 236.05
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.004,
+      "phase": 264.79
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.062,
+      "phase": 37.34
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.067,
+      "phase": 30.95
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.021,
+      "phase": 32.79
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 22.16
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 58.11
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 30.89
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 30.07
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 135.17
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.003,
+      "phase": 253.36
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.001,
+      "phase": 177.07
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 258.08
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 235.5
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 121.93
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 233.24
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 144.41
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 102.39
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 162.29
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 279.73
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 147.73
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 237.83
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.003,
+      "phase": 55.31
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 57.18
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 3.28
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 350
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 55.88
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 277.07
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 327.69
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 261.04
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 212.41
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 60.08
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 187.81
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 274.93
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 263.37
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.016,
+      "phase": 92.06
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.004,
+      "phase": 228.01
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.013,
+      "phase": 115.8
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.013,
+      "phase": 283.39
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.01,
+      "phase": 330.59
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.126,
+      "phase": 222.57
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.111,
+      "phase": 77.79
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0,
+      "phase": 219.45
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 116.98
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 55.55
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 319.97
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 48.03
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2021-01-18"
+  }
+}

--- a/data/ioc/chat.json
+++ b/data/ioc/chat.json
@@ -1,0 +1,289 @@
+{
+  "name": "Chateaubelair",
+  "region": "Saint David Parish",
+  "country": "Saint Vincent and the Grenadines",
+  "continent": "Americas",
+  "latitude": 13.2911,
+  "longitude": -61.2406,
+  "timezone": "America/St_Vincent",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=chat",
+    "id": "chat",
+    "published_harmonics": false,
+    "operator": "National Emergency Management Office ( Saint Vincent & Grenadines )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Emergency Management Office ( Saint Vincent & Grenadines )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.832,
+    "MHHW": 7.686,
+    "MHW": 7.622,
+    "MSL": 7.515,
+    "MTL": 7.52,
+    "MLW": 7.417,
+    "MLLW": 7.321,
+    "LAT": 7.137,
+    "MHWS": 7.623,
+    "MLWS": 7.407
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.084,
+      "phase": 204.96
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.024,
+      "phase": 237.68
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.021,
+      "phase": 182.05
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.007,
+      "phase": 245.73
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.089,
+      "phase": 232.11
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.067,
+      "phase": 226.9
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.027,
+      "phase": 237.14
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.013,
+      "phase": 218.01
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 217.85
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 249.69
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 163.97
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 163.31
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.003,
+      "phase": 182.5
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 152.91
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.005,
+      "phase": 177.99
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 200.28
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 289.7
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 1.04
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 11.76
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 282.18
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 27.32
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 36.23
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 131.97
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 213.13
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 240.15
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 249.88
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 239.33
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 248.7
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 249.69
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 117.12
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 94.48
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 152.95
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 134.99
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 128.47
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 120.18
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 310.74
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 35.22
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.007,
+      "phase": 259.52
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 0.01
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 287.94
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 1.26
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 230.09
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.069,
+      "phase": 154.38
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.015,
+      "phase": 67.76
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 116.86
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 189.67
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 156.92
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 253.99
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 321.46
+    }
+  ],
+  "epoch": {
+    "start": "2022-02-05",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/chenn.json
+++ b/data/ioc/chenn.json
@@ -1,0 +1,289 @@
+{
+  "name": "Chennai",
+  "region": "Tamil Nadu",
+  "country": "India",
+  "continent": "Asia",
+  "latitude": 13.1,
+  "longitude": 80.3,
+  "timezone": "Asia/Kolkata",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=chenn",
+    "id": "chenn",
+    "published_harmonics": false,
+    "operator": "Indian National Centre for Ocean Information Services ( India )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Indian National Centre for Ocean Information Services ( India )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.406,
+    "MHHW": 1.147,
+    "MHW": 1.078,
+    "MSL": 0.814,
+    "MTL": 0.828,
+    "MLW": 0.577,
+    "MLLW": 0.554,
+    "LAT": 0.228,
+    "MHWS": 1.162,
+    "MLWS": 0.466
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.243,
+      "phase": 62.16
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.105,
+      "phase": 90.35
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.049,
+      "phase": 62.25
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.024,
+      "phase": 97.49
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.075,
+      "phase": 243.58
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.018,
+      "phase": 221.82
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.027,
+      "phase": 249.33
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.009,
+      "phase": 358.01
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 116.61
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 49.35
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 136.28
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 288.9
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 56.46
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.009,
+      "phase": 38.91
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.006,
+      "phase": 94.94
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.013,
+      "phase": 92.2
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 154.02
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 44.1
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 101.29
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.006,
+      "phase": 88.71
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 229.83
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 31.37
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.017,
+      "phase": 273.09
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 108.02
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 330.49
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 236.14
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 246.92
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 349.05
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 241.29
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 39.37
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.009,
+      "phase": 104.04
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 112.11
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 16.79
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 359.5
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 7.24
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 3.8
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 269.76
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 108.92
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.013,
+      "phase": 352.64
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 131.92
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.012,
+      "phase": 78.75
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 220.83
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.054,
+      "phase": 206.55
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.06,
+      "phase": 133.06
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 53.95
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 42.73
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 196.64
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.005,
+      "phase": 189.24
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.006,
+      "phase": 265.58
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/chim2.json
+++ b/data/ioc/chim2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Chimbote,Ancash ",
+  "region": "Ancash",
+  "country": "Peru",
+  "continent": "Americas",
+  "latitude": -9.0762,
+  "longitude": -78.6127,
+  "timezone": "America/Lima",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=chim2",
+    "id": "chim2",
+    "published_harmonics": false,
+    "operator": "Dirección de Hidrografía y Navegación (Perú)"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dirección de Hidrografía y Navegación (Perú)). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 1.826,
+    "MHHW": 0.306,
+    "MHW": 0.281,
+    "MSL": 0,
+    "MTL": 0.06,
+    "MLW": -0.161,
+    "MLLW": -0.315,
+    "LAT": -2.426,
+    "MHWS": 0.227,
+    "MLWS": -0.227
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.168,
+      "phase": 285.94
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.059,
+      "phase": 4.37
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.163,
+      "phase": 247.22
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.034,
+      "phase": 308.78
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.145,
+      "phase": 10.21
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.134,
+      "phase": 339.36
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.034,
+      "phase": 229.09
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.006,
+      "phase": 279.33
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.016,
+      "phase": 347.56
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.038,
+      "phase": 148.35
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.011,
+      "phase": 97.28
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.022,
+      "phase": 345.69
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 227.18
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 239.84
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.035,
+      "phase": 323.92
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.068,
+      "phase": 77.68
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.038,
+      "phase": 280.55
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.058,
+      "phase": 285.61
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.044,
+      "phase": 302.8
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.09,
+      "phase": 323.35
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.052,
+      "phase": 194.52
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.061,
+      "phase": 203.01
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.019,
+      "phase": 190.22
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.021,
+      "phase": 230.52
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.051,
+      "phase": 64.96
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.035,
+      "phase": 73.87
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.018,
+      "phase": 324.18
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.036,
+      "phase": 76.5
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.01,
+      "phase": 17.98
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.018,
+      "phase": 43.03
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.012,
+      "phase": 167.49
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.026,
+      "phase": 355.14
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.018,
+      "phase": 262.79
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 229.63
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.016,
+      "phase": 169.09
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.007,
+      "phase": 258.42
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 195.19
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.354,
+      "phase": 206.69
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.241,
+      "phase": 65.4
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.229,
+      "phase": 120.86
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.111,
+      "phase": 79.33
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.368,
+      "phase": 272.66
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.215,
+      "phase": 184.92
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.127,
+      "phase": 216.9
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.055,
+      "phase": 233.78
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.008,
+      "phase": 164.53
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.028,
+      "phase": 181.17
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 340.87
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.018,
+      "phase": 311.7
+    }
+  ],
+  "epoch": {
+    "start": "2022-12-24",
+    "end": "2026-08-13"
+  }
+}

--- a/data/ioc/chimb.json
+++ b/data/ioc/chimb.json
@@ -1,0 +1,289 @@
+{
+  "name": "Chimbote,Ancash",
+  "region": "Ancash",
+  "country": "Peru",
+  "continent": "Americas",
+  "latitude": -9.0761,
+  "longitude": -78.6125,
+  "timezone": "America/Lima",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=chimb",
+    "id": "chimb",
+    "published_harmonics": false,
+    "operator": "Dirección de Hidrografía y Navegación (Perú)"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dirección de Hidrografía y Navegación (Perú)). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 1.826,
+    "MHHW": 0.306,
+    "MHW": 0.281,
+    "MSL": 0,
+    "MTL": 0.06,
+    "MLW": -0.161,
+    "MLLW": -0.315,
+    "LAT": -2.426,
+    "MHWS": 0.227,
+    "MLWS": -0.227
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.168,
+      "phase": 285.94
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.059,
+      "phase": 4.37
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.163,
+      "phase": 247.22
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.034,
+      "phase": 308.78
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.145,
+      "phase": 10.21
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.134,
+      "phase": 339.36
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.034,
+      "phase": 229.09
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.006,
+      "phase": 279.33
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.016,
+      "phase": 347.56
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.038,
+      "phase": 148.35
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.011,
+      "phase": 97.28
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.022,
+      "phase": 345.69
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 227.18
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 239.84
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.035,
+      "phase": 323.92
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.068,
+      "phase": 77.68
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.038,
+      "phase": 280.55
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.058,
+      "phase": 285.61
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.044,
+      "phase": 302.8
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.09,
+      "phase": 323.35
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.052,
+      "phase": 194.52
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.061,
+      "phase": 203.01
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.019,
+      "phase": 190.22
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.021,
+      "phase": 230.52
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.051,
+      "phase": 64.96
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.035,
+      "phase": 73.87
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.018,
+      "phase": 324.18
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.036,
+      "phase": 76.5
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.01,
+      "phase": 17.98
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.018,
+      "phase": 43.03
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.012,
+      "phase": 167.49
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.026,
+      "phase": 355.14
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.018,
+      "phase": 262.79
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 229.63
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.016,
+      "phase": 169.09
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.007,
+      "phase": 258.42
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 195.19
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.354,
+      "phase": 206.69
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.241,
+      "phase": 65.4
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.229,
+      "phase": 120.86
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.111,
+      "phase": 79.33
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.368,
+      "phase": 272.66
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.215,
+      "phase": 184.92
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.127,
+      "phase": 216.9
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.055,
+      "phase": 233.78
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.008,
+      "phase": 164.53
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.028,
+      "phase": 181.17
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 340.87
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.018,
+      "phase": 311.7
+    }
+  ],
+  "epoch": {
+    "start": "2022-12-24",
+    "end": "2026-08-13"
+  }
+}

--- a/data/ioc/chit.json
+++ b/data/ioc/chit.json
@@ -1,0 +1,289 @@
+{
+  "name": "Owenga, Chatham Island",
+  "region": "Chatham Islands",
+  "country": "New Zealand",
+  "continent": "Oceania",
+  "latitude": -44.0247,
+  "longitude": -176.3688,
+  "timezone": "Pacific/Chatham",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=chit",
+    "id": "chit",
+    "published_harmonics": false,
+    "operator": "Land Information New Zealand ( New Zealand )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Land Information New Zealand ( New Zealand )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.463,
+    "MHHW": 3.201,
+    "MHW": 3.172,
+    "MSL": 2.715,
+    "MTL": 2.709,
+    "MLW": 2.245,
+    "MLLW": 2.222,
+    "LAT": 1.943,
+    "MHWS": 3.201,
+    "MLWS": 2.229
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.467,
+      "phase": 134.19
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.019,
+      "phase": 206.48
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.106,
+      "phase": 102.91
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.005,
+      "phase": 112.22
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.019,
+      "phase": 239.47
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.02,
+      "phase": 170.81
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.005,
+      "phase": 240.19
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.004,
+      "phase": 177.63
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 88.22
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 100.65
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 42.12
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 293.1
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 79.25
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.016,
+      "phase": 82.3
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.02,
+      "phase": 109.65
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 165.66
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.004,
+      "phase": 259.27
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 186.7
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 112.35
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 247.03
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.006,
+      "phase": 303.48
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 334.09
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 151.24
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 296.8
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.002,
+      "phase": 3.62
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 2.5
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 205.97
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.001,
+      "phase": 185.37
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 203.51
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 84.46
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 235.22
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 23.3
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 50.46
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 41.14
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 308.52
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 96.23
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 337.67
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.015,
+      "phase": 298.18
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.018,
+      "phase": 213.99
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.011,
+      "phase": 152.91
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.009,
+      "phase": 275.45
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 324.79
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.064,
+      "phase": 340.68
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.021,
+      "phase": 106.72
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 62.27
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 144.7
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.01,
+      "phase": 293.69
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 340.84
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 87.21
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/chnr.json
+++ b/data/ioc/chnr.json
@@ -1,0 +1,289 @@
+{
+  "name": "Chañaral",
+  "region": "Atacama",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -26.351758,
+  "longitude": -70.633759,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=chnr",
+    "id": "chnr",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.915,
+    "MHHW": 4.554,
+    "MHW": 4.385,
+    "MSL": 3.993,
+    "MTL": 3.998,
+    "MLW": 3.611,
+    "MLLW": 3.582,
+    "LAT": 3.264,
+    "MHWS": 4.499,
+    "MLWS": 3.487
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.383,
+      "phase": 28.6
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.123,
+      "phase": 52.56
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.084,
+      "phase": 354.68
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.038,
+      "phase": 42.94
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.15,
+      "phase": 26.51
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.091,
+      "phase": 343.79
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.045,
+      "phase": 22.24
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.018,
+      "phase": 316.96
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 324.27
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 46.47
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 193.4
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 299.47
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 318.07
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 336.89
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 356.58
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 32.26
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.004,
+      "phase": 51.86
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 81
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 341.73
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 275.97
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 201.73
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 117.08
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 184.42
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 312.87
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 58.99
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 104.24
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 254.72
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 323.09
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 295.86
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 48.53
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 176.98
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 337.91
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 191.01
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 180.63
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 325.39
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 174.2
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 152.09
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 355.09
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 92.22
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 21.87
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 137.34
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 158.97
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.039,
+      "phase": 14.35
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.018,
+      "phase": 215.47
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 301.35
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 359.68
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 223.34
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 146.27
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 238.95
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/chnr2.json
+++ b/data/ioc/chnr2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Chañaral",
+  "region": "Atacama",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -26.351758,
+  "longitude": -70.633759,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=chnr2",
+    "id": "chnr2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.915,
+    "MHHW": 4.554,
+    "MHW": 4.385,
+    "MSL": 3.993,
+    "MTL": 3.998,
+    "MLW": 3.611,
+    "MLLW": 3.582,
+    "LAT": 3.264,
+    "MHWS": 4.499,
+    "MLWS": 3.487
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.383,
+      "phase": 28.6
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.123,
+      "phase": 52.56
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.084,
+      "phase": 354.68
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.038,
+      "phase": 42.94
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.15,
+      "phase": 26.51
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.091,
+      "phase": 343.79
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.045,
+      "phase": 22.24
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.018,
+      "phase": 316.96
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 324.27
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 46.47
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 193.4
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 299.47
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 318.07
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 336.89
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 356.58
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 32.26
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.004,
+      "phase": 51.86
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 81
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 341.73
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 275.97
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 201.73
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 117.08
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 184.42
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 312.87
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 58.99
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 104.24
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 254.72
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 323.09
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 295.86
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 48.53
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 176.98
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 337.91
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 191.01
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 180.63
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 325.39
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 174.2
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 152.09
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 355.09
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 92.22
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 21.87
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 137.34
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 158.97
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.039,
+      "phase": 14.35
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.018,
+      "phase": 215.47
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 301.35
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 359.68
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 223.34
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 146.27
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 238.95
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/cmet.json
+++ b/data/ioc/cmet.json
@@ -1,0 +1,288 @@
+{
+  "name": "Caleta Meteoro",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -52.961019,
+  "longitude": -74.072156,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=cmet",
+    "id": "cmet",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.029,
+    "MHHW": 2.52,
+    "MHW": 2.29,
+    "MSL": 1.843,
+    "MTL": 1.827,
+    "MLW": 1.364,
+    "MLLW": 1.264,
+    "LAT": 0.898,
+    "MHWS": 2.41,
+    "MLWS": 1.276
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.444,
+      "phase": 162.58
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.123,
+      "phase": 144.66
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.13,
+      "phase": 131.16
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.039,
+      "phase": 142.21
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.2,
+      "phase": 87.85
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.144,
+      "phase": 46.08
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.06,
+      "phase": 81.65
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 23.8
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.011,
+      "phase": 195.95
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 253.87
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 160.14
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.018,
+      "phase": 216.26
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.019,
+      "phase": 97.15
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 109.36
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.024,
+      "phase": 136.65
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 163.88
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 117.2
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 199.16
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 166.09
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 86.11
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 1.75
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 3.43
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 43.68
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 21.82
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 124.79
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 176.73
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 5.44
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 36.37
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 0.34
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 0.56
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 141.36
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 204.4
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 111.83
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 282.48
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.015,
+      "phase": 273.02
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 61.4
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 14.32
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.018,
+      "phase": 208
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.024,
+      "phase": 151.99
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 281.5
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.013,
+      "phase": 93.19
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.007,
+      "phase": 161.15
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.06,
+      "phase": 57.68
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.029,
+      "phase": 87.67
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 86.36
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 211.15
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.011,
+      "phase": 32.17
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 242.3
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 353.19
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/cmet3.json
+++ b/data/ioc/cmet3.json
@@ -1,0 +1,288 @@
+{
+  "name": "Caleta Meteoro",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -52.961019,
+  "longitude": -74.072156,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=cmet3",
+    "id": "cmet3",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.029,
+    "MHHW": 2.52,
+    "MHW": 2.29,
+    "MSL": 1.843,
+    "MTL": 1.827,
+    "MLW": 1.364,
+    "MLLW": 1.264,
+    "LAT": 0.898,
+    "MHWS": 2.41,
+    "MLWS": 1.276
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.444,
+      "phase": 162.58
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.123,
+      "phase": 144.66
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.13,
+      "phase": 131.16
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.039,
+      "phase": 142.21
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.2,
+      "phase": 87.85
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.144,
+      "phase": 46.08
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.06,
+      "phase": 81.65
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 23.8
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.011,
+      "phase": 195.95
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 253.87
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 160.14
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.018,
+      "phase": 216.26
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.019,
+      "phase": 97.15
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 109.36
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.024,
+      "phase": 136.65
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 163.88
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 117.2
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 199.16
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 166.09
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 86.11
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 1.75
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 3.43
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 43.68
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 21.82
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 124.79
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 176.73
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 5.44
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 36.37
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 0.34
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 0.56
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 141.36
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 204.4
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 111.83
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 282.48
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.015,
+      "phase": 273.02
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 61.4
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 14.32
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.018,
+      "phase": 208
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.024,
+      "phase": 151.99
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 281.5
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.013,
+      "phase": 93.19
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.007,
+      "phase": 161.15
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.06,
+      "phase": 57.68
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.029,
+      "phase": 87.67
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 86.36
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 211.15
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.011,
+      "phase": 32.17
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 242.3
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 353.19
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/coli.json
+++ b/data/ioc/coli.json
@@ -1,0 +1,289 @@
+{
+  "name": "Coliumo",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -36.53797,
+  "longitude": -72.957142,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=coli",
+    "id": "coli",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.097,
+    "MHHW": 5.62,
+    "MHW": 5.435,
+    "MSL": 4.983,
+    "MTL": 4.982,
+    "MLW": 4.529,
+    "MLLW": 4.491,
+    "LAT": 4.099,
+    "MHWS": 5.588,
+    "MLWS": 4.378
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.445,
+      "phase": 59.33
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.16,
+      "phase": 77.77
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.102,
+      "phase": 30.77
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.048,
+      "phase": 71.07
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.159,
+      "phase": 38.42
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.108,
+      "phase": 354.51
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 35.08
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 330.43
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 352.8
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 350.14
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 267.67
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 86.9
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 0.99
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 7.48
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 32.95
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 57.83
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 68.5
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 106.57
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 30.17
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 307.03
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 230.84
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 144.51
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 359.27
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 330.17
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 78.13
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 125.87
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 289.99
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 328.55
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 318.53
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 101.62
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 276.31
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 192.23
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 159.2
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 283.65
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 134.87
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 114.9
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 71.06
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 161.59
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.008,
+      "phase": 152.7
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 94.83
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 223.71
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 86.35
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.044,
+      "phase": 54.14
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 220.07
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 335.08
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 68.13
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 277.19
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 85.16
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 184.94
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/coli2.json
+++ b/data/ioc/coli2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Coliumo",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -36.53797,
+  "longitude": -72.957142,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=coli2",
+    "id": "coli2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.097,
+    "MHHW": 5.62,
+    "MHW": 5.435,
+    "MSL": 4.983,
+    "MTL": 4.982,
+    "MLW": 4.529,
+    "MLLW": 4.491,
+    "LAT": 4.099,
+    "MHWS": 5.588,
+    "MLWS": 4.378
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.445,
+      "phase": 59.33
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.16,
+      "phase": 77.77
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.102,
+      "phase": 30.77
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.048,
+      "phase": 71.07
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.159,
+      "phase": 38.42
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.108,
+      "phase": 354.51
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 35.08
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 330.43
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 352.8
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 350.14
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 267.67
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 86.9
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 0.99
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 7.48
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 32.95
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 57.83
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 68.5
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 106.57
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 30.17
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 307.03
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 230.84
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 144.51
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 359.27
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 330.17
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 78.13
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 125.87
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 289.99
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 328.55
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 318.53
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 101.62
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 276.31
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 192.23
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 159.2
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 283.65
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 134.87
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 114.9
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 71.06
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 161.59
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.008,
+      "phase": 152.7
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 94.83
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 223.71
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 86.35
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.044,
+      "phase": 54.14
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 220.07
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 335.08
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 68.13
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 277.19
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 85.16
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 184.94
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/cons2.json
+++ b/data/ioc/cons2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Constitucion (Chile)",
+  "region": "Maule Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -35.355725,
+  "longitude": -72.457031,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=cons2",
+    "id": "cons2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.571,
+    "MHHW": 6.131,
+    "MHW": 5.926,
+    "MSL": 5.463,
+    "MTL": 5.498,
+    "MLW": 5.071,
+    "MLLW": 4.977,
+    "LAT": 4.598,
+    "MHWS": 6.065,
+    "MLWS": 4.861
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.443,
+      "phase": 56.43
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.159,
+      "phase": 78.04
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.102,
+      "phase": 30.6
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.045,
+      "phase": 70.96
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.159,
+      "phase": 37.15
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.103,
+      "phase": 354.82
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.05,
+      "phase": 29.18
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 318.37
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 318.92
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 50.54
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 162.48
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 225.03
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.018,
+      "phase": 7.64
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 11.81
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 20.69
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 55.18
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 57.3
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 70.2
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 310.77
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 199.23
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 214.33
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 119.58
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 14.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 294.2
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 79.95
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 105.72
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 150.9
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.009,
+      "phase": 332.8
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.006,
+      "phase": 254.16
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 41.34
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 351.36
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 140.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 102.27
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 126.63
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 113.48
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 131.42
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 358.72
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 145.66
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 127.42
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 66.38
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 181.25
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.015,
+      "phase": 44.84
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.036,
+      "phase": 59.98
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.019,
+      "phase": 183.98
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 327.63
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 93.75
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 269.12
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 118.65
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 186.48
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/const.json
+++ b/data/ioc/const.json
@@ -1,0 +1,289 @@
+{
+  "name": "Constitucion (Chile)",
+  "region": "Maule Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -35.355725,
+  "longitude": -72.457031,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=const",
+    "id": "const",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.571,
+    "MHHW": 6.131,
+    "MHW": 5.926,
+    "MSL": 5.463,
+    "MTL": 5.498,
+    "MLW": 5.071,
+    "MLLW": 4.977,
+    "LAT": 4.598,
+    "MHWS": 6.065,
+    "MLWS": 4.861
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.443,
+      "phase": 56.43
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.159,
+      "phase": 78.04
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.102,
+      "phase": 30.6
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.045,
+      "phase": 70.96
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.159,
+      "phase": 37.15
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.103,
+      "phase": 354.82
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.05,
+      "phase": 29.18
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 318.37
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 318.92
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 50.54
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 162.48
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 225.03
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.018,
+      "phase": 7.64
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 11.81
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 20.69
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 55.18
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 57.3
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 70.2
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 310.77
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 199.23
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 214.33
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 119.58
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 14.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 294.2
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 79.95
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 105.72
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 150.9
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.009,
+      "phase": 332.8
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.006,
+      "phase": 254.16
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 41.34
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 351.36
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 140.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 102.27
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 126.63
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 113.48
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 131.42
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 358.72
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 145.66
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 127.42
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 66.38
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 181.25
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.015,
+      "phase": 44.84
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.036,
+      "phase": 59.98
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.019,
+      "phase": 183.98
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 327.63
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 93.75
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 269.12
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 118.65
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 186.48
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/coqu.json
+++ b/data/ioc/coqu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Coquimbo",
+  "region": "Coquimbo Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -29.950139,
+  "longitude": -71.335258,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=coqu",
+    "id": "coqu",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.115,
+    "MHHW": 4.711,
+    "MHW": 4.537,
+    "MSL": 4.124,
+    "MTL": 4.124,
+    "MLW": 3.711,
+    "MLLW": 3.69,
+    "LAT": 3.339,
+    "MHWS": 4.666,
+    "MLWS": 3.582
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.408,
+      "phase": 39.32
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.134,
+      "phase": 62.07
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.09,
+      "phase": 6.96
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.041,
+      "phase": 53.31
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 30.96
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.096,
+      "phase": 346.18
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 26.69
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.019,
+      "phase": 320.28
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 326.42
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 10.84
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 251.54
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 190.14
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 334.82
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 346.89
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 8.53
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 40
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 58.61
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 77.87
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 1.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 287.52
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 206.48
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 139.43
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 242.08
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 320.95
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 68.38
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 114.5
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 290.66
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 321.47
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 308.03
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 52.62
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 234.43
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 198.22
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 186.92
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 60.46
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 95.01
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 114.45
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 64.07
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.001,
+      "phase": 86.34
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 103.91
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 93.53
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 147.38
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 187.46
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.044,
+      "phase": 359.34
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.018,
+      "phase": 219.99
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 311.13
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 49.61
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 242.54
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 117.65
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 201.77
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/coqu2.json
+++ b/data/ioc/coqu2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Coquimbo",
+  "region": "Coquimbo Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -29.950139,
+  "longitude": -71.335258,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=coqu2",
+    "id": "coqu2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.115,
+    "MHHW": 4.711,
+    "MHW": 4.537,
+    "MSL": 4.124,
+    "MTL": 4.124,
+    "MLW": 3.711,
+    "MLLW": 3.69,
+    "LAT": 3.339,
+    "MHWS": 4.666,
+    "MLWS": 3.582
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.408,
+      "phase": 39.32
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.134,
+      "phase": 62.07
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.09,
+      "phase": 6.96
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.041,
+      "phase": 53.31
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 30.96
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.096,
+      "phase": 346.18
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 26.69
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.019,
+      "phase": 320.28
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 326.42
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 10.84
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 251.54
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 190.14
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 334.82
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 346.89
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 8.53
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 40
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 58.61
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 77.87
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 1.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 287.52
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 206.48
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 139.43
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 242.08
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 320.95
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 68.38
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 114.5
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 290.66
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 321.47
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 308.03
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 52.62
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 234.43
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 198.22
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 186.92
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 60.46
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 95.01
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 114.45
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 64.07
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.001,
+      "phase": 86.34
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 103.91
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 93.53
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 147.38
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 187.46
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.044,
+      "phase": 359.34
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.018,
+      "phase": 219.99
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 311.13
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 49.61
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 242.54
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 117.65
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 201.77
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/corr.json
+++ b/data/ioc/corr.json
@@ -1,0 +1,289 @@
+{
+  "name": "Corral",
+  "region": "Los Rios Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -39.886595,
+  "longitude": -73.42748,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=corr",
+    "id": "corr",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.215,
+    "MHHW": 5.686,
+    "MHW": 5.497,
+    "MSL": 5.057,
+    "MTL": 5.057,
+    "MLW": 4.618,
+    "MLLW": 4.564,
+    "LAT": 4.174,
+    "MHWS": 5.647,
+    "MLWS": 4.467
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.428,
+      "phase": 76.24
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.162,
+      "phase": 89.96
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.102,
+      "phase": 49.76
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.049,
+      "phase": 84.5
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.158,
+      "phase": 46.74
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.111,
+      "phase": 3.07
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 42.8
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 336.58
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 132.37
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 201.25
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 188.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 98.69
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 19.1
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 26.84
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 51.08
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 71.06
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 68.41
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 343.54
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 47.27
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 325.46
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 77.24
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 18.1
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 65.91
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 339.15
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 80.67
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 128.8
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 302.07
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 340.08
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 318.57
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 190.74
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 299.96
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 181.8
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 153.89
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 124.14
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 136.37
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 80.86
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 347.11
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 168.5
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 173.89
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 100.01
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 63.6
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 141.11
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.086,
+      "phase": 98.11
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 209.53
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 357
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 45.07
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 301.55
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 100.16
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 191.91
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/corr2.json
+++ b/data/ioc/corr2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Corral",
+  "region": "Los Rios Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -39.886595,
+  "longitude": -73.42748,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=corr2",
+    "id": "corr2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.215,
+    "MHHW": 5.686,
+    "MHW": 5.497,
+    "MSL": 5.057,
+    "MTL": 5.057,
+    "MLW": 4.618,
+    "MLLW": 4.564,
+    "LAT": 4.174,
+    "MHWS": 5.647,
+    "MLWS": 4.467
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.428,
+      "phase": 76.24
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.162,
+      "phase": 89.96
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.102,
+      "phase": 49.76
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.049,
+      "phase": 84.5
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.158,
+      "phase": 46.74
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.111,
+      "phase": 3.07
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 42.8
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 336.58
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 132.37
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 201.25
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 188.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 98.69
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 19.1
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 26.84
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 51.08
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 71.06
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 68.41
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 343.54
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 47.27
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 325.46
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 77.24
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 18.1
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 65.91
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 339.15
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 80.67
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 128.8
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 302.07
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 340.08
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 318.57
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 190.74
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 299.96
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 181.8
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 153.89
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 124.14
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 136.37
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 80.86
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 347.11
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 168.5
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 173.89
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 100.01
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 63.6
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 141.11
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.086,
+      "phase": 98.11
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 209.53
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 357
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 45.07
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 301.55
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 100.16
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 191.91
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/crnl.json
+++ b/data/ioc/crnl.json
@@ -1,0 +1,289 @@
+{
+  "name": "Coronel",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -37.028605,
+  "longitude": -73.151731,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=crnl",
+    "id": "crnl",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.799,
+    "MHHW": 5.323,
+    "MHW": 5.137,
+    "MSL": 4.688,
+    "MTL": 4.688,
+    "MLW": 4.239,
+    "MLLW": 4.198,
+    "LAT": 3.813,
+    "MHWS": 5.289,
+    "MLWS": 4.087
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.441,
+      "phase": 61.58
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.16,
+      "phase": 79.96
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.101,
+      "phase": 33.66
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.048,
+      "phase": 73.26
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.158,
+      "phase": 39.24
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.107,
+      "phase": 355.71
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 35.55
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.021,
+      "phase": 331.5
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 354.86
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 0.99
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 268.05
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 90.49
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 3.79
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 10.11
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 36.05
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 59.7
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 69.78
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 96.05
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 33.03
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 308.78
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 234.81
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 266.68
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 57.59
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 330.6
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 79.54
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 127.92
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 295.71
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 330.55
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 317.82
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 112.26
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 279.01
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 198.65
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 136.94
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 280
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 138.16
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 117.05
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 65.78
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 159.1
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 152.78
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 111.26
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 111.07
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 86.83
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.046,
+      "phase": 65.94
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 218.33
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 338.32
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 71.39
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 281.98
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 91.14
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 189.16
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/crnl2.json
+++ b/data/ioc/crnl2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Coronel",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -37.028605,
+  "longitude": -73.151731,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=crnl2",
+    "id": "crnl2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.799,
+    "MHHW": 5.323,
+    "MHW": 5.137,
+    "MSL": 4.688,
+    "MTL": 4.688,
+    "MLW": 4.239,
+    "MLLW": 4.198,
+    "LAT": 3.813,
+    "MHWS": 5.289,
+    "MLWS": 4.087
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.441,
+      "phase": 61.58
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.16,
+      "phase": 79.96
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.101,
+      "phase": 33.66
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.048,
+      "phase": 73.26
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.158,
+      "phase": 39.24
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.107,
+      "phase": 355.71
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 35.55
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.021,
+      "phase": 331.5
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 354.86
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 0.99
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 268.05
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 90.49
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 3.79
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 10.11
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 36.05
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 59.7
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 69.78
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 96.05
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 33.03
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 308.78
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 234.81
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 266.68
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 57.59
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 330.6
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 79.54
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 127.92
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 295.71
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 330.55
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 317.82
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 112.26
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 279.01
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 198.65
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 136.94
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 280
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 138.16
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 117.05
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 65.78
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 159.1
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 152.78
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 111.26
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 111.07
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 86.83
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.046,
+      "phase": 65.94
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 218.33
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 338.32
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 71.39
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 281.98
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 91.14
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 189.16
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/cstr.json
+++ b/data/ioc/cstr.json
@@ -1,0 +1,289 @@
+{
+  "name": "Castro",
+  "region": "Los Lagos Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -42.480894,
+  "longitude": -73.758181,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=cstr",
+    "id": "cstr",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 8.686,
+    "MHHW": 7.384,
+    "MHW": 7.147,
+    "MSL": 5.448,
+    "MTL": 5.449,
+    "MLW": 3.752,
+    "MLLW": 3.613,
+    "LAT": 2.331,
+    "MHWS": 7.738,
+    "MLWS": 3.158
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.62,
+      "phase": 137.17
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.67,
+      "phase": 158.36
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.391,
+      "phase": 112.6
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.208,
+      "phase": 153.88
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.222,
+      "phase": 60.67
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.149,
+      "phase": 17.55
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.067,
+      "phase": 57.82
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.028,
+      "phase": 354.45
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.006,
+      "phase": 284.82
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 318.71
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 239.23
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.006,
+      "phase": 57.81
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.048,
+      "phase": 78.54
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.066,
+      "phase": 150.97
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.077,
+      "phase": 106.82
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.067,
+      "phase": 104.57
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.031,
+      "phase": 154.24
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.009,
+      "phase": 169.06
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.043,
+      "phase": 72.79
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.034,
+      "phase": 311.64
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.03,
+      "phase": 319.35
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.012,
+      "phase": 174.62
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 70.36
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 338.7
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.011,
+      "phase": 108.05
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 140.19
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 313.59
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 335.07
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 2.12
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 9.38
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 91.53
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 6.93
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 250.88
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 352.97
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.007,
+      "phase": 79.26
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 290.9
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 274.84
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 170.64
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 169.45
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 230.97
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 78.03
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 128.86
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.059,
+      "phase": 81.53
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.026,
+      "phase": 200.93
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.019,
+      "phase": 144.82
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.016,
+      "phase": 230.78
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.026,
+      "phase": 15.4
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 231.91
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 22.15
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/cstr2.json
+++ b/data/ioc/cstr2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Castro",
+  "region": "Los Lagos Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -42.480894,
+  "longitude": -73.758181,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=cstr2",
+    "id": "cstr2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 8.686,
+    "MHHW": 7.384,
+    "MHW": 7.147,
+    "MSL": 5.448,
+    "MTL": 5.449,
+    "MLW": 3.752,
+    "MLLW": 3.613,
+    "LAT": 2.331,
+    "MHWS": 7.738,
+    "MLWS": 3.158
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.62,
+      "phase": 137.17
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.67,
+      "phase": 158.36
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.391,
+      "phase": 112.6
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.208,
+      "phase": 153.88
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.222,
+      "phase": 60.67
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.149,
+      "phase": 17.55
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.067,
+      "phase": 57.82
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.028,
+      "phase": 354.45
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.006,
+      "phase": 284.82
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 318.71
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 239.23
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.006,
+      "phase": 57.81
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.048,
+      "phase": 78.54
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.066,
+      "phase": 150.97
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.077,
+      "phase": 106.82
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.067,
+      "phase": 104.57
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.031,
+      "phase": 154.24
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.009,
+      "phase": 169.06
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.043,
+      "phase": 72.79
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.034,
+      "phase": 311.64
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.03,
+      "phase": 319.35
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.012,
+      "phase": 174.62
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 70.36
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 338.7
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.011,
+      "phase": 108.05
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 140.19
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 313.59
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 335.07
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 2.12
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 9.38
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 91.53
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 6.93
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 250.88
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 352.97
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.007,
+      "phase": 79.26
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 290.9
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 274.84
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 170.64
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 169.45
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 230.97
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 78.03
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 128.86
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.059,
+      "phase": 81.53
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.026,
+      "phase": 200.93
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.019,
+      "phase": 144.82
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.016,
+      "phase": 230.78
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.026,
+      "phase": 15.4
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 231.91
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 22.15
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/cuvie.json
+++ b/data/ioc/cuvie.json
@@ -1,0 +1,288 @@
+{
+  "name": "Cape Cuvier Wharf",
+  "country": "Australia",
+  "continent": "Oceania",
+  "latitude": -24.2206,
+  "longitude": 113.3969,
+  "timezone": "Australia/Perth",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=cuvie",
+    "id": "cuvie",
+    "published_harmonics": false,
+    "operator": "National Tidal Centre/Australian Bureau of Meteorology ( Australia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Tidal Centre/Australian Bureau of Meteorology ( Australia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.796,
+    "MHHW": 1.416,
+    "MHW": 1.248,
+    "MSL": 0.943,
+    "MTL": 0.964,
+    "MLW": 0.68,
+    "MLLW": 0.617,
+    "LAT": 0.104,
+    "MHWS": 1.33,
+    "MLWS": 0.556
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.262,
+      "phase": 35.91
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.125,
+      "phase": 94.18
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.052,
+      "phase": 12.97
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.035,
+      "phase": 91.23
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.188,
+      "phase": 159.65
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.125,
+      "phase": 150.82
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.056,
+      "phase": 157.22
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.03,
+      "phase": 141.16
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 111.28
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 156.96
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 75.19
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 9.11
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 358.59
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.006,
+      "phase": 20.71
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.009,
+      "phase": 20.09
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 39.75
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 91.66
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 126.41
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 57.61
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 219.05
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 250.75
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 206.67
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.019,
+      "phase": 308.44
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 145.37
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 181.62
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 205.53
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.007,
+      "phase": 113.01
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 174
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 161.67
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 337
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 230.48
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 241.79
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 105.41
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 195.97
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 101.02
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 104.61
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 93.95
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 49.84
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.014,
+      "phase": 356.99
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 248.21
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 91.75
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 311.41
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.097,
+      "phase": 14.58
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.05,
+      "phase": 128.26
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0,
+      "phase": 275.94
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 93.6
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 305.12
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.006,
+      "phase": 352.73
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 90.59
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/dial.json
+++ b/data/ioc/dial.json
@@ -1,0 +1,289 @@
+{
+  "name": "Dauphin_Island",
+  "region": "AL",
+  "country": "United States",
+  "continent": "Americas",
+  "latitude": 30.2,
+  "longitude": -88.1,
+  "timezone": "America/Chicago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=dial",
+    "id": "dial",
+    "published_harmonics": false,
+    "operator": "National Ocean Service-NOAA ( USA )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Ocean Service-NOAA ( USA )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.776,
+    "MHHW": 0.53,
+    "MHW": 0.453,
+    "MSL": 0.327,
+    "MTL": 0.326,
+    "MLW": 0.198,
+    "MLLW": 0.134,
+    "LAT": -0.171,
+    "MHWS": 0.35,
+    "MLWS": 0.304
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLLW",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.015,
+      "phase": 115.24
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.008,
+      "phase": 119.49
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.003,
+      "phase": 120.07
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.004,
+      "phase": 187.54
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.129,
+      "phase": 42.21
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.126,
+      "phase": 33.8
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.038,
+      "phase": 44.06
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 21.34
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 328.6
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 326.53
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 284.77
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 22.2
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0,
+      "phase": 115.82
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.001,
+      "phase": 112.39
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0,
+      "phase": 117.29
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 227.2
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 201.47
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 150.82
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0,
+      "phase": 137.19
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 42.55
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0,
+      "phase": 256.1
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 130.25
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 273.2
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 60.28
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 65.68
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 33.57
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 12.36
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 24.73
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 19.26
+    },
+    {
+      "name": "M3",
+      "amplitude": 0,
+      "phase": 80.34
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 98.73
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 79.21
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 213.5
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 318.57
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 34.34
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 53.64
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 127.18
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 38.46
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 322.38
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 349.05
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 187.24
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 96.09
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.087,
+      "phase": 142.48
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.075,
+      "phase": 63.12
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0,
+      "phase": 344
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 142.52
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 291.24
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 135.09
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 201.8
+    }
+  ],
+  "epoch": {
+    "start": "2022-11-04",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/flam.json
+++ b/data/ioc/flam.json
@@ -1,0 +1,289 @@
+{
+  "name": "Flamingo Marina",
+  "region": "Guanacaste Province",
+  "country": "Costa Rica",
+  "continent": "Americas",
+  "latitude": 10.4411,
+  "longitude": -85.7888,
+  "timezone": "America/Costa_Rica",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=flam",
+    "id": "flam",
+    "published_harmonics": false,
+    "operator": "Universidad Nacional Costa Rica, SINAMOT ( Costa Rica )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Universidad Nacional Costa Rica, SINAMOT ( Costa Rica )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": -1.255,
+    "MHHW": -2.006,
+    "MHW": -2.033,
+    "MSL": -2.882,
+    "MTL": -2.9,
+    "MLW": -3.768,
+    "MLLW": -3.825,
+    "LAT": -4.501,
+    "MHWS": -1.8,
+    "MLWS": -3.964
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.881,
+      "phase": 229.16
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.201,
+      "phase": 290.9
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.199,
+      "phase": 197.01
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.049,
+      "phase": 283.15
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.101,
+      "phase": 74.43
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.044,
+      "phase": 103.37
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.031,
+      "phase": 71.51
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.009,
+      "phase": 120.37
+    },
+    {
+      "name": "M4",
+      "amplitude": 0,
+      "phase": 334.1
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 285.46
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 275.3
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 108.76
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.024,
+      "phase": 166.68
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.033,
+      "phase": 167.74
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.034,
+      "phase": 200.84
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.016,
+      "phase": 252.33
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.014,
+      "phase": 298.48
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 276.9
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 270.01
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 291.72
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 283.94
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 28.23
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.009,
+      "phase": 165.18
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 143.08
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 83.93
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 94.55
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 104.63
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 126.98
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 151.06
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 213.48
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 234.56
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 297.3
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 274.81
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 39.67
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 127.64
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 243.77
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 34.89
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.014,
+      "phase": 270.33
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 17.69
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.01,
+      "phase": 167.71
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.01,
+      "phase": 89.18
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 99.14
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.15,
+      "phase": 101.89
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.051,
+      "phase": 162.83
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 143.54
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 190.69
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 352.08
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 39.86
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 147.64
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-10",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/gale.json
+++ b/data/ioc/gale.json
@@ -1,0 +1,289 @@
+{
+  "name": "Galeota",
+  "region": "Mayaro",
+  "country": "Trinidad and Tobago",
+  "continent": "Americas",
+  "latitude": 10.1387333,
+  "longitude": -61.00195,
+  "timezone": "America/Port_of_Spain",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=gale",
+    "id": "gale",
+    "published_harmonics": false,
+    "operator": "Land and Surveys Division, Hydrographic Unit ( Trinidad and Tobago )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Land and Surveys Division, Hydrographic Unit ( Trinidad and Tobago )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.288,
+    "MHHW": 2.784,
+    "MHW": 2.748,
+    "MSL": 2.278,
+    "MTL": 2.292,
+    "MLW": 1.836,
+    "MLLW": 1.761,
+    "LAT": 1.397,
+    "MHWS": 2.881,
+    "MLWS": 1.675
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.453,
+      "phase": 27.13
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.15,
+      "phase": 51.76
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.098,
+      "phase": 11.59
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.041,
+      "phase": 47.6
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.1,
+      "phase": 53.09
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.08,
+      "phase": 43.34
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.029,
+      "phase": 58.02
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.016,
+      "phase": 26.03
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.03,
+      "phase": 10.13
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.019,
+      "phase": 67.34
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.01,
+      "phase": 330.46
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 146.3
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 359.54
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.016,
+      "phase": 347.04
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 16.21
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 38.42
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.01,
+      "phase": 45.36
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 104.46
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 40.31
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 253.21
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 156.75
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 10.89
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 24.22
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 45.21
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 56.41
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 62.39
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 351.79
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 18
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 3.92
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.01,
+      "phase": 316.14
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 311.33
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 57.95
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 299.92
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 222.03
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 219.11
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 38.27
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 28.02
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 164.26
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.017,
+      "phase": 177.43
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 153.92
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 189.7
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 325.28
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.066,
+      "phase": 342.65
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.04,
+      "phase": 250.98
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 318.08
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 120.16
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 313.76
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 12.09
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 93.22
+    }
+  ],
+  "epoch": {
+    "start": "2021-06-10",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/gcsb.json
+++ b/data/ioc/gcsb.json
@@ -1,0 +1,289 @@
+{
+  "name": "Gold Coast Sand Bypass Jetty",
+  "region": "Queensland",
+  "country": "Australia",
+  "continent": "Oceania",
+  "latitude": -27.9387,
+  "longitude": 153.4326,
+  "timezone": "Australia/Brisbane",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=gcsb",
+    "id": "gcsb",
+    "published_harmonics": false,
+    "operator": "National Tidal Centre/Australian Bureau of Meteorology ( Australia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Tidal Centre/Australian Bureau of Meteorology ( Australia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.026,
+    "MHHW": 1.555,
+    "MHW": 1.357,
+    "MSL": 0.828,
+    "MTL": 0.834,
+    "MLW": 0.311,
+    "MLLW": 0.243,
+    "LAT": -0.11,
+    "MHWS": 1.496,
+    "MLWS": 0.16
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.517,
+      "phase": 285.71
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.151,
+      "phase": 294.28
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.108,
+      "phase": 277.83
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.044,
+      "phase": 285.5
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.181,
+      "phase": 342.27
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.102,
+      "phase": 311.59
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.055,
+      "phase": 336.01
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.023,
+      "phase": 291.6
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 210.69
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 209.08
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 210.97
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 298.57
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.018,
+      "phase": 268.56
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.018,
+      "phase": 271.53
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.021,
+      "phase": 279.17
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.015,
+      "phase": 292.5
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 314.65
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 275.39
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 279.3
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 158.53
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 97.32
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 135.53
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 270.08
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 303.2
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 1.32
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 30.55
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 264.09
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 296.81
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 263.95
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 22.59
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 90.52
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 354.6
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 177.75
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 103.45
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 286.1
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 26.88
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 179.17
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 29.98
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.003,
+      "phase": 75.49
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 172.41
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 154.86
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 17.24
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.068,
+      "phase": 30.84
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.012,
+      "phase": 71.02
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 264.07
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 95.12
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 78.32
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 19.47
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 218.73
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-02",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/gokc.json
+++ b/data/ioc/gokc.json
@@ -1,0 +1,289 @@
+{
+  "name": "Gokceada",
+  "region": "Canakkale",
+  "country": "Turkiye",
+  "continent": "Asia",
+  "latitude": 40.231391906738,
+  "longitude": 25.89361000061,
+  "timezone": "Europe/Istanbul",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=gokc",
+    "id": "gokc",
+    "published_harmonics": false,
+    "operator": "General Directorate of Mapping ( Turkey )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (General Directorate of Mapping ( Turkey )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.431,
+    "MHHW": 2.023,
+    "MHW": 2.009,
+    "MSL": 1.784,
+    "MTL": 1.88,
+    "MLW": 1.75,
+    "MLLW": 1.577,
+    "LAT": 1.28,
+    "MHWS": 1.913,
+    "MLWS": 1.655
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.07,
+      "phase": 43.12
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.059,
+      "phase": 62.96
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.015,
+      "phase": 26
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.011,
+      "phase": 96.12
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.047,
+      "phase": 303.67
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.023,
+      "phase": 262.28
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.027,
+      "phase": 41.8
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 284.81
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 154.72
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 59.25
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.005,
+      "phase": 328.28
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 156.73
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 282.67
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 160.07
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 335.87
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.012,
+      "phase": 76.98
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 162.68
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.013,
+      "phase": 277.9
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 232.08
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 278.77
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.012,
+      "phase": 74.81
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.007,
+      "phase": 66.03
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.027,
+      "phase": 179.77
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 44.67
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 153.31
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.002,
+      "phase": 93.57
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.011,
+      "phase": 18.65
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 197.66
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.011,
+      "phase": 52.51
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.008,
+      "phase": 335.9
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.004,
+      "phase": 180.56
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 232.17
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.005,
+      "phase": 28.48
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 262.82
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 68.7
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.003,
+      "phase": 345.81
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 260.8
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.017,
+      "phase": 152.86
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 21.01
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.032,
+      "phase": 313.8
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.031,
+      "phase": 38.52
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.013,
+      "phase": 145.38
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.286,
+      "phase": 171.11
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.105,
+      "phase": 315.31
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.01,
+      "phase": 43.78
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 45.71
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.012,
+      "phase": 1.51
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 117.84
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.006,
+      "phase": 113.91
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-09",
+    "end": "2026-03-03"
+  }
+}

--- a/data/ioc/greg.json
+++ b/data/ioc/greg.json
@@ -1,0 +1,288 @@
+{
+  "name": "Bahia Gregorio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -52.648056,
+  "longitude": -70.209167,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=greg",
+    "id": "greg",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 8.945,
+    "MHHW": 8.006,
+    "MHW": 7.92,
+    "MSL": 6.443,
+    "MTL": 6.585,
+    "MLW": 5.251,
+    "MLLW": 5.181,
+    "LAT": 3.988,
+    "MHWS": 7.979,
+    "MLWS": 4.907
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.305,
+      "phase": 26.56
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.231,
+      "phase": 93.07
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.341,
+      "phase": 352.49
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.062,
+      "phase": 91.47
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.301,
+      "phase": 126.54
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.226,
+      "phase": 74.14
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.083,
+      "phase": 120.71
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.046,
+      "phase": 49.35
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.197,
+      "phase": 347.44
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.107,
+      "phase": 47.7
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.082,
+      "phase": 312.25
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.08,
+      "phase": 322.07
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.051,
+      "phase": 312.28
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.05,
+      "phase": 308.95
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.064,
+      "phase": 358.24
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.036,
+      "phase": 46.01
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.019,
+      "phase": 103.22
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 47.16
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.017,
+      "phase": 46.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.006,
+      "phase": 356.87
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 230.57
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 210.96
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.019,
+      "phase": 113.79
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 55.03
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 191.26
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 249.21
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 24.23
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.008,
+      "phase": 50.55
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 53.1
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.01,
+      "phase": 291.32
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.01,
+      "phase": 59.76
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.004,
+      "phase": 77.62
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.019,
+      "phase": 271.34
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.013,
+      "phase": 284.65
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.062,
+      "phase": 24.35
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.006,
+      "phase": 5.88
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.009,
+      "phase": 323.67
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 212.37
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.018,
+      "phase": 142.67
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.012,
+      "phase": 358.82
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 116.81
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 171.69
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.029,
+      "phase": 349.66
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.014,
+      "phase": 93.03
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.013,
+      "phase": 242.05
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.007,
+      "phase": 264.76
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.008,
+      "phase": 215.74
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.017,
+      "phase": 167.68
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.016,
+      "phase": 259.24
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/greg2.json
+++ b/data/ioc/greg2.json
@@ -1,0 +1,288 @@
+{
+  "name": "Bahia Gregorio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -52.648056,
+  "longitude": -70.209167,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=greg2",
+    "id": "greg2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 8.945,
+    "MHHW": 8.006,
+    "MHW": 7.92,
+    "MSL": 6.443,
+    "MTL": 6.585,
+    "MLW": 5.251,
+    "MLLW": 5.181,
+    "LAT": 3.988,
+    "MHWS": 7.979,
+    "MLWS": 4.907
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.305,
+      "phase": 26.56
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.231,
+      "phase": 93.07
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.341,
+      "phase": 352.49
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.062,
+      "phase": 91.47
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.301,
+      "phase": 126.54
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.226,
+      "phase": 74.14
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.083,
+      "phase": 120.71
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.046,
+      "phase": 49.35
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.197,
+      "phase": 347.44
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.107,
+      "phase": 47.7
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.082,
+      "phase": 312.25
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.08,
+      "phase": 322.07
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.051,
+      "phase": 312.28
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.05,
+      "phase": 308.95
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.064,
+      "phase": 358.24
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.036,
+      "phase": 46.01
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.019,
+      "phase": 103.22
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 47.16
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.017,
+      "phase": 46.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.006,
+      "phase": 356.87
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 230.57
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 210.96
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.019,
+      "phase": 113.79
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 55.03
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 191.26
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 249.21
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 24.23
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.008,
+      "phase": 50.55
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 53.1
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.01,
+      "phase": 291.32
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.01,
+      "phase": 59.76
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.004,
+      "phase": 77.62
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.019,
+      "phase": 271.34
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.013,
+      "phase": 284.65
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.062,
+      "phase": 24.35
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.006,
+      "phase": 5.88
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.009,
+      "phase": 323.67
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 212.37
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.018,
+      "phase": 142.67
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.012,
+      "phase": 358.82
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 116.81
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 171.69
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.029,
+      "phase": 349.66
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.014,
+      "phase": 93.03
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.013,
+      "phase": 242.05
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.007,
+      "phase": 264.76
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.008,
+      "phase": 215.74
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.017,
+      "phase": 167.68
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.016,
+      "phase": 259.24
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/gtdpr.json
+++ b/data/ioc/gtdpr.json
@@ -1,0 +1,289 @@
+{
+  "name": "Guayanilla, Puerto Rico",
+  "region": "Guayanilla",
+  "country": "Puerto Rico",
+  "continent": "Americas",
+  "latitude": 18.005219,
+  "longitude": -66.766697,
+  "timezone": "America/Puerto_Rico",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=gtdpr",
+    "id": "gtdpr",
+    "published_harmonics": false,
+    "operator": "Puerto Rico Seismic Network ( USA )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Puerto Rico Seismic Network ( USA )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": -3.287,
+    "MHHW": -3.393,
+    "MHW": -3.438,
+    "MSL": -3.513,
+    "MTL": -3.502,
+    "MLW": -3.566,
+    "MLLW": -3.627,
+    "LAT": -3.738,
+    "MHWS": -3.496,
+    "MLWS": -3.53
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.007,
+      "phase": 42.91
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.01,
+      "phase": 354.99
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.005,
+      "phase": 74.02
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.003,
+      "phase": 351.18
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.081,
+      "phase": 229.13
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.051,
+      "phase": 226.48
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.027,
+      "phase": 228.43
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.01,
+      "phase": 217.84
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 276.24
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 346.41
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 189.33
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 90.05
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.002,
+      "phase": 44.24
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0,
+      "phase": 9.38
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 79.13
+    },
+    {
+      "name": "L2",
+      "amplitude": 0,
+      "phase": 289.01
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 359.45
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 89.64
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 200.32
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 184.33
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 287.7
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 111.28
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 149.34
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 219.47
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 230.57
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 231.32
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 186.56
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 216.67
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 209.38
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 229.05
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 108.48
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 141.29
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 52.84
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 230.7
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 207.66
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 74.91
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 52.38
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 3.89
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 359.14
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 1.9
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 23.85
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 37.26
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.06,
+      "phase": 183.94
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.001,
+      "phase": 284.48
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0,
+      "phase": 232.53
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 344.4
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 173.13
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 301.83
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 147.85
+    }
+  ],
+  "epoch": {
+    "start": "2021-06-17",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/hoko.json
+++ b/data/ioc/hoko.json
@@ -1,0 +1,289 @@
+{
+  "name": "Honokohau Harbor, Hawaii",
+  "region": "HI",
+  "country": "United States",
+  "continent": "Americas",
+  "latitude": 19.66892,
+  "longitude": -156.02351,
+  "timezone": "Pacific/Honolulu",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=hoko",
+    "id": "hoko",
+    "published_harmonics": false,
+    "operator": "University of Hawaii Sea Level Center ( USA )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (University of Hawaii Sea Level Center ( USA )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.444,
+    "MHHW": 2.141,
+    "MHW": 2.011,
+    "MSL": 1.809,
+    "MTL": 1.798,
+    "MLW": 1.585,
+    "MLLW": 1.524,
+    "LAT": 1.379,
+    "MHWS": 2.077,
+    "MLWS": 1.541
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLLW",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.197,
+      "phase": 39.51
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.071,
+      "phase": 44.35
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.036,
+      "phase": 26.05
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.021,
+      "phase": 33.12
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 216.94
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.08,
+      "phase": 207.45
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.046,
+      "phase": 214.01
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.014,
+      "phase": 203.44
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 188.96
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 292.17
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 180.44
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 8.71
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.005,
+      "phase": 12.84
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 8.67
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.009,
+      "phase": 27.81
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.004,
+      "phase": 36.27
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 36.82
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 64.72
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 31.84
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 200.11
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 181.52
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 12.34
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 323.97
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 242.18
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 231.82
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 251.57
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 183.89
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 205.59
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 231.94
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 325.66
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 3.69
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 67.56
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 67.46
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 343.76
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 305.68
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 143.09
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 110.79
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.013,
+      "phase": 46.03
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.008,
+      "phase": 44.66
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 38.38
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 54.49
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 33.31
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.042,
+      "phase": 178.5
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.013,
+      "phase": 217.75
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 15.52
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 346.5
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 97.94
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 89.79
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 179.54
+    }
+  ],
+  "epoch": {
+    "start": "2024-08-16",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/huas.json
+++ b/data/ioc/huas.json
@@ -1,0 +1,289 @@
+{
+  "name": "Huasco",
+  "region": "Atacama",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -28.468893,
+  "longitude": -71.249937,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=huas",
+    "id": "huas",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.357,
+    "MHHW": 5.857,
+    "MHW": 5.779,
+    "MSL": 5.396,
+    "MTL": 5.38,
+    "MLW": 4.981,
+    "MLLW": 4.925,
+    "LAT": 4.635,
+    "MHWS": 5.926,
+    "MLWS": 4.866
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.401,
+      "phase": 34.98
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.129,
+      "phase": 58.78
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.088,
+      "phase": 1.42
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.04,
+      "phase": 49.64
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 29.14
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.095,
+      "phase": 345.37
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 24.24
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.018,
+      "phase": 319.55
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 323.5
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 39.36
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 250
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 223.7
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 329.08
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 342.13
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 1.66
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 38.39
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 58.18
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 66.52
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 350.99
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 281.01
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 174.65
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 139
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 208.99
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 341.89
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 68.78
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 111.48
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 283.53
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 316.48
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 307.1
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 50.47
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 225.99
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 214.75
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 163.44
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 48.78
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 50.26
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 107.83
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 61.19
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.001,
+      "phase": 20.32
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 97.1
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 26.08
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 137.94
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 194.8
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.042,
+      "phase": 22.35
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.016,
+      "phase": 208.28
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 305.64
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 152.81
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 232.61
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 133.18
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 214.66
+    }
+  ],
+  "epoch": {
+    "start": "2020-09-09",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/huas2.json
+++ b/data/ioc/huas2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Huasco",
+  "region": "Atacama",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -28.468893,
+  "longitude": -71.249937,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=huas2",
+    "id": "huas2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.357,
+    "MHHW": 5.857,
+    "MHW": 5.779,
+    "MSL": 5.396,
+    "MTL": 5.38,
+    "MLW": 4.981,
+    "MLLW": 4.925,
+    "LAT": 4.635,
+    "MHWS": 5.926,
+    "MLWS": 4.866
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.401,
+      "phase": 34.98
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.129,
+      "phase": 58.78
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.088,
+      "phase": 1.42
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.04,
+      "phase": 49.64
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 29.14
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.095,
+      "phase": 345.37
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 24.24
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.018,
+      "phase": 319.55
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 323.5
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 39.36
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 250
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 223.7
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 329.08
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 342.13
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 1.66
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 38.39
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 58.18
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 66.52
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 350.99
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 281.01
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 174.65
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 139
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 208.99
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 341.89
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 68.78
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 111.48
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 283.53
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 316.48
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 307.1
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 50.47
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 225.99
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 214.75
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 163.44
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 48.78
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 50.26
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 107.83
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 61.19
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.001,
+      "phase": 20.32
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 97.1
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 26.08
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 137.94
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 194.8
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.042,
+      "phase": 22.35
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.016,
+      "phase": 208.28
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 305.64
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 152.81
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 232.61
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 133.18
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 214.66
+    }
+  ],
+  "epoch": {
+    "start": "2020-09-09",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/iclr.json
+++ b/data/ioc/iclr.json
@@ -1,0 +1,288 @@
+{
+  "name": "Isla Clarion",
+  "country": "Mexico",
+  "continent": "Americas",
+  "latitude": 18.5338,
+  "longitude": -114.7227,
+  "timezone": "America/Mazatlan",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=iclr",
+    "id": "iclr",
+    "published_harmonics": false,
+    "operator": "International Tsunami Information Center Caribbean Office ( USA )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (International Tsunami Information Center Caribbean Office ( USA )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.738,
+    "MHHW": 0.696,
+    "MHW": 0.683,
+    "MSL": 0.632,
+    "MTL": 0.633,
+    "MLW": 0.582,
+    "MLLW": 0.575,
+    "LAT": 0.519,
+    "MHWS": 0.695,
+    "MLWS": 0.569
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.041,
+      "phase": 259.4
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.022,
+      "phase": 269.74
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.01,
+      "phase": 245.04
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.007,
+      "phase": 265.02
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.02,
+      "phase": 10.21
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.014,
+      "phase": 356.17
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.006,
+      "phase": 8.11
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 347.83
+    },
+    {
+      "name": "M4",
+      "amplitude": 0,
+      "phase": 350.26
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 159.5
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 302.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 272.95
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.001,
+      "phase": 224.48
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 224.49
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 245.94
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 263.11
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 254.86
+    },
+    {
+      "name": "R2",
+      "amplitude": 0,
+      "phase": 281.25
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0,
+      "phase": 265.67
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 178.58
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0,
+      "phase": 192.47
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 181.12
+    },
+    {
+      "name": "S1",
+      "amplitude": 0,
+      "phase": 130.09
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 313.85
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.001,
+      "phase": 13.81
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 46.96
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 333.69
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0,
+      "phase": 357.1
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0,
+      "phase": 7.46
+    },
+    {
+      "name": "M3",
+      "amplitude": 0,
+      "phase": 101.73
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 271.09
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 98.07
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 337.34
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 60.78
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 101.76
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 358.28
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 357.45
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.001,
+      "phase": 199.68
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.001,
+      "phase": 205.26
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0,
+      "phase": 86.3
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0,
+      "phase": 268.8
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 231.81
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.006,
+      "phase": 328.34
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.003,
+      "phase": 158.95
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0,
+      "phase": 214.04
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 73.55
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 164.88
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 96.08
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 230.82
+    }
+  ],
+  "epoch": {
+    "start": "2020-03-06",
+    "end": "2026-09-03"
+  }
+}

--- a/data/ioc/ilom.json
+++ b/data/ioc/ilom.json
@@ -1,0 +1,289 @@
+{
+  "name": "Ilo,Moquegua",
+  "region": "Moquegua Department",
+  "country": "Peru",
+  "continent": "Americas",
+  "latitude": -17.6447,
+  "longitude": -71.3496,
+  "timezone": "America/Lima",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ilom",
+    "id": "ilom",
+    "published_harmonics": false,
+    "operator": "Dirección de Hidrografía y Navegación (Perú)"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dirección de Hidrografía y Navegación (Perú)). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 0.852,
+    "MHHW": 0.28,
+    "MHW": 0.275,
+    "MSL": 0,
+    "MTL": -0.031,
+    "MLW": -0.337,
+    "MLLW": -0.337,
+    "LAT": -0.695,
+    "MHWS": 0.405,
+    "MLWS": -0.405
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.304,
+      "phase": 7.54
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.101,
+      "phase": 30.13
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.075,
+      "phase": 332.93
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.029,
+      "phase": 21.59
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.17,
+      "phase": 23.13
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.077,
+      "phase": 353.16
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.037,
+      "phase": 10.42
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.023,
+      "phase": 306.85
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 12.58
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.007,
+      "phase": 187.98
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 273.77
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 76.02
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.012,
+      "phase": 272.54
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 0.88
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.004,
+      "phase": 315.89
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 12.89
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 265.77
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 148
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 312.86
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 198.6
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.012,
+      "phase": 196.71
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 163.73
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.01,
+      "phase": 282.95
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 79.09
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 34.23
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 71.79
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.012,
+      "phase": 161.78
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 24.35
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 287.1
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.009,
+      "phase": 47.75
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 79.57
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.005,
+      "phase": 43.9
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 43.94
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 329.75
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 334.1
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 198.97
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 341.73
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.042,
+      "phase": 0.4
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.025,
+      "phase": 27.87
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.031,
+      "phase": 177.04
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.02,
+      "phase": 20.09
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 228.68
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.067,
+      "phase": 28.54
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.049,
+      "phase": 204.41
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 225.53
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 303.26
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 218.36
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 77.25
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 311.12
+    }
+  ],
+  "epoch": {
+    "start": "2022-12-07",
+    "end": "2026-08-31"
+  }
+}

--- a/data/ioc/ilom2.json
+++ b/data/ioc/ilom2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Ilo,Moquegua",
+  "region": "Moquegua Department",
+  "country": "Peru",
+  "continent": "Americas",
+  "latitude": -17.6447,
+  "longitude": -71.3496,
+  "timezone": "America/Lima",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ilom2",
+    "id": "ilom2",
+    "published_harmonics": false,
+    "operator": "Dirección de Hidrografía y Navegación (Perú)"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dirección de Hidrografía y Navegación (Perú)). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 0.852,
+    "MHHW": 0.28,
+    "MHW": 0.275,
+    "MSL": 0,
+    "MTL": -0.031,
+    "MLW": -0.337,
+    "MLLW": -0.337,
+    "LAT": -0.695,
+    "MHWS": 0.405,
+    "MLWS": -0.405
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.304,
+      "phase": 7.54
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.101,
+      "phase": 30.13
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.075,
+      "phase": 332.93
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.029,
+      "phase": 21.59
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.17,
+      "phase": 23.13
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.077,
+      "phase": 353.16
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.037,
+      "phase": 10.42
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.023,
+      "phase": 306.85
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 12.58
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.007,
+      "phase": 187.98
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 273.77
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 76.02
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.012,
+      "phase": 272.54
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 0.88
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.004,
+      "phase": 315.89
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 12.89
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 265.77
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 148
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 312.86
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 198.6
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.012,
+      "phase": 196.71
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 163.73
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.01,
+      "phase": 282.95
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 79.09
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 34.23
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 71.79
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.012,
+      "phase": 161.78
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 24.35
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 287.1
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.009,
+      "phase": 47.75
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 79.57
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.005,
+      "phase": 43.9
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 43.94
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 329.75
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 334.1
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 198.97
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 341.73
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.042,
+      "phase": 0.4
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.025,
+      "phase": 27.87
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.031,
+      "phase": 177.04
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.02,
+      "phase": 20.09
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 228.68
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.067,
+      "phase": 28.54
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.049,
+      "phase": 204.41
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 225.53
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 303.26
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 218.36
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 77.25
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 311.12
+    }
+  ],
+  "epoch": {
+    "start": "2022-12-07",
+    "end": "2026-08-31"
+  }
+}

--- a/data/ioc/inav.json
+++ b/data/ioc/inav.json
@@ -1,0 +1,289 @@
+{
+  "name": "Isla Naval",
+  "region": "Bolivar",
+  "country": "Colombia",
+  "continent": "Americas",
+  "latitude": 10.180556,
+  "longitude": -75.750278,
+  "timezone": "America/Bogota",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=inav",
+    "id": "inav",
+    "published_harmonics": false,
+    "operator": "Dirección General Marítima ( Colombia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dirección General Marítima ( Colombia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.329,
+    "MHHW": 9,
+    "MHW": 4.73,
+    "MSL": 3.076,
+    "MTL": 3.182,
+    "MLW": 1.634,
+    "MLLW": 0.8,
+    "LAT": 0.935,
+    "MHWS": 3.252,
+    "MLWS": 2.9
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.079,
+      "phase": 138.5
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.097,
+      "phase": 169
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.021,
+      "phase": 127.36
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.077,
+      "phase": 251.63
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.292,
+      "phase": 146.38
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.045,
+      "phase": 221.31
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.256,
+      "phase": 14.52
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.042,
+      "phase": 316.13
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.051,
+      "phase": 325.41
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.022,
+      "phase": 293.34
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.074,
+      "phase": 218.06
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.011,
+      "phase": 320.62
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.022,
+      "phase": 329.86
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.029,
+      "phase": 331.26
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.108,
+      "phase": 144.62
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.047,
+      "phase": 357.86
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.093,
+      "phase": 298.28
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.081,
+      "phase": 252.35
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.077,
+      "phase": 23.75
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.069,
+      "phase": 311.42
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.051,
+      "phase": 205.74
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.02,
+      "phase": 104.17
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.11,
+      "phase": 149.84
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.032,
+      "phase": 39.6
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.052,
+      "phase": 207.57
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.022,
+      "phase": 256.94
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.017,
+      "phase": 321.38
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.014,
+      "phase": 64.29
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.041,
+      "phase": 147.66
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.047,
+      "phase": 246.53
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.201,
+      "phase": 55.85
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.078,
+      "phase": 193.54
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.056,
+      "phase": 222.51
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.008,
+      "phase": 171.32
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.03,
+      "phase": 161.34
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.038,
+      "phase": 359.49
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.022,
+      "phase": 135.85
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.103,
+      "phase": 343.98
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.098,
+      "phase": 344.14
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.07,
+      "phase": 58.25
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.125,
+      "phase": 256.66
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.021,
+      "phase": 328.31
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.697,
+      "phase": 162.18
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.208,
+      "phase": 90.82
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.042,
+      "phase": 124.55
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.034,
+      "phase": 37.08
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.055,
+      "phase": 18.58
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.03,
+      "phase": 150.32
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.028,
+      "phase": 254.26
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-08-18"
+  }
+}

--- a/data/ioc/iqui.json
+++ b/data/ioc/iqui.json
@@ -1,0 +1,289 @@
+{
+  "name": "Iquique",
+  "region": "Tarapaca",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -20.2045777778,
+  "longitude": -70.1478305555,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=iqui",
+    "id": "iqui",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.212,
+    "MHHW": 5.866,
+    "MHW": 5.698,
+    "MSL": 5.356,
+    "MTL": 5.351,
+    "MLW": 5.003,
+    "MLLW": 4.98,
+    "LAT": 4.722,
+    "MHWS": 5.797,
+    "MLWS": 4.915
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.34,
+      "phase": 14.44
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.101,
+      "phase": 36.88
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.075,
+      "phase": 336.66
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.033,
+      "phase": 27.73
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.151,
+      "phase": 25.8
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.084,
+      "phase": 342.67
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.045,
+      "phase": 22.31
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 315.73
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 298.56
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 93.57
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 229.32
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 175.16
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 299.51
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.018,
+      "phase": 322.01
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 337.14
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 13.42
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 37.28
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 40.34
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 336.06
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 263.85
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 186.74
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 144.06
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 69.49
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 325.34
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 60.6
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 100.35
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 271.41
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 316.15
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 304.79
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 37.69
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 163.7
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 330.51
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 206.55
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 304.93
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 299.03
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 227.2
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 146.64
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 7.8
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 43.31
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 1.69
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 77.29
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 98.38
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.047,
+      "phase": 25.65
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.012,
+      "phase": 196.48
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 283.5
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 47.67
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 216.96
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 194.7
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 267.55
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/iqui2.json
+++ b/data/ioc/iqui2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Iquique",
+  "region": "Tarapaca",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -20.2045777778,
+  "longitude": -70.1478305555,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=iqui2",
+    "id": "iqui2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.212,
+    "MHHW": 5.866,
+    "MHW": 5.698,
+    "MSL": 5.356,
+    "MTL": 5.351,
+    "MLW": 5.003,
+    "MLLW": 4.98,
+    "LAT": 4.722,
+    "MHWS": 5.797,
+    "MLWS": 4.915
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.34,
+      "phase": 14.44
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.101,
+      "phase": 36.88
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.075,
+      "phase": 336.66
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.033,
+      "phase": 27.73
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.151,
+      "phase": 25.8
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.084,
+      "phase": 342.67
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.045,
+      "phase": 22.31
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 315.73
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 298.56
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 93.57
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 229.32
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 175.16
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 299.51
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.018,
+      "phase": 322.01
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 337.14
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 13.42
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 37.28
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 40.34
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 336.06
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 263.85
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 186.74
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 144.06
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 69.49
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 325.34
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 60.6
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 100.35
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 271.41
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 316.15
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 304.79
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 37.69
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 163.7
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 330.51
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 206.55
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 304.93
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 299.03
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 227.2
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 146.64
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 7.8
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 43.31
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 1.69
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 77.29
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 98.38
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.047,
+      "phase": 25.65
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.012,
+      "phase": 196.48
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 283.5
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 47.67
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 216.96
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 194.7
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 267.55
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/kala.json
+++ b/data/ioc/kala.json
@@ -1,0 +1,289 @@
+{
+  "name": "Kalamata",
+  "region": "Peloponnese",
+  "country": "Greece",
+  "continent": "Europe",
+  "latitude": 37.021533,
+  "longitude": 22.109833,
+  "timezone": "Europe/Athens",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=kala",
+    "id": "kala",
+    "published_harmonics": false,
+    "operator": "Hellenic Navy Hydrographic Service ( Greece )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Hellenic Navy Hydrographic Service ( Greece )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.212,
+    "MHHW": 2.333,
+    "MHW": 2.295,
+    "MSL": 2.19,
+    "MTL": 2.295,
+    "MLW": 2.295,
+    "MLLW": 2.283,
+    "LAT": -0.216,
+    "MHWS": 2.252,
+    "MLWS": 2.128
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.039,
+      "phase": 208.94
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.023,
+      "phase": 218.71
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.031,
+      "phase": 222.72
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.011,
+      "phase": 256.27
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.034,
+      "phase": 150.16
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.021,
+      "phase": 259.06
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.055,
+      "phase": 253.43
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.005,
+      "phase": 23.74
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.007,
+      "phase": 340
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.007,
+      "phase": 81.43
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.013,
+      "phase": 77.31
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.009,
+      "phase": 51.19
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 182.48
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 196.19
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 272.72
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.021,
+      "phase": 49.29
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.032,
+      "phase": 93.19
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.043,
+      "phase": 152.36
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.016,
+      "phase": 27.73
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.01,
+      "phase": 126.96
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.045,
+      "phase": 197.25
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.041,
+      "phase": 230.75
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.046,
+      "phase": 196.15
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 289.83
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 81.86
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 55.3
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.019,
+      "phase": 341.68
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.031,
+      "phase": 331.98
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.017,
+      "phase": 75.14
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 161.55
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.004,
+      "phase": 90.48
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.007,
+      "phase": 324.6
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.012,
+      "phase": 277.58
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.011,
+      "phase": 297.99
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.006,
+      "phase": 336.08
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.006,
+      "phase": 67.21
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.006,
+      "phase": 317.54
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.202,
+      "phase": 201.09
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.057,
+      "phase": 6.22
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.134,
+      "phase": 172.61
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 251.13
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.099,
+      "phase": 123.54
+    },
+    {
+      "name": "SA",
+      "amplitude": 1.648,
+      "phase": 13.46
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.262,
+      "phase": 233.99
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.019,
+      "phase": 199.61
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.007,
+      "phase": 259.14
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.023,
+      "phase": 55.67
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.01,
+      "phase": 179.37
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 216.69
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/kapi.json
+++ b/data/ioc/kapi.json
@@ -1,0 +1,289 @@
+{
+  "name": "Kapingamarangi",
+  "region": "Pohnpei State",
+  "country": "Federated States of Micronesia",
+  "continent": "Oceania",
+  "latitude": 1.0779583,
+  "longitude": 154.8066861,
+  "timezone": "Pacific/Pohnpei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=kapi",
+    "id": "kapi",
+    "published_harmonics": false,
+    "operator": "Yap Weather Service Office ( Federated States of Micronesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Yap Weather Service Office ( Federated States of Micronesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.744,
+    "MHHW": 5.975,
+    "MHW": 5.808,
+    "MSL": 5.538,
+    "MTL": 5.542,
+    "MLW": 5.275,
+    "MLLW": 5.211,
+    "LAT": 4.493,
+    "MHWS": 5.854,
+    "MLWS": 5.222
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLLW",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.169,
+      "phase": 133.88
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.147,
+      "phase": 148.82
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.033,
+      "phase": 163.12
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.053,
+      "phase": 146.15
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.185,
+      "phase": 65.18
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.118,
+      "phase": 42.43
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.061,
+      "phase": 42.61
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.027,
+      "phase": 33.82
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.006,
+      "phase": 212.83
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.012,
+      "phase": 213.37
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 214.41
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 191.7
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.006,
+      "phase": 156.12
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 133.39
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.005,
+      "phase": 158.91
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 141.93
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.016,
+      "phase": 208.47
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.007,
+      "phase": 279.02
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 140.59
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 0.93
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 305.18
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 127.01
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.031,
+      "phase": 261.33
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 25.73
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 62.39
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 97.06
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 329.19
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 19.73
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 35.42
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 218.33
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.009,
+      "phase": 293.34
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.009,
+      "phase": 237.04
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 274.75
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 173.91
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 249.94
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 131.43
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 100.02
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 154.47
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.018,
+      "phase": 3.66
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.026,
+      "phase": 336.4
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.019,
+      "phase": 15.96
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.012,
+      "phase": 251.8
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.5,
+      "phase": 259.3
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.05,
+      "phase": 22.92
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 218.22
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 179.93
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 185
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.008,
+      "phase": 47.65
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.015,
+      "phase": 94.85
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/kata.json
+++ b/data/ioc/kata.json
@@ -1,0 +1,289 @@
+{
+  "name": "Katakolo",
+  "region": "West Greece",
+  "country": "Greece",
+  "continent": "Europe",
+  "latitude": 37.64045,
+  "longitude": 21.319233,
+  "timezone": "Europe/Athens",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=kata",
+    "id": "kata",
+    "published_harmonics": false,
+    "operator": "Hellenic Navy Hydrographic Service ( Greece )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Hellenic Navy Hydrographic Service ( Greece )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 8.36,
+    "MHHW": 4.006,
+    "MHW": 3.836,
+    "MSL": 3.967,
+    "MTL": 3.767,
+    "MLW": 3.698,
+    "MLLW": 3.771,
+    "LAT": -0.134,
+    "MHWS": 4.014,
+    "MLWS": 3.92
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.026,
+      "phase": 319.44
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.021,
+      "phase": 117.65
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.05,
+      "phase": 115.24
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.021,
+      "phase": 327.2
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.05,
+      "phase": 137.58
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.004,
+      "phase": 148.48
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.068,
+      "phase": 353.13
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.078,
+      "phase": 269.69
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.015,
+      "phase": 359.56
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.009,
+      "phase": 197.66
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.014,
+      "phase": 130.04
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.006,
+      "phase": 129.42
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.034,
+      "phase": 337.38
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.041,
+      "phase": 214.1
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.04,
+      "phase": 158.4
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.043,
+      "phase": 17.04
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.021,
+      "phase": 288.95
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.022,
+      "phase": 17.95
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.053,
+      "phase": 61.55
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.013,
+      "phase": 268.4
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.048,
+      "phase": 258.89
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.016,
+      "phase": 142.88
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.079,
+      "phase": 263
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.01,
+      "phase": 17.98
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.026,
+      "phase": 56.14
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.042,
+      "phase": 288.19
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.039,
+      "phase": 127.96
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.07,
+      "phase": 150.33
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.068,
+      "phase": 272.16
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.021,
+      "phase": 248.86
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.027,
+      "phase": 100.29
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.019,
+      "phase": 45.89
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.007,
+      "phase": 267.81
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.02,
+      "phase": 320.72
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.016,
+      "phase": 321.08
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.013,
+      "phase": 197.19
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.005,
+      "phase": 102.45
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.441,
+      "phase": 314.98
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.838,
+      "phase": 316.27
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.321,
+      "phase": 51.3
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.501,
+      "phase": 205.55
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.522,
+      "phase": 186.78
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.949,
+      "phase": 54.85
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.918,
+      "phase": 131.16
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.032,
+      "phase": 214.12
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.013,
+      "phase": 83.52
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.059,
+      "phase": 264.92
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.012,
+      "phase": 279.09
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.02,
+      "phase": 159.24
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-06",
+    "end": "2026-01-20"
+  }
+}

--- a/data/ioc/kisr.json
+++ b/data/ioc/kisr.json
@@ -1,0 +1,289 @@
+{
+  "name": "Salmiya - KWT",
+  "region": "Hawalli",
+  "country": "Kuwait",
+  "continent": "Asia",
+  "latitude": 29.351944,
+  "longitude": 48.094841,
+  "timezone": "Asia/Kuwait",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=kisr",
+    "id": "kisr",
+    "published_harmonics": false,
+    "operator": "Kuwait Institute for Scientific Research ( Kuwait )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kuwait Institute for Scientific Research ( Kuwait )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": -3.602,
+    "MHHW": -4.172,
+    "MHW": -4.432,
+    "MSL": -5.361,
+    "MTL": -5.341,
+    "MLW": -6.25,
+    "MLLW": -6.506,
+    "LAT": -7.585,
+    "MHWS": -4.283,
+    "MLWS": -6.439
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.794,
+      "phase": 242.56
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.284,
+      "phase": 298.24
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.168,
+      "phase": 211.59
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.099,
+      "phase": 287.15
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.492,
+      "phase": 257.36
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.301,
+      "phase": 213.27
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.139,
+      "phase": 250.43
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.05,
+      "phase": 199.99
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.007,
+      "phase": 7.56
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 100.53
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 316.37
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 144.31
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.021,
+      "phase": 165.56
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.014,
+      "phase": 16.15
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.041,
+      "phase": 217.67
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.034,
+      "phase": 276.42
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.021,
+      "phase": 319.31
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.005,
+      "phase": 327.78
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.017,
+      "phase": 270.27
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.007,
+      "phase": 171.33
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 333.27
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.007,
+      "phase": 81.9
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.03,
+      "phase": 33.64
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.01,
+      "phase": 240.81
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.02,
+      "phase": 270.26
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.019,
+      "phase": 328.41
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 180.74
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.013,
+      "phase": 190.4
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.01,
+      "phase": 260.9
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.021,
+      "phase": 330.94
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 175.2
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 131.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 174.25
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 238.75
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 212.78
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.003,
+      "phase": 23.26
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 326.97
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.013,
+      "phase": 4.94
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.004,
+      "phase": 143.8
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 289.19
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 120.87
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.01,
+      "phase": 335.15
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.129,
+      "phase": 125.33
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.019,
+      "phase": 259.35
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 323.59
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 347
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.011,
+      "phase": 50.08
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 154.9
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.012,
+      "phase": 183.14
+    }
+  ],
+  "epoch": {
+    "start": "2023-06-15",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/koli.json
+++ b/data/ioc/koli.json
@@ -1,0 +1,289 @@
+{
+  "name": "Kolinamil, Jakarta Port",
+  "region": "Jakarta",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -6.10667,
+  "longitude": 106.89083,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=koli",
+    "id": "koli",
+    "published_harmonics": false,
+    "operator": "Geospacial Agency of Indonesia ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Geospacial Agency of Indonesia ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.737,
+    "MHHW": 7.396,
+    "MHW": 7.232,
+    "MSL": 7.038,
+    "MTL": 7.031,
+    "MLW": 6.831,
+    "MLLW": 6.682,
+    "LAT": 6.399,
+    "MHWS": 7.151,
+    "MLWS": 6.925
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.064,
+      "phase": 126.4
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.049,
+      "phase": 63.06
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.022,
+      "phase": 93.01
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.021,
+      "phase": 40.53
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.261,
+      "phase": 26.57
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.137,
+      "phase": 15.94
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.075,
+      "phase": 25.24
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.035,
+      "phase": 7.1
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.006,
+      "phase": 71.97
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 117.16
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 46.77
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 38.15
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 67.8
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 342.87
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.005,
+      "phase": 130.25
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.004,
+      "phase": 232.81
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 118.99
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 12.17
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 243.25
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 219.92
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.018,
+      "phase": 106.57
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.018,
+      "phase": 342.04
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.018,
+      "phase": 245.39
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 10.5
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.016,
+      "phase": 75.84
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.015,
+      "phase": 81.97
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 339.54
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.008,
+      "phase": 9.25
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 323.72
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 12.88
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 275.58
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 42.6
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 38.18
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 190.17
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 127.7
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 191.98
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 71.07
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 16.78
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 29.45
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.009,
+      "phase": 101.73
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 40.38
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 151.03
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.057,
+      "phase": 118.25
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.042,
+      "phase": 129.92
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 330.97
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 216.89
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 184.47
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 283.33
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 347.54
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-08-10"
+  }
+}

--- a/data/ioc/kors.json
+++ b/data/ioc/kors.json
@@ -1,0 +1,289 @@
+{
+  "name": "Korsakov",
+  "region": "Sakhalin Oblast",
+  "country": "Russia",
+  "continent": "Asia",
+  "latitude": 46.633333,
+  "longitude": 142.766667,
+  "timezone": "Asia/Sakhalin",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=kors",
+    "id": "kors",
+    "published_harmonics": false,
+    "operator": "Federal Service of Russia for Hydrometeorology and Environmental Monitoring ( Russia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Federal Service of Russia for Hydrometeorology and Environmental Monitoring ( Russia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 16.702,
+    "MHHW": 1.903,
+    "MHW": 1.898,
+    "MSL": 0,
+    "MTL": 0.036,
+    "MLW": -1.825,
+    "MLLW": -2.013,
+    "LAT": -19.582,
+    "MHWS": 0.866,
+    "MLWS": -0.866
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.142,
+      "phase": 83.66
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.724,
+      "phase": 143.39
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.797,
+      "phase": 162.72
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.093,
+      "phase": 46.8
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.389,
+      "phase": 320.35
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.12,
+      "phase": 338.96
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.564,
+      "phase": 189.57
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.574,
+      "phase": 285.98
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.061,
+      "phase": 118.41
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.046,
+      "phase": 235.41
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.052,
+      "phase": 300.06
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.013,
+      "phase": 32.09
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.116,
+      "phase": 24.58
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.397,
+      "phase": 310.06
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.374,
+      "phase": 8.84
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.333,
+      "phase": 230.4
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.632,
+      "phase": 131.52
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.681,
+      "phase": 2.35
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.772,
+      "phase": 31.46
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.064,
+      "phase": 313.96
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.639,
+      "phase": 135.64
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.653,
+      "phase": 12.81
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.399,
+      "phase": 67.25
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.15,
+      "phase": 262.59
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.313,
+      "phase": 135.88
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.215,
+      "phase": 28.84
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.277,
+      "phase": 84.99
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.529,
+      "phase": 126.39
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.319,
+      "phase": 358.15
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.017,
+      "phase": 227.22
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.029,
+      "phase": 156.63
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.02,
+      "phase": 307.6
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.049,
+      "phase": 358.79
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.02,
+      "phase": 204.15
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.031,
+      "phase": 305.48
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.053,
+      "phase": 184.79
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.028,
+      "phase": 83.25
+    },
+    {
+      "name": "MM",
+      "amplitude": 1.165,
+      "phase": 186.49
+    },
+    {
+      "name": "MF",
+      "amplitude": 1.118,
+      "phase": 3.94
+    },
+    {
+      "name": "MSF",
+      "amplitude": 1.038,
+      "phase": 136.89
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.693,
+      "phase": 160.32
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.314,
+      "phase": 190.67
+    },
+    {
+      "name": "SA",
+      "amplitude": 7.202,
+      "phase": 147.17
+    },
+    {
+      "name": "SSA",
+      "amplitude": 5.702,
+      "phase": 68.39
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.308,
+      "phase": 94.7
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.339,
+      "phase": 123.32
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.708,
+      "phase": 321.44
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.05,
+      "phase": 37.89
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.012,
+      "phase": 278.1
+    }
+  ],
+  "epoch": {
+    "start": "2024-09-09",
+    "end": "2026-05-15"
+  }
+}

--- a/data/ioc/lago.json
+++ b/data/ioc/lago.json
@@ -1,0 +1,289 @@
+{
+  "name": "LaGomera",
+  "region": "Canary Islands",
+  "country": "Spain",
+  "continent": "Europe",
+  "latitude": 28.08777,
+  "longitude": -17.10831,
+  "timezone": "Atlantic/Canary",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=lago",
+    "id": "lago",
+    "published_harmonics": false,
+    "operator": "Puertos del Estado ( Spain )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Puertos del Estado ( Spain )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.571,
+    "MHHW": 2.02,
+    "MHW": 1.959,
+    "MSL": 1.373,
+    "MTL": 1.369,
+    "MLW": 0.78,
+    "MLLW": 0.77,
+    "LAT": 0.234,
+    "MHWS": 2.176,
+    "MLWS": 0.57
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.573,
+      "phase": 9.51
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.23,
+      "phase": 30.91
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.119,
+      "phase": 357.88
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.065,
+      "phase": 27.12
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.055,
+      "phase": 26.92
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.044,
+      "phase": 283.95
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.016,
+      "phase": 18.09
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 233.42
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 93.19
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 146.63
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 56.12
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 239.81
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.018,
+      "phase": 345.13
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.025,
+      "phase": 331.54
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.022,
+      "phase": 1.46
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.012,
+      "phase": 13.81
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.012,
+      "phase": 25.41
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 357.6
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 343.39
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 202.01
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 327.07
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 334.96
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 200
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 237.85
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.002,
+      "phase": 63.16
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 98.11
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 186.94
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 239.4
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 198.24
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 309.3
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 151.11
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 196.46
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 5.19
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 87.85
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 305.13
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 243.84
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 70.82
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.005,
+      "phase": 6.14
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 18.08
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 158.8
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 321.32
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 290.88
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.065,
+      "phase": 162.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.014,
+      "phase": 18.27
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 305.98
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 42.34
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 194.05
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 100.45
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 201.55
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/lalb.json
+++ b/data/ioc/lalb.json
@@ -1,0 +1,289 @@
+{
+  "name": "La Libertad",
+  "region": "La Libertad Department",
+  "country": "El Salvador",
+  "continent": "Americas",
+  "latitude": 13.4851,
+  "longitude": -89.319,
+  "timezone": "America/El_Salvador",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=lalb",
+    "id": "lalb",
+    "published_harmonics": false,
+    "operator": "Ministerio de Medio Ambiente y Recursos Naturales ( El Salvador )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Ministerio de Medio Ambiente y Recursos Naturales ( El Salvador )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.877,
+    "MHHW": 7.259,
+    "MHW": 7.242,
+    "MSL": 6.501,
+    "MTL": 6.484,
+    "MLW": 5.726,
+    "MLLW": 5.678,
+    "LAT": 5.161,
+    "MHWS": 7.434,
+    "MLWS": 5.568
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.77,
+      "phase": 232.56
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.163,
+      "phase": 300.14
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.168,
+      "phase": 196.83
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.038,
+      "phase": 294.99
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.101,
+      "phase": 87.8
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.054,
+      "phase": 114.79
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.031,
+      "phase": 87.87
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 128.01
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 335.14
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 48.31
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 0.27
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 45.2
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.021,
+      "phase": 161.35
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.028,
+      "phase": 168.69
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.03,
+      "phase": 201.36
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.015,
+      "phase": 272.6
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.01,
+      "phase": 315.47
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 4.9
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 291.81
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 248.09
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 29.19
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 46.42
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.013,
+      "phase": 201.44
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 61.85
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 97.8
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 104.84
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 128.25
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 116.47
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 130.42
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 200.07
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 55.47
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 43.83
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 102.97
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 269.25
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 120.93
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 108.72
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 69.68
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 47.79
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 38.92
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 206.31
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 103.95
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 190.79
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.075,
+      "phase": 125.91
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.031,
+      "phase": 181.52
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 134.97
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 210.1
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.009,
+      "phase": 9.62
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 91.8
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 141.06
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/larn2.json
+++ b/data/ioc/larn2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Larnaca",
+  "region": "Larnaka",
+  "country": "Cyprus",
+  "continent": "Asia",
+  "latitude": 34.92775556,
+  "longitude": 33.64136944,
+  "timezone": "Asia/Nicosia",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=larn2",
+    "id": "larn2",
+    "published_harmonics": false,
+    "operator": "Cyprus Marine and Maritime Institute ( Cyprus )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Cyprus Marine and Maritime Institute ( Cyprus )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.171,
+    "MHHW": -0.122,
+    "MHW": -0.281,
+    "MSL": -0.253,
+    "MTL": -0.301,
+    "MLW": -0.322,
+    "MLLW": -0.404,
+    "LAT": -1.765,
+    "MHWS": -0.135,
+    "MLWS": -0.371
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.087,
+      "phase": 223.04
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.031,
+      "phase": 229.5
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.011,
+      "phase": 233.38
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.017,
+      "phase": 222.03
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.065,
+      "phase": 297.51
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.023,
+      "phase": 225.59
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.036,
+      "phase": 78.08
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.007,
+      "phase": 139.78
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 214.54
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 37.75
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.005,
+      "phase": 301.06
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 105.78
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 337.2
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 252.95
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 65.77
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.021,
+      "phase": 53.86
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.017,
+      "phase": 91.42
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.019,
+      "phase": 203.91
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.013,
+      "phase": 225.57
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 284.05
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.022,
+      "phase": 101.53
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.011,
+      "phase": 18.14
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.051,
+      "phase": 188.64
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 51.75
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 13.87
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 0.42
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.017,
+      "phase": 303.82
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 40.38
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 30.74
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 219.01
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.01,
+      "phase": 144.37
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.006,
+      "phase": 252.56
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 7.82
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 16.66
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 115.69
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 4.38
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 329.43
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.179,
+      "phase": 180.54
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.075,
+      "phase": 21.25
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.199,
+      "phase": 8.25
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.049,
+      "phase": 308.17
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.053,
+      "phase": 309.01
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.731,
+      "phase": 269.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.363,
+      "phase": 291.74
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 118.14
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.008,
+      "phase": 345.52
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.022,
+      "phase": 128.3
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.011,
+      "phase": 112.09
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 79.75
+    }
+  ],
+  "epoch": {
+    "start": "2023-10-28",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/larn3.json
+++ b/data/ioc/larn3.json
@@ -1,0 +1,289 @@
+{
+  "name": "Larnaka",
+  "region": "Larnaka",
+  "country": "Cyprus",
+  "continent": "Asia",
+  "latitude": 34.928197777,
+  "longitude": 33.645045927,
+  "timezone": "Asia/Nicosia",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=larn3",
+    "id": "larn3",
+    "published_harmonics": false,
+    "operator": "Department of Lands and Surveys ( Cyprus )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Department of Lands and Surveys ( Cyprus )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.171,
+    "MHHW": -0.122,
+    "MHW": -0.281,
+    "MSL": -0.253,
+    "MTL": -0.301,
+    "MLW": -0.322,
+    "MLLW": -0.404,
+    "LAT": -1.765,
+    "MHWS": -0.135,
+    "MLWS": -0.371
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.087,
+      "phase": 223.04
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.031,
+      "phase": 229.5
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.011,
+      "phase": 233.38
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.017,
+      "phase": 222.03
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.065,
+      "phase": 297.51
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.023,
+      "phase": 225.59
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.036,
+      "phase": 78.08
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.007,
+      "phase": 139.78
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 214.54
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 37.75
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.005,
+      "phase": 301.06
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 105.78
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 337.2
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 252.95
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 65.77
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.021,
+      "phase": 53.86
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.017,
+      "phase": 91.42
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.019,
+      "phase": 203.91
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.013,
+      "phase": 225.57
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 284.05
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.022,
+      "phase": 101.53
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.011,
+      "phase": 18.14
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.051,
+      "phase": 188.64
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 51.75
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 13.87
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 0.42
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.017,
+      "phase": 303.82
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 40.38
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 30.74
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 219.01
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.01,
+      "phase": 144.37
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.006,
+      "phase": 252.56
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 7.82
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 16.66
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 115.69
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 4.38
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 329.43
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.179,
+      "phase": 180.54
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.075,
+      "phase": 21.25
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.199,
+      "phase": 8.25
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.049,
+      "phase": 308.17
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.053,
+      "phase": 309.01
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.731,
+      "phase": 269.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.363,
+      "phase": 291.74
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 118.14
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.008,
+      "phase": 345.52
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.022,
+      "phase": 128.3
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.011,
+      "phase": 112.09
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 79.75
+    }
+  ],
+  "epoch": {
+    "start": "2023-10-28",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/lebu.json
+++ b/data/ioc/lebu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Lebu",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -37.594092,
+  "longitude": -73.664119,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=lebu",
+    "id": "lebu",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.287,
+    "MHHW": 4.784,
+    "MHW": 4.595,
+    "MSL": 4.156,
+    "MTL": 4.154,
+    "MLW": 3.713,
+    "MLLW": 3.673,
+    "LAT": 3.31,
+    "MHWS": 4.742,
+    "MLWS": 3.57
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.428,
+      "phase": 66.57
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.158,
+      "phase": 83.42
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.099,
+      "phase": 38.75
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.047,
+      "phase": 76.11
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.161,
+      "phase": 42.27
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.11,
+      "phase": 358.42
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 39.27
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 332.93
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 328.92
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 273.02
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 256.69
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 111.06
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 7.42
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 13.77
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 41.91
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 62.62
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 71.24
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 126.85
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 44.06
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 318.54
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 271.69
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 280.01
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 358.78
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 337.89
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 77.23
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 126.52
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 287.63
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 332.78
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 316.4
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 125.28
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 285.18
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 208.56
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 55.74
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 298.9
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 150.05
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 114.88
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 95.34
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 163.17
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 163.78
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 120.36
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 50.93
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 96.29
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.06,
+      "phase": 86.81
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.037,
+      "phase": 216.57
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 341.21
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 356.13
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 289.83
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 91.97
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 184.16
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/lebu2.json
+++ b/data/ioc/lebu2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Lebu",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -37.594092,
+  "longitude": -73.664119,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=lebu2",
+    "id": "lebu2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.287,
+    "MHHW": 4.784,
+    "MHW": 4.595,
+    "MSL": 4.156,
+    "MTL": 4.154,
+    "MLW": 3.713,
+    "MLLW": 3.673,
+    "LAT": 3.31,
+    "MHWS": 4.742,
+    "MLWS": 3.57
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.428,
+      "phase": 66.57
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.158,
+      "phase": 83.42
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.099,
+      "phase": 38.75
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.047,
+      "phase": 76.11
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.161,
+      "phase": 42.27
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.11,
+      "phase": 358.42
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 39.27
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 332.93
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 328.92
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 273.02
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 256.69
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 111.06
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 7.42
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 13.77
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 41.91
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 62.62
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 71.24
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 126.85
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 44.06
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 318.54
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 271.69
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 280.01
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 358.78
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 337.89
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 77.23
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 126.52
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 287.63
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 332.78
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 316.4
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 125.28
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 285.18
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 208.56
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 55.74
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 298.9
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 150.05
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 114.88
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 95.34
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 163.17
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 163.78
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 120.36
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 50.93
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 96.29
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.06,
+      "phase": 86.81
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.037,
+      "phase": 216.57
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 341.21
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 356.13
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 289.83
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 91.97
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 184.16
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/leme.json
+++ b/data/ioc/leme.json
@@ -1,0 +1,289 @@
+{
+  "name": "Limassol",
+  "region": "Limassol",
+  "country": "Cyprus",
+  "continent": "Asia",
+  "latitude": 34.668691,
+  "longitude": 33.042388,
+  "timezone": "Asia/Nicosia",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=leme",
+    "id": "leme",
+    "published_harmonics": false,
+    "operator": "Cyprus University of Technology ( Cyprus )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Cyprus University of Technology ( Cyprus )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.358,
+    "MHHW": 0.184,
+    "MHW": 0.163,
+    "MSL": 0.048,
+    "MTL": 0.048,
+    "MLW": -0.068,
+    "MLLW": -0.085,
+    "LAT": -0.241,
+    "MHWS": 0.208,
+    "MLWS": -0.112
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.1,
+      "phase": 224.59
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.06,
+      "phase": 239.19
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.017,
+      "phase": 223.43
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.018,
+      "phase": 233.75
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.024,
+      "phase": 273.75
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.018,
+      "phase": 249.22
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.01,
+      "phase": 269.96
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.002,
+      "phase": 233.4
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 279.23
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 306.43
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 247
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 24.17
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.002,
+      "phase": 230.39
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.003,
+      "phase": 245.4
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.003,
+      "phase": 230.23
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.004,
+      "phase": 228.23
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.004,
+      "phase": 255.38
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 287.47
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 231.59
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 113.65
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 80.99
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 104.94
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 3.59
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 272.55
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.001,
+      "phase": 274.95
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 262.25
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 349.96
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0,
+      "phase": 235.54
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 184.42
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 158.34
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 237.69
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 19.04
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 288.24
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 159.29
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 213.07
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 304.94
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 19.78
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.013,
+      "phase": 9.54
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 94.72
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 12.62
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 61.81
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.007,
+      "phase": 193.42
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.079,
+      "phase": 170.72
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.008,
+      "phase": 49.39
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 235.03
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 26.09
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 302.68
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 171.18
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 285.66
+    }
+  ],
+  "epoch": {
+    "start": "2023-07-06",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/lena.json
+++ b/data/ioc/lena.json
@@ -1,0 +1,289 @@
+{
+  "name": "Lenakel, Tanna",
+  "region": "Tafea",
+  "country": "Vanuatu",
+  "continent": "Oceania",
+  "latitude": -19.53256,
+  "longitude": 169.265953,
+  "timezone": "Pacific/Efate",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=lena",
+    "id": "lena",
+    "published_harmonics": false,
+    "operator": "Department of Geology, Mines and Water Resources ( Vanuatu )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Department of Geology, Mines and Water Resources ( Vanuatu )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.46,
+    "MHHW": 5.148,
+    "MHW": 5.093,
+    "MSL": 4.677,
+    "MTL": 4.69,
+    "MLW": 4.286,
+    "MLLW": 4.15,
+    "LAT": 3.859,
+    "MHWS": 5.176,
+    "MLWS": 4.178
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.405,
+      "phase": 191.43
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.094,
+      "phase": 202.37
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.085,
+      "phase": 170.45
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.029,
+      "phase": 197.68
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.144,
+      "phase": 30.68
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.065,
+      "phase": 10.55
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.042,
+      "phase": 28.32
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.01,
+      "phase": 359.95
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.007,
+      "phase": 31.4
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 19.07
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 355.75
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 32.62
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 157.9
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.009,
+      "phase": 148.68
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 174.77
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 201.43
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 223.68
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 282.64
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 199.15
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 9.38
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.006,
+      "phase": 223.2
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 354.44
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.014,
+      "phase": 215.29
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 50.88
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 46.23
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 83.11
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 239.23
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 348.4
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0,
+      "phase": 264.03
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 308.41
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 48.01
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 173.6
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 323.8
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 18.88
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 31.5
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 232.54
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 196.82
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.013,
+      "phase": 13.59
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 13.98
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 344.26
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 98.27
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 344.16
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.047,
+      "phase": 274.38
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.011,
+      "phase": 228.16
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 132.71
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 107.14
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 357.37
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 83.52
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 188.11
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/lirf.json
+++ b/data/ioc/lirf.json
@@ -1,0 +1,288 @@
+{
+  "name": "Lihou_Reef",
+  "country": "Australia",
+  "continent": "Oceania",
+  "latitude": -17.133,
+  "longitude": 152.145,
+  "timezone": "Australia/Brisbane",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=lirf",
+    "id": "lirf",
+    "published_harmonics": false,
+    "operator": "National Tidal Centre/Australian Bureau of Meteorology ( Australia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Tidal Centre/Australian Bureau of Meteorology ( Australia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.296,
+    "MHHW": 1.736,
+    "MHW": 1.532,
+    "MSL": 1.11,
+    "MTL": 1.105,
+    "MLW": 0.678,
+    "MLLW": 0.522,
+    "LAT": -0.002,
+    "MHWS": 1.654,
+    "MLWS": 0.566
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.354,
+      "phase": 314.49
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.19,
+      "phase": 282.53
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.115,
+      "phase": 302.63
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.051,
+      "phase": 277.91
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.27,
+      "phase": 25.07
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.134,
+      "phase": 0.49
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.08,
+      "phase": 21.41
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.025,
+      "phase": 339.22
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 58.25
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 15.45
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 52.38
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 125.16
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.017,
+      "phase": 292.96
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.025,
+      "phase": 283.9
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 304.73
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.003,
+      "phase": 259.88
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.013,
+      "phase": 262.71
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 236.95
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 96.48
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 15.78
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 205.27
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 239.49
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 245.51
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 329.57
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.015,
+      "phase": 44.76
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.013,
+      "phase": 78.02
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 304.6
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 344.86
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 314.74
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 46.49
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 91.95
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 358.04
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 357.01
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 267.25
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 104.78
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 109.89
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 74.95
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 320.19
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 10.24
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 257.87
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 53.63
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 150.34
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.073,
+      "phase": 272.67
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.007,
+      "phase": 239.4
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 273.75
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 278.88
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.008,
+      "phase": 204.38
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 121.53
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 284.88
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/litz.json
+++ b/data/ioc/litz.json
@@ -1,0 +1,288 @@
+{
+  "name": "Litzlitz, Malekula",
+  "region": "Malampa",
+  "country": "Vanuatu",
+  "continent": "Oceania",
+  "latitude": -16.11283,
+  "longitude": 167.44397,
+  "timezone": "Pacific/Efate",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=litz",
+    "id": "litz",
+    "published_harmonics": false
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator. Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.572,
+    "MHHW": 5.119,
+    "MHW": 5.054,
+    "MSL": 4.611,
+    "MTL": 4.643,
+    "MLW": 4.232,
+    "MLLW": 4.043,
+    "LAT": 3.58,
+    "MHWS": 5.153,
+    "MLWS": 4.069
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.398,
+      "phase": 168.15
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.144,
+      "phase": 162.77
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.096,
+      "phase": 157.07
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.042,
+      "phase": 157.29
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.159,
+      "phase": 34.66
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.084,
+      "phase": 13.28
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.046,
+      "phase": 31.74
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 358.24
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 172.48
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 192.77
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 170.76
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 337.7
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 143.6
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.014,
+      "phase": 137.67
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 158.53
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 163.27
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 170.67
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 218.34
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 146.1
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 334.16
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 60.59
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 155.23
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 212.64
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 345.94
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 46.47
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 85.75
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 300.44
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 0
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 335.25
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 291.96
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 295.38
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 148.3
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 161.14
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 327.98
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 330.3
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 255.02
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 240.24
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 340.87
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.013,
+      "phase": 46.55
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 217.83
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 29.29
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 307.71
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.109,
+      "phase": 282.89
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.057,
+      "phase": 266.52
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 128.46
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 293.12
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 42.36
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 339.41
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 82.47
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/live2.json
+++ b/data/ioc/live2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Liverpool",
+  "region": "England",
+  "country": "United Kingdom",
+  "continent": "Europe",
+  "latitude": 53.405636,
+  "longitude": -3.014598,
+  "timezone": "Europe/London",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=live2",
+    "id": "live2",
+    "published_harmonics": false,
+    "operator": "National Oceanography Centre ( UK )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Oceanography Centre ( UK )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 8.979,
+    "MHHW": 9.296,
+    "MHW": 9.247,
+    "MSL": 6.241,
+    "MTL": 6.124,
+    "MLW": 3.002,
+    "MLLW": 2.875,
+    "LAT": 1.91,
+    "MHWS": 8.402,
+    "MLWS": 4.08
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.652,
+      "phase": 305.31
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.509,
+      "phase": 351.15
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.311,
+      "phase": 283.87
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.127,
+      "phase": 357.36
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.036,
+      "phase": 194.24
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.04,
+      "phase": 64.88
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.024,
+      "phase": 197.79
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.02,
+      "phase": 345.24
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.554,
+      "phase": 86.91
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.422,
+      "phase": 124.3
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.202,
+      "phase": 68.72
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.186,
+      "phase": 243.85
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.066,
+      "phase": 260.88
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.098,
+      "phase": 53.34
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.04,
+      "phase": 277.96
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.082,
+      "phase": 344.86
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.107,
+      "phase": 7.03
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.062,
+      "phase": 107.8
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.046,
+      "phase": 257.27
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.074,
+      "phase": 163.81
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.23,
+      "phase": 54.07
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.208,
+      "phase": 201.06
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.014,
+      "phase": 358.19
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 250.28
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 348.35
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.002,
+      "phase": 316.97
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 255.93
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 26.96
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.008,
+      "phase": 150.46
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.013,
+      "phase": 78.16
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.014,
+      "phase": 222.13
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.081,
+      "phase": 173.88
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.055,
+      "phase": 45.63
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.157,
+      "phase": 140.97
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.159,
+      "phase": 278.94
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.033,
+      "phase": 115.31
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.027,
+      "phase": 297.7
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.154,
+      "phase": 20.88
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.05,
+      "phase": 16.14
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.384,
+      "phase": 42.16
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 253.18
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.014,
+      "phase": 269.86
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.206,
+      "phase": 73
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.015,
+      "phase": 69.71
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.057,
+      "phase": 17.19
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.026,
+      "phase": 78
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.118,
+      "phase": 37.41
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.009,
+      "phase": 313.99
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.006,
+      "phase": 73.16
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/lpbc.json
+++ b/data/ioc/lpbc.json
@@ -1,0 +1,289 @@
+{
+  "name": "Langara_Point_BC (Henslung Cove)",
+  "country": "Canada",
+  "continent": "Americas",
+  "latitude": 54.2,
+  "longitude": -133.1,
+  "timezone": "America/Vancouver",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=lpbc",
+    "id": "lpbc",
+    "published_harmonics": false,
+    "operator": "Fisheries and Oceans Canada ( Canada )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Fisheries and Oceans Canada ( Canada )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.232,
+    "MHHW": 4.046,
+    "MHW": 3.949,
+    "MSL": 2.74,
+    "MTL": 2.733,
+    "MLW": 1.517,
+    "MLLW": 1.055,
+    "LLWLT": 0.296,
+    "LAT": 0.046,
+    "MHWS": 4.34,
+    "MLWS": 1.14
+  },
+  "datums_source": "observed",
+  "chart_datum": "LLWLT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.21,
+      "phase": 246.23
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.39,
+      "phase": 276.1
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.247,
+      "phase": 222.55
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.107,
+      "phase": 268.65
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.462,
+      "phase": 249.57
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.286,
+      "phase": 234.83
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.144,
+      "phase": 246.5
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.05,
+      "phase": 226.63
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.014,
+      "phase": 96.95
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.008,
+      "phase": 111.35
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.005,
+      "phase": 69.5
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 10.73
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.028,
+      "phase": 197.06
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.026,
+      "phase": 198.54
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.048,
+      "phase": 226.1
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.028,
+      "phase": 264.05
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.023,
+      "phase": 269.81
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 293.94
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.007,
+      "phase": 265.53
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 104.83
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 128.01
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 131.21
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.013,
+      "phase": 43.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 212.72
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.026,
+      "phase": 261.82
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.018,
+      "phase": 281.6
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 226.74
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.01,
+      "phase": 228.17
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 231.18
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 96.46
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 302.68
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 150.28
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 45.92
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 235.31
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 27.88
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 16.84
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 1.14
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.02,
+      "phase": 218.29
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.022,
+      "phase": 171.75
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.01,
+      "phase": 176.27
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 142.88
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 263.68
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.096,
+      "phase": 258.91
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.021,
+      "phase": 150.9
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 199.57
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 198.06
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 144.99
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 356.44
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 88.31
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/luga.json
+++ b/data/ioc/luga.json
@@ -1,0 +1,289 @@
+{
+  "name": "Luganville",
+  "region": "Sanma",
+  "country": "Vanuatu",
+  "continent": "Oceania",
+  "latitude": -15.5156,
+  "longitude": 167.1886,
+  "timezone": "Pacific/Efate",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=luga",
+    "id": "luga",
+    "published_harmonics": false,
+    "operator": "National Tidal Centre/Australian Bureau of Meteorology ( Australia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Tidal Centre/Australian Bureau of Meteorology ( Australia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.875,
+    "MHHW": 1.464,
+    "MHW": 1.371,
+    "MSL": 0.926,
+    "MTL": 0.931,
+    "MLW": 0.491,
+    "MLLW": 0.337,
+    "LAT": -0.083,
+    "MHWS": 1.504,
+    "MLWS": 0.348
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.418,
+      "phase": 167.16
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.16,
+      "phase": 161.81
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.102,
+      "phase": 155.5
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.045,
+      "phase": 155.92
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.163,
+      "phase": 35.98
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.087,
+      "phase": 16.07
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 32.7
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 357.92
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 172.36
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 204.7
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 158.51
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 99.34
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 137.67
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.017,
+      "phase": 141.41
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 158.04
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 159.99
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.01,
+      "phase": 157.1
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 183.37
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 161.26
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 352.22
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 326.97
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 9.89
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 227.7
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 264.29
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 53.43
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 86.1
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 319.7
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 5.47
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 333.75
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 305.25
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 326.88
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 207.91
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 158.52
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 168.38
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 132.74
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 202.76
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 148.35
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 10.83
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 22.44
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 281.34
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 78.7
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 272.15
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.063,
+      "phase": 241.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.006,
+      "phase": 352.88
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 130
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 141.63
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 31.93
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 73.25
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 141.51
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/malp2.json
+++ b/data/ioc/malp2.json
@@ -1,0 +1,288 @@
+{
+  "name": "Malpelo",
+  "country": "Colombia",
+  "continent": "Americas",
+  "latitude": 4.0024,
+  "longitude": -81.6042,
+  "timezone": "America/Bogota",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=malp2",
+    "id": "malp2",
+    "published_harmonics": false,
+    "operator": "Dirección General Marítima ( Colombia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dirección General Marítima ( Colombia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 9.817,
+    "MHHW": 14.812,
+    "MHW": 10.73,
+    "MSL": 6.873,
+    "MTL": 7.2,
+    "MLW": 3.671,
+    "MLLW": 0.903,
+    "LAT": 3.141,
+    "MHWS": 7.375,
+    "MLWS": 6.371
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.263,
+      "phase": 225.28
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.239,
+      "phase": 194.17
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.051,
+      "phase": 217.32
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.057,
+      "phase": 242.2
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.111,
+      "phase": 183.52
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.019,
+      "phase": 243.77
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.021,
+      "phase": 100.76
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.024,
+      "phase": 4.34
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.137,
+      "phase": 249.21
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.094,
+      "phase": 243.58
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.043,
+      "phase": 266.67
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.014,
+      "phase": 7.41
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 72.66
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.089,
+      "phase": 203.44
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.067,
+      "phase": 137.04
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.079,
+      "phase": 82.67
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.149,
+      "phase": 261.52
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.11,
+      "phase": 326.87
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.049,
+      "phase": 6.59
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.112,
+      "phase": 43.26
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.036,
+      "phase": 192.02
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.035,
+      "phase": 261.23
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.19,
+      "phase": 193.79
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.03,
+      "phase": 165.81
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.043,
+      "phase": 167.35
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.027,
+      "phase": 188.92
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.084,
+      "phase": 163.82
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.06,
+      "phase": 216.92
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.044,
+      "phase": 120.28
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.02,
+      "phase": 36.78
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.384,
+      "phase": 66.12
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.044,
+      "phase": 125.52
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.058,
+      "phase": 75.62
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.067,
+      "phase": 270.08
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.077,
+      "phase": 276.35
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.011,
+      "phase": 190.66
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.053,
+      "phase": 224.82
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.136,
+      "phase": 257.79
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.126,
+      "phase": 345.22
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.08,
+      "phase": 79.21
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.06,
+      "phase": 88.8
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.091,
+      "phase": 184.02
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.871,
+      "phase": 162.05
+    },
+    {
+      "name": "SSA",
+      "amplitude": 1.164,
+      "phase": 114.24
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.067,
+      "phase": 152.91
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.106,
+      "phase": 117.05
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.09,
+      "phase": 170.76
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.06,
+      "phase": 313.63
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.094,
+      "phase": 294.57
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-08-28"
+  }
+}

--- a/data/ioc/marm.json
+++ b/data/ioc/marm.json
@@ -1,0 +1,289 @@
+{
+  "name": "Marmagao",
+  "region": "Goa",
+  "country": "India",
+  "continent": "Asia",
+  "latitude": 15.41,
+  "longitude": 73.8,
+  "timezone": "Asia/Kolkata",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=marm",
+    "id": "marm",
+    "published_harmonics": false,
+    "operator": "Indian National Centre for Ocean Information Services ( India )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Indian National Centre for Ocean Information Services ( India )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.47,
+    "MHHW": 3.927,
+    "MHW": 3.853,
+    "MSL": 3.302,
+    "MTL": 3.304,
+    "MLW": 2.756,
+    "MLLW": 2.383,
+    "LAT": 1.573,
+    "MHWS": 4.04,
+    "MLWS": 2.564
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.533,
+      "phase": 129.33
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.205,
+      "phase": 180.81
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.122,
+      "phase": 107.1
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.048,
+      "phase": 162.14
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.313,
+      "phase": 321.71
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.137,
+      "phase": 318.4
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.105,
+      "phase": 320.41
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.038,
+      "phase": 317.4
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.006,
+      "phase": 50.36
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 98.52
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 318.85
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.008,
+      "phase": 147.83
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.019,
+      "phase": 74.22
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.012,
+      "phase": 70.35
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 110.31
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.025,
+      "phase": 157.41
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.014,
+      "phase": 182.84
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.007,
+      "phase": 53.58
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.008,
+      "phase": 114.35
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.014,
+      "phase": 50.87
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 248.11
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.013,
+      "phase": 117.23
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.148,
+      "phase": 103.16
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 273.45
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.011,
+      "phase": 325.45
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.017,
+      "phase": 6.41
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.007,
+      "phase": 277.84
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.012,
+      "phase": 337.32
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.008,
+      "phase": 21.81
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 146.18
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.039,
+      "phase": 259.38
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.027,
+      "phase": 241.24
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.007,
+      "phase": 233.18
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.009,
+      "phase": 63.9
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.008,
+      "phase": 196.98
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.003,
+      "phase": 341.84
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 335.54
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.039,
+      "phase": 244.75
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.005,
+      "phase": 51.44
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.055,
+      "phase": 96.18
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.026,
+      "phase": 95.63
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.025,
+      "phase": 352.61
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.154,
+      "phase": 106.92
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.082,
+      "phase": 56.62
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.008,
+      "phase": 286.13
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.01,
+      "phase": 84.46
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.012,
+      "phase": 162.17
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 186.33
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.006,
+      "phase": 190.82
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/matr.json
+++ b/data/ioc/matr.json
@@ -1,0 +1,289 @@
+{
+  "name": "Marsa Matruh",
+  "region": "Matruh",
+  "country": "Egypt",
+  "continent": "Africa",
+  "latitude": 31.370025,
+  "longitude": 27.203928,
+  "timezone": "Africa/Cairo",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=matr",
+    "id": "matr",
+    "published_harmonics": false,
+    "operator": "National Institute of Oceanography and Fisheries, Alexandria ( Egypt )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Institute of Oceanography and Fisheries, Alexandria ( Egypt )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": -1.756,
+    "MHHW": -1.923,
+    "MHW": -1.943,
+    "MSL": -2.012,
+    "MTL": -2.015,
+    "MLW": -2.087,
+    "MLLW": -2.09,
+    "LAT": -2.297,
+    "MHWS": -1.921,
+    "MLWS": -2.103
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.055,
+      "phase": 236.65
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.036,
+      "phase": 238.06
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.01,
+      "phase": 241.63
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.011,
+      "phase": 242.24
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.014,
+      "phase": 274.37
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.012,
+      "phase": 238.21
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.005,
+      "phase": 288.02
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.002,
+      "phase": 197.25
+    },
+    {
+      "name": "M4",
+      "amplitude": 0,
+      "phase": 198.5
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 116.94
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 176.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 169.42
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.001,
+      "phase": 279.78
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 263.09
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.001,
+      "phase": 223.31
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 106.08
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 235.87
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 234.3
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 235.82
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 73.72
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 8.86
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 26.37
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.015,
+      "phase": 166.48
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 187.35
+    },
+    {
+      "name": "J1",
+      "amplitude": 0,
+      "phase": 261.84
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 211.78
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 264.81
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 309.66
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 94.03
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 132.92
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 149.62
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 280.22
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 192.67
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 76.46
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 338.51
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 231.39
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 41.45
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.028,
+      "phase": 3.5
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.008,
+      "phase": 129.48
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.011,
+      "phase": 170.55
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 332.82
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.013,
+      "phase": 277.92
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.073,
+      "phase": 190.22
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.06,
+      "phase": 253.78
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 223.24
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 9.63
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 114.22
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 169.44
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 306.62
+    }
+  ],
+  "epoch": {
+    "start": "2025-06-08",
+    "end": "2026-09-02"
+  }
+}

--- a/data/ioc/meji.json
+++ b/data/ioc/meji.json
@@ -1,0 +1,289 @@
+{
+  "name": "Mejillones",
+  "region": "Antofagasta",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -23.097712,
+  "longitude": -70.450663,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=meji",
+    "id": "meji",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.752,
+    "MHHW": 4.41,
+    "MHW": 4.243,
+    "MSL": 3.871,
+    "MTL": 3.88,
+    "MLW": 3.517,
+    "MLLW": 3.476,
+    "LAT": 3.223,
+    "MHWS": 4.338,
+    "MLWS": 3.404
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.36,
+      "phase": 21.5
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.107,
+      "phase": 44.9
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.079,
+      "phase": 344.67
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.034,
+      "phase": 35.29
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.15,
+      "phase": 25.83
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.086,
+      "phase": 343.63
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 23.17
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.016,
+      "phase": 320.42
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 307.75
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 70.37
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 295.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 199.87
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 313.6
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 327.1
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 348.46
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 27.48
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 49.2
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 53.11
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 318.84
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 271.77
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 185.6
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 57.01
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.01,
+      "phase": 117.55
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 343.5
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 53.52
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 105.14
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 302.14
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 307
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 291.05
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 41.46
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 143.58
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 346.66
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 270.8
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 22.43
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 295.43
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 196.83
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 15.91
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 74.23
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.008,
+      "phase": 54.23
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 19.89
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 45.8
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 215.32
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.03,
+      "phase": 48.24
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.003,
+      "phase": 262.74
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 275.75
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 204.62
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 214.83
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 166.64
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 265.68
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/meji2.json
+++ b/data/ioc/meji2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Mejillones",
+  "region": "Antofagasta",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -23.097712,
+  "longitude": -70.450663,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=meji2",
+    "id": "meji2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.752,
+    "MHHW": 4.41,
+    "MHW": 4.243,
+    "MSL": 3.871,
+    "MTL": 3.88,
+    "MLW": 3.517,
+    "MLLW": 3.476,
+    "LAT": 3.223,
+    "MHWS": 4.338,
+    "MLWS": 3.404
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.36,
+      "phase": 21.5
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.107,
+      "phase": 44.9
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.079,
+      "phase": 344.67
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.034,
+      "phase": 35.29
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.15,
+      "phase": 25.83
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.086,
+      "phase": 343.63
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 23.17
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.016,
+      "phase": 320.42
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 307.75
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 70.37
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 295.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 199.87
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 313.6
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 327.1
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 348.46
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 27.48
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 49.2
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 53.11
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 318.84
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 271.77
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 185.6
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 57.01
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.01,
+      "phase": 117.55
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 343.5
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 53.52
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 105.14
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 302.14
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 307
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 291.05
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 41.46
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 143.58
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 346.66
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 270.8
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 22.43
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 295.43
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 196.83
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 15.91
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 74.23
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.008,
+      "phase": 54.23
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 19.89
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 45.8
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 215.32
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.03,
+      "phase": 48.24
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.003,
+      "phase": 262.74
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 275.75
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 204.62
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 214.83
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 166.64
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 265.68
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/milo.json
+++ b/data/ioc/milo.json
@@ -1,0 +1,289 @@
+{
+  "name": "Milolii, Hawaii",
+  "region": "HI",
+  "country": "United States",
+  "continent": "Americas",
+  "latitude": 19.185046,
+  "longitude": -155.90725,
+  "timezone": "Pacific/Honolulu",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=milo",
+    "id": "milo",
+    "published_harmonics": false,
+    "operator": "University of Hawaii Sea Level Center ( USA )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (University of Hawaii Sea Level Center ( USA )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 8.027,
+    "MHHW": 2.848,
+    "MHW": 2.677,
+    "MSL": 2.478,
+    "MTL": 2.448,
+    "MLW": 2.219,
+    "MLLW": 2.188,
+    "LAT": -1.331,
+    "MHWS": 2.753,
+    "MLWS": 2.203
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLLW",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.221,
+      "phase": 56.16
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.054,
+      "phase": 49.11
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.032,
+      "phase": 37.36
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.019,
+      "phase": 28.61
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.143,
+      "phase": 217.9
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.084,
+      "phase": 205.25
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.05,
+      "phase": 227.73
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.014,
+      "phase": 252.85
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 184.3
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 85.66
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 100.61
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 49.86
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 320.49
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 301.36
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.009,
+      "phase": 38.15
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.021,
+      "phase": 71.65
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 137.17
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.008,
+      "phase": 113.66
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 105.23
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.007,
+      "phase": 85.62
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.025,
+      "phase": 143.64
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.021,
+      "phase": 102.53
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 176.87
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.011,
+      "phase": 159.22
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.015,
+      "phase": 269.63
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.002,
+      "phase": 214.85
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 44.94
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 206.21
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.012,
+      "phase": 6.76
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 193.96
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.006,
+      "phase": 104.19
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 59.22
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 305.06
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 331.06
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 189.92
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 145
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 100.24
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.145,
+      "phase": 349.05
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.061,
+      "phase": 193.08
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.133,
+      "phase": 93.73
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.079,
+      "phase": 275.74
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.037,
+      "phase": 33.01
+    },
+    {
+      "name": "SA",
+      "amplitude": 2.279,
+      "phase": 22.67
+    },
+    {
+      "name": "SSA",
+      "amplitude": 2.562,
+      "phase": 24.53
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.01,
+      "phase": 40.21
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.006,
+      "phase": 133.44
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.019,
+      "phase": 128.59
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 313.48
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.011,
+      "phase": 196.73
+    }
+  ],
+  "epoch": {
+    "start": "2024-09-06",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/mnts.json
+++ b/data/ioc/mnts.json
@@ -1,0 +1,289 @@
+{
+  "name": "Little Bay",
+  "region": "Saint Peter",
+  "country": "Montserrat",
+  "continent": "Americas",
+  "latitude": 16.80348528,
+  "longitude": -62.2059336,
+  "timezone": "America/Montserrat",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=mnts",
+    "id": "mnts",
+    "published_harmonics": false,
+    "operator": "UK Hydrographic Office ( UK )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (UK Hydrographic Office ( UK )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.864,
+    "MHHW": 0.588,
+    "MHW": 0.557,
+    "MSL": 0.482,
+    "MTL": 0.475,
+    "MLW": 0.393,
+    "MLLW": 0.36,
+    "LAT": -0.009,
+    "MHWS": 0.522,
+    "MLWS": 0.442
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.029,
+      "phase": 223.29
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.011,
+      "phase": 249.93
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.008,
+      "phase": 198.67
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.003,
+      "phase": 239.01
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.078,
+      "phase": 227.33
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.062,
+      "phase": 222.84
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.024,
+      "phase": 228.35
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 212.68
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 276.32
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 310.66
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 142.11
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 189.88
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.002,
+      "phase": 214.12
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.003,
+      "phase": 111.64
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 189.96
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.003,
+      "phase": 40.45
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 316.54
+    },
+    {
+      "name": "R2",
+      "amplitude": 0,
+      "phase": 75.48
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0,
+      "phase": 56.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 160.76
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 306.24
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 210.31
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 217.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 267.03
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 234.44
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 222.7
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 162.19
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 210.92
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 199.4
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 175.3
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 70.18
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 159.09
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 18.72
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 156.62
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 345.44
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 109.85
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 198.44
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.017,
+      "phase": 10.96
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 343.58
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 182.96
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 95.75
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 213.58
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.2,
+      "phase": 193.48
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.097,
+      "phase": 237.55
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 203.26
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 291.38
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 114.59
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 212.14
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 196.92
+    }
+  ],
+  "epoch": {
+    "start": "2024-03-22",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/mpaw.json
+++ b/data/ioc/mpaw.json
@@ -1,0 +1,289 @@
+{
+  "name": "A2",
+  "region": "Flanders",
+  "country": "Belgium",
+  "continent": "Europe",
+  "latitude": 51.36055556,
+  "longitude": 3.118333333,
+  "timezone": "Europe/Brussels",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=mpaw",
+    "id": "mpaw",
+    "published_harmonics": false,
+    "operator": "Maritieme Dienstverlening en Kust ( Belgium )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Maritieme Dienstverlening en Kust ( Belgium )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.167,
+    "MHHW": 4.254,
+    "MHW": 4.163,
+    "MSL": 2.359,
+    "MTL": 2.436,
+    "MLW": 0.709,
+    "MLLW": 0.556,
+    "LAT": -0.204,
+    "MHWS": 4.519,
+    "MLWS": 0.199
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.673,
+      "phase": 357.3
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.487,
+      "phase": 51.33
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.289,
+      "phase": 333.14
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.142,
+      "phase": 50.23
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.06,
+      "phase": 341.56
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.1,
+      "phase": 162.37
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.031,
+      "phase": 324.18
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.035,
+      "phase": 121.17
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.094,
+      "phase": 336.97
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.067,
+      "phase": 39.78
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.034,
+      "phase": 319.92
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.079,
+      "phase": 276.55
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.026,
+      "phase": 273.48
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.103,
+      "phase": 103.28
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.087,
+      "phase": 324.25
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.114,
+      "phase": 30.25
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.029,
+      "phase": 37.21
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 99.29
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.055,
+      "phase": 8.96
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.037,
+      "phase": 276.09
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.023,
+      "phase": 321.65
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.017,
+      "phase": 121.98
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 285.74
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 11.09
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 61.18
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 138.09
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 29.13
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 152.81
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 174.49
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 253.08
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 280.67
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.008,
+      "phase": 142.57
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.005,
+      "phase": 286.15
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.024,
+      "phase": 192.2
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.08,
+      "phase": 325.03
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.009,
+      "phase": 58.42
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.006,
+      "phase": 273.69
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 174.04
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.014,
+      "phase": 198.77
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.01,
+      "phase": 2.1
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.009,
+      "phase": 67.9
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 97.21
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.074,
+      "phase": 214.04
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.022,
+      "phase": 113.09
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.028,
+      "phase": 93.95
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.014,
+      "phase": 178.17
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.057,
+      "phase": 154.52
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 177.46
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.01,
+      "phase": 268.15
+    }
+  ],
+  "epoch": {
+    "start": "2023-10-22",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/mpcw.json
+++ b/data/ioc/mpcw.json
@@ -1,0 +1,289 @@
+{
+  "name": "Westhinder",
+  "region": "Flanders",
+  "country": "Belgium",
+  "continent": "Europe",
+  "latitude": 51.38861111,
+  "longitude": 2.437777778,
+  "timezone": "Etc/GMT",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=mpcw",
+    "id": "mpcw",
+    "published_harmonics": false,
+    "operator": "Maritieme Dienstverlening en Kust ( Belgium )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Maritieme Dienstverlening en Kust ( Belgium )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.196,
+    "MHHW": 4.246,
+    "MHW": 4.169,
+    "MSL": 2.397,
+    "MTL": 2.44,
+    "MLW": 0.71,
+    "MLLW": 0.572,
+    "LAT": -0.276,
+    "MHWS": 4.609,
+    "MLWS": 0.185
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.701,
+      "phase": 341.49
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.511,
+      "phase": 34.59
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.301,
+      "phase": 318.16
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.148,
+      "phase": 33.21
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.057,
+      "phase": 345.53
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.095,
+      "phase": 159.06
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.028,
+      "phase": 321.95
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.033,
+      "phase": 116.15
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.089,
+      "phase": 270.3
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.057,
+      "phase": 332.56
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.032,
+      "phase": 247.7
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.033,
+      "phase": 221.02
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.03,
+      "phase": 269.33
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.089,
+      "phase": 82.49
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.086,
+      "phase": 309.18
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.105,
+      "phase": 13.66
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.03,
+      "phase": 19.93
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 94.66
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.053,
+      "phase": 347.91
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.034,
+      "phase": 252.59
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.024,
+      "phase": 307.79
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.015,
+      "phase": 125.96
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 265.77
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 134.65
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 54.56
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 151.01
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 33.68
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 133.24
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 186.2
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 207.41
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 10.04
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.005,
+      "phase": 64.17
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 213.41
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.018,
+      "phase": 120.16
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.036,
+      "phase": 267.41
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.011,
+      "phase": 24.25
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.008,
+      "phase": 226.6
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.013,
+      "phase": 159.52
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 177.58
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.014,
+      "phase": 321.16
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 32.1
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.01,
+      "phase": 76.7
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.066,
+      "phase": 227.61
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.018,
+      "phase": 99.68
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.026,
+      "phase": 74.97
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.012,
+      "phase": 150.56
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.05,
+      "phase": 138.42
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 191.78
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.006,
+      "phase": 261.34
+    }
+  ],
+  "epoch": {
+    "start": "2023-10-22",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/mpsw.json
+++ b/data/ioc/mpsw.json
@@ -1,0 +1,289 @@
+{
+  "name": "Scheur Wielingen",
+  "region": "Flanders",
+  "country": "Belgium",
+  "continent": "Europe",
+  "latitude": 51.418333333333,
+  "longitude": 3.298611111,
+  "timezone": "Europe/Brussels",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=mpsw",
+    "id": "mpsw",
+    "published_harmonics": false,
+    "operator": "Maritieme Dienstverlening en Kust ( Belgium )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Maritieme Dienstverlening en Kust ( Belgium )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.055,
+    "MHHW": 4.239,
+    "MHW": 4.149,
+    "MSL": 2.369,
+    "MTL": 2.471,
+    "MLW": 0.793,
+    "MLLW": 0.634,
+    "LAT": -0.091,
+    "MHWS": 4.448,
+    "MLWS": 0.29
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.613,
+      "phase": 5.19
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.466,
+      "phase": 60.05
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.277,
+      "phase": 341.63
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.136,
+      "phase": 59.86
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.06,
+      "phase": 344.7
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.104,
+      "phase": 166.65
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.029,
+      "phase": 326.2
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.035,
+      "phase": 126.35
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.106,
+      "phase": 4.92
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.078,
+      "phase": 66.02
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.039,
+      "phase": 345.49
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.088,
+      "phase": 297.89
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.043,
+      "phase": 265.91
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.11,
+      "phase": 109.17
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.085,
+      "phase": 331.31
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.147,
+      "phase": 29.45
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.027,
+      "phase": 50.56
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 97.99
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.053,
+      "phase": 18.74
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.038,
+      "phase": 287.22
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.022,
+      "phase": 334.92
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.02,
+      "phase": 118.75
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.011,
+      "phase": 298.71
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 19.26
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 48.79
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 132.52
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.007,
+      "phase": 20.48
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 152.71
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 166.31
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 46.72
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 317.16
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.009,
+      "phase": 160.94
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 301.7
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.022,
+      "phase": 238.84
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.092,
+      "phase": 348.7
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.007,
+      "phase": 87.86
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.004,
+      "phase": 317.59
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.015,
+      "phase": 242.82
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.026,
+      "phase": 199.89
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.015,
+      "phase": 38.32
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 227.87
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.007,
+      "phase": 73.63
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.086,
+      "phase": 198.8
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.017,
+      "phase": 121.04
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.028,
+      "phase": 104.59
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.014,
+      "phase": 191.66
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.066,
+      "phase": 124.6
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 162.2
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.011,
+      "phase": 282.29
+    }
+  ],
+  "epoch": {
+    "start": "2023-10-22",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/mpww.json
+++ b/data/ioc/mpww.json
@@ -1,0 +1,289 @@
+{
+  "name": "Wandelaar",
+  "region": "Flanders",
+  "country": "Belgium",
+  "continent": "Europe",
+  "latitude": 51.39444444,
+  "longitude": 3.045833333,
+  "timezone": "Europe/Brussels",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=mpww",
+    "id": "mpww",
+    "published_harmonics": false,
+    "operator": "Maritieme Dienstverlening en Kust ( Belgium )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Maritieme Dienstverlening en Kust ( Belgium )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.039,
+    "MHHW": 4.21,
+    "MHW": 4.125,
+    "MSL": 2.369,
+    "MTL": 2.45,
+    "MLW": 0.776,
+    "MLLW": 0.618,
+    "LAT": -0.147,
+    "MHWS": 4.466,
+    "MLWS": 0.272
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.622,
+      "phase": 356.03
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.475,
+      "phase": 50.02
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.28,
+      "phase": 332.64
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.138,
+      "phase": 49.63
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.057,
+      "phase": 343.5
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.101,
+      "phase": 163.78
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.027,
+      "phase": 319.38
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.035,
+      "phase": 123.88
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.095,
+      "phase": 335.69
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.067,
+      "phase": 38.98
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.034,
+      "phase": 316.16
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.072,
+      "phase": 272.66
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.04,
+      "phase": 260.09
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.098,
+      "phase": 99.52
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.083,
+      "phase": 323.28
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.149,
+      "phase": 21.7
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.029,
+      "phase": 38.64
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 87.79
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.05,
+      "phase": 7.6
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.036,
+      "phase": 276.8
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.022,
+      "phase": 325.65
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.015,
+      "phase": 107.93
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.01,
+      "phase": 283.77
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 24.88
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.003,
+      "phase": 58.25
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 127.23
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.009,
+      "phase": 29.73
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 142.74
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 165.3
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 22.16
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 287.71
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.007,
+      "phase": 138.38
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 261.94
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.022,
+      "phase": 185.98
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.075,
+      "phase": 322.49
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.009,
+      "phase": 54.08
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.005,
+      "phase": 268.59
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 215.63
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.023,
+      "phase": 197.15
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.013,
+      "phase": 22.09
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 165.46
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 36.98
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.077,
+      "phase": 198.02
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.017,
+      "phase": 116
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.026,
+      "phase": 97.42
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.013,
+      "phase": 182.77
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.07,
+      "phase": 114.39
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 142.31
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.01,
+      "phase": 270.43
+    }
+  ],
+  "epoch": {
+    "start": "2024-06-21",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/mrms.json
+++ b/data/ioc/mrms.json
@@ -1,0 +1,289 @@
+{
+  "name": "Marmaris",
+  "region": "Mugla",
+  "country": "Turkiye",
+  "continent": "Asia",
+  "latitude": 36.837989807129,
+  "longitude": 28.384845733643,
+  "timezone": "Europe/Istanbul",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=mrms",
+    "id": "mrms",
+    "published_harmonics": false,
+    "operator": "General Directorate of Mapping ( Turkey )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (General Directorate of Mapping ( Turkey )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 2.03,
+    "MHHW": 0.323,
+    "MHW": 0.308,
+    "MSL": 0,
+    "MTL": 0.021,
+    "MLW": -0.266,
+    "MLLW": -0.325,
+    "LAT": -1.794,
+    "MHWS": 0.19,
+    "MLWS": -0.19
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.112,
+      "phase": 262.9
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.078,
+      "phase": 186.7
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.038,
+      "phase": 167.61
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.036,
+      "phase": 46.9
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.103,
+      "phase": 291.34
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.051,
+      "phase": 224.91
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.047,
+      "phase": 175.86
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.051,
+      "phase": 248.18
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.013,
+      "phase": 226.39
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.012,
+      "phase": 7.57
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.013,
+      "phase": 122.92
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.009,
+      "phase": 292.34
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.006,
+      "phase": 99.62
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.037,
+      "phase": 2.67
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.073,
+      "phase": 10.49
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.047,
+      "phase": 330.35
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.059,
+      "phase": 99.16
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.062,
+      "phase": 2.82
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.122,
+      "phase": 113.75
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.053,
+      "phase": 182.15
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.174,
+      "phase": 313.88
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.078,
+      "phase": 251.87
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.008,
+      "phase": 51.96
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.028,
+      "phase": 237.6
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 130.34
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.064,
+      "phase": 254.81
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.06,
+      "phase": 37.94
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.07,
+      "phase": 3.24
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.05,
+      "phase": 5.82
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.028,
+      "phase": 336.5
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.022,
+      "phase": 266.93
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.011,
+      "phase": 325.83
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.016,
+      "phase": 182.66
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.004,
+      "phase": 333.07
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.007,
+      "phase": 96.45
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.009,
+      "phase": 205.79
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 72.65
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.225,
+      "phase": 351.62
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.131,
+      "phase": 353.51
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.031,
+      "phase": 348.97
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.09,
+      "phase": 328.52
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.099,
+      "phase": 238.75
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.493,
+      "phase": 209.87
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.469,
+      "phase": 41.58
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.054,
+      "phase": 313.79
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.122,
+      "phase": 180.75
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.078,
+      "phase": 169.99
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.027,
+      "phase": 182.31
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.023,
+      "phase": 275.82
+    }
+  ],
+  "epoch": {
+    "start": "2020-07-22",
+    "end": "2026-08-24"
+  }
+}

--- a/data/ioc/ms001.json
+++ b/data/ioc/ms001.json
@@ -1,0 +1,289 @@
+{
+  "name": "Porto Malai, Langkawi",
+  "region": "Kedah",
+  "country": "Malaysia",
+  "continent": "Asia",
+  "latitude": 6.257092,
+  "longitude": 99.734422,
+  "timezone": "Asia/Kuala_Lumpur",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ms001",
+    "id": "ms001",
+    "published_harmonics": false,
+    "operator": "Malaysian Meteorological Department ( Malaysia)"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Malaysian Meteorological Department ( Malaysia)). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.024,
+    "MHHW": 3.355,
+    "MHW": 3.184,
+    "MSL": 2.411,
+    "MTL": 2.416,
+    "MLW": 1.649,
+    "MLLW": 1.549,
+    "LAT": 0.774,
+    "MHWS": 3.497,
+    "MLWS": 1.325
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.698,
+      "phase": 106.49
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.388,
+      "phase": 143.08
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.131,
+      "phase": 100.18
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.119,
+      "phase": 132.57
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.161,
+      "phase": 225.02
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.048,
+      "phase": 179.98
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.05,
+      "phase": 219.94
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.009,
+      "phase": 119.43
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.011,
+      "phase": 200.4
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.008,
+      "phase": 251.41
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.005,
+      "phase": 205.23
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 199.35
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 95.84
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.043,
+      "phase": 133.65
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.018,
+      "phase": 110.24
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.022,
+      "phase": 87.71
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.018,
+      "phase": 93.01
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.018,
+      "phase": 100.88
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.007,
+      "phase": 65.34
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.02,
+      "phase": 318.19
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.026,
+      "phase": 46.06
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.027,
+      "phase": 149.07
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.014,
+      "phase": 324.01
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 156.12
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 247.04
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.013,
+      "phase": 255.89
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 67.43
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 69.22
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.006,
+      "phase": 174.82
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 348.45
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 23.01
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 331.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 155.88
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 56.02
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 258.86
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 317.22
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 263
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.034,
+      "phase": 352.37
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.019,
+      "phase": 30.25
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.018,
+      "phase": 114.58
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.016,
+      "phase": 254.42
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.013,
+      "phase": 237.08
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.124,
+      "phase": 177.6
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.019,
+      "phase": 93.48
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.009,
+      "phase": 118.96
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.019,
+      "phase": 18.56
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 20.12
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 54.95
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 69.2
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/nanc.json
+++ b/data/ioc/nanc.json
@@ -1,0 +1,288 @@
+{
+  "name": "Nancowry",
+  "country": "India",
+  "continent": "Asia",
+  "latitude": 8.05,
+  "longitude": 93.55,
+  "timezone": "Asia/Kolkata",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=nanc",
+    "id": "nanc",
+    "published_harmonics": false,
+    "operator": "Indian National Centre for Ocean Information Services ( India )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Indian National Centre for Ocean Information Services ( India )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.883,
+    "MHHW": 1.455,
+    "MHW": 1.366,
+    "MSL": 0.836,
+    "MTL": 0.831,
+    "MLW": 0.297,
+    "MLLW": 0.264,
+    "LAT": -0.212,
+    "MHWS": 1.571,
+    "MLWS": 0.101
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.499,
+      "phase": 73.34
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.236,
+      "phase": 108.25
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.1,
+      "phase": 67.84
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.065,
+      "phase": 104.14
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.095,
+      "phase": 213.35
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.04,
+      "phase": 184.42
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.03,
+      "phase": 216.99
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.006,
+      "phase": 118.08
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.017,
+      "phase": 62.91
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.018,
+      "phase": 107.99
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.006,
+      "phase": 43.54
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 80.58
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.015,
+      "phase": 52.83
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 102.52
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.02,
+      "phase": 59.07
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.02,
+      "phase": 61.51
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.015,
+      "phase": 110.89
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 136.31
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.009,
+      "phase": 56.93
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.006,
+      "phase": 292.09
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 228.76
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 282.11
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 297.71
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 95.28
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 214.19
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 222.52
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 46.53
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 138.59
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 121.89
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 211.04
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 237.54
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.004,
+      "phase": 155.09
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 29.55
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 33.75
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 115.5
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 115.81
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 180.24
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 312.75
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 16.51
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 269.98
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 13.03
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 18.81
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.057,
+      "phase": 161.99
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.034,
+      "phase": 187.04
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 101.14
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 196.98
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 330.76
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 228.47
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 100.22
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-02",
+    "end": "2026-03-05"
+  }
+}

--- a/data/ioc/nhte.json
+++ b/data/ioc/nhte.json
@@ -1,0 +1,289 @@
+{
+  "name": "Nehuentue",
+  "region": "Araucania",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -38.749925,
+  "longitude": -73.408106,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=nhte",
+    "id": "nhte",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.582,
+    "MHHW": 2.156,
+    "MHW": 1.995,
+    "MSL": 1.679,
+    "MTL": 1.68,
+    "MLW": 1.365,
+    "MLLW": 1.33,
+    "LAT": 1.094,
+    "MHWS": 2.062,
+    "MLWS": 1.296
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.285,
+      "phase": 106.46
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.098,
+      "phase": 122.23
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.063,
+      "phase": 80.74
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.032,
+      "phase": 123.1
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.128,
+      "phase": 72
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.093,
+      "phase": 30.18
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.04,
+      "phase": 79.36
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.017,
+      "phase": 9.17
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.017,
+      "phase": 152.76
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.01,
+      "phase": 175.22
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 133.02
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 319.57
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 48
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 6.62
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.013,
+      "phase": 78.04
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 95.19
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.012,
+      "phase": 145.16
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 103.9
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 87.16
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 309.99
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.021,
+      "phase": 212.17
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 101.46
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 243.67
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 1.14
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 142.71
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 171.72
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 355.66
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 358.22
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 141.81
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 266.52
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 320.5
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 201.02
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 94.7
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 47.31
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.005,
+      "phase": 324.11
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 290.91
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 276.39
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 43.95
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.004,
+      "phase": 181.31
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.021,
+      "phase": 24.14
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.009,
+      "phase": 97.75
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 216.92
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.13,
+      "phase": 96.44
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.045,
+      "phase": 238.11
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 252.46
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.006,
+      "phase": 162.84
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 337.21
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 70.83
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 118.84
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/nksk.json
+++ b/data/ioc/nksk.json
@@ -1,0 +1,289 @@
+{
+  "name": "Nikol'skoe",
+  "region": "Kamchatka",
+  "country": "Russia",
+  "continent": "Asia",
+  "latitude": 55.2,
+  "longitude": 166.02,
+  "timezone": "Asia/Kamchatka",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=nksk",
+    "id": "nksk",
+    "published_harmonics": false,
+    "operator": "Federal Service of Russia for Hydrometeorology and Environmental Monitoring ( Russia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Federal Service of Russia for Hydrometeorology and Environmental Monitoring ( Russia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 1.375,
+    "MHHW": 0.331,
+    "MHW": 0.34,
+    "MSL": 0,
+    "MTL": 0.034,
+    "MLW": -0.272,
+    "MLLW": -0.272,
+    "LAT": -1.904,
+    "MHWS": 0.295,
+    "MLWS": -0.295
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.22,
+      "phase": 124.22
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.075,
+      "phase": 208.23
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.045,
+      "phase": 111.73
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.01,
+      "phase": 138.27
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.356,
+      "phase": 356.41
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.251,
+      "phase": 327.93
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.102,
+      "phase": 330.13
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.087,
+      "phase": 3.78
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.007,
+      "phase": 143.77
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 337.67
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 263.46
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 52.02
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.006,
+      "phase": 354.22
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 355.34
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 272.47
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.04,
+      "phase": 212.1
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.011,
+      "phase": 35.52
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.027,
+      "phase": 286.61
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.042,
+      "phase": 173.66
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.012,
+      "phase": 212.99
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.03,
+      "phase": 45.72
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.015,
+      "phase": 161.53
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.021,
+      "phase": 9.37
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.023,
+      "phase": 279.1
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.02,
+      "phase": 275.9
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 266.57
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.022,
+      "phase": 239.97
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.03,
+      "phase": 352.77
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.026,
+      "phase": 172.16
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 290.34
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 176.18
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.004,
+      "phase": 175.68
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.008,
+      "phase": 52.17
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.004,
+      "phase": 117.26
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.005,
+      "phase": 195.9
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.01,
+      "phase": 76.87
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.006,
+      "phase": 232.64
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.14,
+      "phase": 107.06
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.167,
+      "phase": 194.31
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.331,
+      "phase": 21.94
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.158,
+      "phase": 91.29
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.192,
+      "phase": 37.45
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.038,
+      "phase": 239.68
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.21,
+      "phase": 342.5
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.021,
+      "phase": 201.82
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.017,
+      "phase": 326
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.017,
+      "phase": 231.97
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 47.13
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.007,
+      "phase": 114.71
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-08",
+    "end": "2026-07-14"
+  }
+}

--- a/data/ioc/ntue.json
+++ b/data/ioc/ntue.json
@@ -1,0 +1,289 @@
+{
+  "name": "Nehuentue",
+  "region": "Araucania",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -38.749925,
+  "longitude": -73.408106,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ntue",
+    "id": "ntue",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.582,
+    "MHHW": 2.156,
+    "MHW": 1.995,
+    "MSL": 1.679,
+    "MTL": 1.68,
+    "MLW": 1.365,
+    "MLLW": 1.33,
+    "LAT": 1.094,
+    "MHWS": 2.062,
+    "MLWS": 1.296
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.285,
+      "phase": 106.46
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.098,
+      "phase": 122.23
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.063,
+      "phase": 80.74
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.032,
+      "phase": 123.1
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.128,
+      "phase": 72
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.093,
+      "phase": 30.18
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.04,
+      "phase": 79.36
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.017,
+      "phase": 9.17
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.017,
+      "phase": 152.76
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.01,
+      "phase": 175.22
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 133.02
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 319.57
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 48
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 6.62
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.013,
+      "phase": 78.04
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 95.19
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.012,
+      "phase": 145.16
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 103.9
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 87.16
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 309.99
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.021,
+      "phase": 212.17
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 101.46
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 243.67
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 1.14
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 142.71
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 171.72
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 355.66
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 358.22
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 141.81
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 266.52
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 320.5
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 201.02
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 94.7
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 47.31
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.005,
+      "phase": 324.11
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 290.91
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 276.39
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 43.95
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.004,
+      "phase": 181.31
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.021,
+      "phase": 24.14
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.009,
+      "phase": 97.75
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 216.92
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.13,
+      "phase": 96.44
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.045,
+      "phase": 238.11
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 252.46
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.006,
+      "phase": 162.84
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 337.21
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 70.83
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 118.84
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ntue2.json
+++ b/data/ioc/ntue2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Nehuentue",
+  "region": "Araucania",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -38.749925,
+  "longitude": -73.408106,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ntue2",
+    "id": "ntue2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.582,
+    "MHHW": 2.156,
+    "MHW": 1.995,
+    "MSL": 1.679,
+    "MTL": 1.68,
+    "MLW": 1.365,
+    "MLLW": 1.33,
+    "LAT": 1.094,
+    "MHWS": 2.062,
+    "MLWS": 1.296
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.285,
+      "phase": 106.46
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.098,
+      "phase": 122.23
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.063,
+      "phase": 80.74
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.032,
+      "phase": 123.1
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.128,
+      "phase": 72
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.093,
+      "phase": 30.18
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.04,
+      "phase": 79.36
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.017,
+      "phase": 9.17
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.017,
+      "phase": 152.76
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.01,
+      "phase": 175.22
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 133.02
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 319.57
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 48
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 6.62
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.013,
+      "phase": 78.04
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 95.19
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.012,
+      "phase": 145.16
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 103.9
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 87.16
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 309.99
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.021,
+      "phase": 212.17
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 101.46
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 243.67
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 1.14
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 142.71
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 171.72
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 355.66
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 358.22
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 141.81
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 266.52
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 320.5
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 201.02
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 94.7
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 47.31
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.005,
+      "phase": 324.11
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 290.91
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 276.39
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 43.95
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.004,
+      "phase": 181.31
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.021,
+      "phase": 24.14
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.009,
+      "phase": 97.75
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 216.92
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.13,
+      "phase": 96.44
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.045,
+      "phase": 238.11
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 252.46
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.006,
+      "phase": 162.84
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 337.21
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 70.83
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 118.84
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ohig3.json
+++ b/data/ioc/ohig3.json
@@ -1,0 +1,288 @@
+{
+  "name": "Base General Bernardo O'Higgins CL",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -63.320314,
+  "longitude": -57.898731,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ohig3",
+    "id": "ohig3",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.193,
+    "MHHW": 2.667,
+    "MHW": 2.599,
+    "MSL": 1.976,
+    "MTL": 1.993,
+    "MLW": 1.388,
+    "MLLW": 0.955,
+    "LAT": 0.233,
+    "MHWS": 2.757,
+    "MLWS": 1.195
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.482,
+      "phase": 273.09
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.299,
+      "phase": 322.65
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.06,
+      "phase": 251.03
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.087,
+      "phase": 322.43
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.337,
+      "phase": 53.89
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.367,
+      "phase": 40.57
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.108,
+      "phase": 52.51
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.087,
+      "phase": 29.76
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 34.28
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 131.37
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 270.88
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 346.73
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.002,
+      "phase": 252.56
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 241.2
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.013,
+      "phase": 255.64
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.019,
+      "phase": 284.65
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.018,
+      "phase": 319.67
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 320.05
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 285.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 200.01
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 36.56
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 23.25
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 50.59
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 15.92
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.011,
+      "phase": 48.66
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 47.9
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.013,
+      "phase": 15
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.016,
+      "phase": 30.39
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.012,
+      "phase": 24.15
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 154.28
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 157.94
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 189.33
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 161.68
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 15.02
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 291.4
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 93.71
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 355.81
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 134.29
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.026,
+      "phase": 221.41
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.012,
+      "phase": 348.58
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 246.45
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 292.7
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.041,
+      "phase": 249.28
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.021,
+      "phase": 82.15
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 57.8
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 40.32
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 234.46
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 241.28
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 337.97
+    }
+  ],
+  "epoch": {
+    "start": "2020-04-14",
+    "end": "2026-09-03"
+  }
+}

--- a/data/ioc/pagi.json
+++ b/data/ioc/pagi.json
@@ -1,0 +1,288 @@
+{
+  "name": "Puerto Aguirre",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -45.164573,
+  "longitude": -73.521111,
+  "timezone": "America/Coyhaique",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pagi",
+    "id": "pagi",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.965,
+    "MHHW": 7.268,
+    "MHW": 7.05,
+    "MSL": 6.277,
+    "MTL": 6.272,
+    "MLW": 5.494,
+    "MLLW": 5.449,
+    "LAT": 4.784,
+    "MHWS": 7.318,
+    "MLWS": 5.236
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.762,
+      "phase": 136.22
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.279,
+      "phase": 150
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.193,
+      "phase": 110.17
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.086,
+      "phase": 145.27
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.195,
+      "phase": 64.78
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.136,
+      "phase": 21.48
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.06,
+      "phase": 60.18
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.027,
+      "phase": 356.25
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.013,
+      "phase": 33.83
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.012,
+      "phase": 45.02
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 357.41
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 288.36
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.027,
+      "phase": 77.11
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 111.93
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.038,
+      "phase": 111.51
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.023,
+      "phase": 120.57
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.013,
+      "phase": 138.01
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 157.67
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.015,
+      "phase": 94.76
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.01,
+      "phase": 337.98
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.01,
+      "phase": 334.17
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 227.51
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 64.66
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 31.08
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 102.62
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 151.81
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 309.35
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 0.1
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 1.46
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 272.08
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 350.96
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 137.11
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 321.25
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 139.33
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.006,
+      "phase": 303.65
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 345.95
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 337.78
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.005,
+      "phase": 229.72
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 170.37
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 226.15
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 33.07
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 160.76
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.068,
+      "phase": 85.64
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.017,
+      "phase": 180.73
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 101.52
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 258.95
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.012,
+      "phase": 5.86
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 145.57
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 257.05
+    }
+  ],
+  "epoch": {
+    "start": "2021-05-12",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pagi2.json
+++ b/data/ioc/pagi2.json
@@ -1,0 +1,288 @@
+{
+  "name": "Puerto Aguire",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -45.164573,
+  "longitude": -73.521111,
+  "timezone": "America/Coyhaique",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pagi2",
+    "id": "pagi2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.965,
+    "MHHW": 7.268,
+    "MHW": 7.05,
+    "MSL": 6.277,
+    "MTL": 6.272,
+    "MLW": 5.494,
+    "MLLW": 5.449,
+    "LAT": 4.784,
+    "MHWS": 7.318,
+    "MLWS": 5.236
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.762,
+      "phase": 136.22
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.279,
+      "phase": 150
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.193,
+      "phase": 110.17
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.086,
+      "phase": 145.27
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.195,
+      "phase": 64.78
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.136,
+      "phase": 21.48
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.06,
+      "phase": 60.18
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.027,
+      "phase": 356.25
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.013,
+      "phase": 33.83
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.012,
+      "phase": 45.02
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 357.41
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 288.36
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.027,
+      "phase": 77.11
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 111.93
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.038,
+      "phase": 111.51
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.023,
+      "phase": 120.57
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.013,
+      "phase": 138.01
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 157.67
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.015,
+      "phase": 94.76
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.01,
+      "phase": 337.98
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.01,
+      "phase": 334.17
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 227.51
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 64.66
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 31.08
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 102.62
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 151.81
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 309.35
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 0.1
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 1.46
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 272.08
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 350.96
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 137.11
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 321.25
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 139.33
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.006,
+      "phase": 303.65
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 345.95
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 337.78
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.005,
+      "phase": 229.72
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 170.37
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 226.15
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 33.07
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 160.76
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.068,
+      "phase": 85.64
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.017,
+      "phase": 180.73
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 101.52
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 258.95
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.012,
+      "phase": 5.86
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 145.57
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 257.05
+    }
+  ],
+  "epoch": {
+    "start": "2021-05-12",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pait2.json
+++ b/data/ioc/pait2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Paita,Piura",
+  "region": "Piura",
+  "country": "Peru",
+  "continent": "Americas",
+  "latitude": -5.0836,
+  "longitude": -81.1077,
+  "timezone": "America/Lima",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pait2",
+    "id": "pait2",
+    "published_harmonics": false,
+    "operator": "Dirección de Hidrografía y Navegación (Perú)"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dirección de Hidrografía y Navegación (Perú)). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.666,
+    "MHHW": 2.118,
+    "MHW": 2.121,
+    "MSL": 1.443,
+    "MTL": 1.452,
+    "MLW": 0.782,
+    "MLLW": 0.694,
+    "LAT": 0.189,
+    "MHWS": 2.146,
+    "MLWS": 0.74
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.536,
+      "phase": 246.62
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.167,
+      "phase": 283.86
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.12,
+      "phase": 216.26
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.048,
+      "phase": 279.69
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.121,
+      "phase": 27.35
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.041,
+      "phase": 342.97
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.034,
+      "phase": 23.93
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.005,
+      "phase": 2.38
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 139.98
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 153.64
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 25.8
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 152.85
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.019,
+      "phase": 201.05
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 182
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 241.69
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 301.32
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 273.76
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 296.67
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 215.5
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 321.9
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 253.74
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 75.65
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.009,
+      "phase": 132.96
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 52.14
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 64.84
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 76.19
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 221.16
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 225.86
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 15.27
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 56.74
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 93.94
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 43.43
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 192.97
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 0.45
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 98.26
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 73.71
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 354.22
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.037,
+      "phase": 15.06
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.033,
+      "phase": 163.62
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.016,
+      "phase": 14.19
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 347.59
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.05,
+      "phase": 54.98
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.137,
+      "phase": 58.38
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.101,
+      "phase": 300.93
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.008,
+      "phase": 216.95
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 354.48
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 213.04
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 217.34
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 341.39
+    }
+  ],
+  "epoch": {
+    "start": "2022-09-30",
+    "end": "2026-09-03"
+  }
+}

--- a/data/ioc/paita.json
+++ b/data/ioc/paita.json
@@ -1,0 +1,289 @@
+{
+  "name": "Paita,Piura",
+  "region": "Piura",
+  "country": "Peru",
+  "continent": "Americas",
+  "latitude": -5.08366,
+  "longitude": -81.1077,
+  "timezone": "America/Lima",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=paita",
+    "id": "paita",
+    "published_harmonics": false,
+    "operator": "Dirección de Hidrografía y Navegación (Perú)"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dirección de Hidrografía y Navegación (Perú)). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.666,
+    "MHHW": 2.118,
+    "MHW": 2.121,
+    "MSL": 1.443,
+    "MTL": 1.452,
+    "MLW": 0.782,
+    "MLLW": 0.694,
+    "LAT": 0.189,
+    "MHWS": 2.146,
+    "MLWS": 0.74
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.536,
+      "phase": 246.62
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.167,
+      "phase": 283.86
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.12,
+      "phase": 216.26
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.048,
+      "phase": 279.69
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.121,
+      "phase": 27.35
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.041,
+      "phase": 342.97
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.034,
+      "phase": 23.93
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.005,
+      "phase": 2.38
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 139.98
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 153.64
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 25.8
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 152.85
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.019,
+      "phase": 201.05
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 182
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 241.69
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 301.32
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 273.76
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 296.67
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 215.5
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 321.9
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 253.74
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 75.65
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.009,
+      "phase": 132.96
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 52.14
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 64.84
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 76.19
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 221.16
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 225.86
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 15.27
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 56.74
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 93.94
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 43.43
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 192.97
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 0.45
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 98.26
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 73.71
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 354.22
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.037,
+      "phase": 15.06
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.033,
+      "phase": 163.62
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.016,
+      "phase": 14.19
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 347.59
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.05,
+      "phase": 54.98
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.137,
+      "phase": 58.38
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.101,
+      "phase": 300.93
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.008,
+      "phase": 216.95
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 354.48
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 213.04
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 217.34
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 341.39
+    }
+  ],
+  "epoch": {
+    "start": "2022-09-30",
+    "end": "2026-09-03"
+  }
+}

--- a/data/ioc/papo.json
+++ b/data/ioc/papo.json
@@ -1,0 +1,289 @@
+{
+  "name": "Paposo",
+  "region": "Antofagasta",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -25.008982,
+  "longitude": -70.468728,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=papo",
+    "id": "papo",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.749,
+    "MHHW": 4.392,
+    "MHW": 4.218,
+    "MSL": 3.842,
+    "MTL": 3.841,
+    "MLW": 3.463,
+    "MLLW": 3.44,
+    "LAT": 3.135,
+    "MHWS": 4.334,
+    "MLWS": 3.35
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.374,
+      "phase": 24.86
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.118,
+      "phase": 47.37
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.082,
+      "phase": 349.49
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.037,
+      "phase": 38.5
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.153,
+      "phase": 27.17
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.09,
+      "phase": 343.2
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.047,
+      "phase": 22.48
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.017,
+      "phase": 316.54
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 319.52
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 64.66
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 254.35
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 206.2
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 315.9
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 331.72
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 350.81
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 21.76
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 48.84
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 72.01
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 348.98
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 273.77
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 184.35
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 162.03
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 169.84
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 322.51
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 62.92
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 105.96
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 284.24
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 319.97
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 303.91
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 42.05
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 184.37
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 313.3
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 248.85
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 74.24
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 320.2
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 179.15
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 95.42
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 14.11
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 73.69
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 30.53
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 107.3
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 148.09
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.039,
+      "phase": 18.59
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.016,
+      "phase": 207.68
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 295.73
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 47.01
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 222.79
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 175.15
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 245.85
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/papo2.json
+++ b/data/ioc/papo2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Paposo",
+  "region": "Antofagasta",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -25.008982,
+  "longitude": -70.468728,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=papo2",
+    "id": "papo2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.749,
+    "MHHW": 4.392,
+    "MHW": 4.218,
+    "MSL": 3.842,
+    "MTL": 3.841,
+    "MLW": 3.463,
+    "MLLW": 3.44,
+    "LAT": 3.135,
+    "MHWS": 4.334,
+    "MLWS": 3.35
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.374,
+      "phase": 24.86
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.118,
+      "phase": 47.37
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.082,
+      "phase": 349.49
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.037,
+      "phase": 38.5
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.153,
+      "phase": 27.17
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.09,
+      "phase": 343.2
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.047,
+      "phase": 22.48
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.017,
+      "phase": 316.54
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 319.52
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 64.66
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 254.35
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 206.2
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 315.9
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 331.72
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 350.81
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 21.76
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 48.84
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 72.01
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 348.98
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 273.77
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 184.35
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 162.03
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 169.84
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 322.51
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 62.92
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 105.96
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 284.24
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 319.97
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 303.91
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 42.05
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 184.37
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 313.3
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 248.85
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 74.24
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 320.2
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 179.15
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 95.42
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 14.11
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 73.69
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 30.53
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 107.3
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 148.09
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.039,
+      "phase": 18.59
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.016,
+      "phase": 207.68
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 295.73
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 47.01
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 222.79
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 175.15
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 245.85
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pass.json
+++ b/data/ioc/pass.json
@@ -1,0 +1,289 @@
+{
+  "name": "Bungus, Padang, West Sumatra",
+  "region": "West Sumatra",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -1.030151,
+  "longitude": 100.395641,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pass",
+    "id": "pass",
+    "published_harmonics": false,
+    "operator": "Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Kepala Badan Meteorologi, Klimatologi, dan Geofisika ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.393,
+    "MHHW": 1.764,
+    "MHW": 1.724,
+    "MSL": 1.388,
+    "MTL": 1.365,
+    "MLW": 1.006,
+    "MLLW": 0.96,
+    "LAT": 0.676,
+    "MHWS": 1.896,
+    "MLWS": 0.88
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.355,
+      "phase": 322.17
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.153,
+      "phase": 2.76
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.076,
+      "phase": 306.09
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.042,
+      "phase": 359.72
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.125,
+      "phase": 170.43
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.078,
+      "phase": 162.9
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.04,
+      "phase": 174.12
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 143.51
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.016,
+      "phase": 4.21
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.007,
+      "phase": 116.47
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.008,
+      "phase": 308.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 34.44
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 263.79
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.015,
+      "phase": 312.57
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 309.77
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.003,
+      "phase": 36.85
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 15.67
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 63.54
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 314
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 129.51
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 49.79
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 160.7
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.009,
+      "phase": 59.75
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 223.18
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 165.28
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 199.82
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 101.1
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 161.46
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 124.58
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 136.93
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 233.77
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.004,
+      "phase": 342.78
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 221.18
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 239.16
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 125.26
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 349.2
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 206.24
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 42.99
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 348.16
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 38.94
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.011,
+      "phase": 7.5
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 101.08
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.056,
+      "phase": 212.22
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.063,
+      "phase": 109.87
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 282.05
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 7.81
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.011,
+      "phase": 203.02
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.005,
+      "phase": 254.21
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 8.5
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-12",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pata.json
+++ b/data/ioc/pata.json
@@ -1,0 +1,289 @@
+{
+  "name": "Patache",
+  "region": "Tarapaca",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -20.803213,
+  "longitude": -70.198029,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pata",
+    "id": "pata",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.677,
+    "MHHW": 4.321,
+    "MHW": 4.151,
+    "MSL": 3.804,
+    "MTL": 3.8,
+    "MLW": 3.449,
+    "MLLW": 3.423,
+    "LAT": 3.162,
+    "MHWS": 4.254,
+    "MLWS": 3.354
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.347,
+      "phase": 16.38
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.103,
+      "phase": 38.32
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.077,
+      "phase": 338.65
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.033,
+      "phase": 29.24
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.151,
+      "phase": 25.97
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.086,
+      "phase": 342.23
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.046,
+      "phase": 22.46
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 316.4
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 307.79
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 65.33
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 244.64
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 176.53
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 302.15
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.018,
+      "phase": 323.91
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 339.11
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 14.81
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 39.93
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 55.69
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 336.16
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 266.82
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 193.69
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 122.29
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 88.43
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 319.07
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 60.46
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 102.46
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 269.07
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 317.43
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 306.48
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 39.71
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 169.05
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 316.69
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 270.19
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 162.33
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 304.86
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 215.05
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 135.07
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.005,
+      "phase": 0.94
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 45.46
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 8.75
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 106.64
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 241.43
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.044,
+      "phase": 29.13
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.014,
+      "phase": 193.61
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 285.23
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 51.25
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 218.08
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 194.42
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 264.54
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pata2.json
+++ b/data/ioc/pata2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Patache",
+  "region": "Tarapaca",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -20.803213,
+  "longitude": -70.198029,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pata2",
+    "id": "pata2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.677,
+    "MHHW": 4.321,
+    "MHW": 4.151,
+    "MSL": 3.804,
+    "MTL": 3.8,
+    "MLW": 3.449,
+    "MLLW": 3.423,
+    "LAT": 3.162,
+    "MHWS": 4.254,
+    "MLWS": 3.354
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.347,
+      "phase": 16.38
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.103,
+      "phase": 38.32
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.077,
+      "phase": 338.65
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.033,
+      "phase": 29.24
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.151,
+      "phase": 25.97
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.086,
+      "phase": 342.23
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.046,
+      "phase": 22.46
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 316.4
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 307.79
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 65.33
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 244.64
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 176.53
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 302.15
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.018,
+      "phase": 323.91
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 339.11
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 14.81
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 39.93
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 55.69
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 336.16
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 266.82
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 193.69
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 122.29
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 88.43
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 319.07
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 60.46
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 102.46
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 269.07
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 317.43
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 306.48
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 39.71
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 169.05
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 316.69
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 270.19
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 162.33
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 304.86
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 215.05
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 135.07
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.005,
+      "phase": 0.94
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 45.46
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 8.75
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 106.64
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 241.43
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.044,
+      "phase": 29.13
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.014,
+      "phase": 193.61
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 285.23
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 51.25
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 218.08
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 194.42
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 264.54
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/patu.json
+++ b/data/ioc/patu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Puerto Atún - Manta",
+  "region": "Manabi",
+  "country": "Ecuador",
+  "continent": "Americas",
+  "latitude": -0.92574,
+  "longitude": -80.6658,
+  "timezone": "America/Guayaquil",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=patu",
+    "id": "patu",
+    "published_harmonics": false,
+    "operator": "Instituto Oceanográfico y Antártico de la Armada ( Ecuador )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Instituto Oceanográfico y Antártico de la Armada ( Ecuador )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.96,
+    "MHHW": 2.65,
+    "MHW": 2.58,
+    "MSL": 1.695,
+    "MTL": 1.7,
+    "MLW": 0.819,
+    "MLLW": 0.785,
+    "LAT": -0.375,
+    "MHWS": 2.86,
+    "MLWS": 0.53
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.913,
+      "phase": 234
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.252,
+      "phase": 282.69
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.199,
+      "phase": 205.78
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.074,
+      "phase": 278.41
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.091,
+      "phase": 41.56
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.022,
+      "phase": 13.5
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.033,
+      "phase": 36.35
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.002,
+      "phase": 24.08
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 98.4
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 57.75
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 58.55
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 256.45
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.028,
+      "phase": 176.3
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.028,
+      "phase": 184.77
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.039,
+      "phase": 204.32
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.017,
+      "phase": 230.62
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.015,
+      "phase": 330.58
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 74.5
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 268.44
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 264.48
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 155.8
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 46.54
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 239.25
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 39.82
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 44.62
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 70.66
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 317.5
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 193.26
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 81.83
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 139.86
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.012,
+      "phase": 254
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.008,
+      "phase": 313.25
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 201.83
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 146.04
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 29.07
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 311.66
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 76.48
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.038,
+      "phase": 336.96
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.022,
+      "phase": 303.32
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.01,
+      "phase": 218.09
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.036,
+      "phase": 18.92
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.023,
+      "phase": 282.18
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.586,
+      "phase": 153.06
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.053,
+      "phase": 291.4
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.01,
+      "phase": 181.11
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 318.15
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.01,
+      "phase": 179.98
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.009,
+      "phase": 41.84
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.01,
+      "phase": 4.05
+    }
+  ],
+  "epoch": {
+    "start": "2024-10-02",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pcha.json
+++ b/data/ioc/pcha.json
@@ -1,0 +1,289 @@
+{
+  "name": "Puerto_Chacabuco",
+  "region": "Aysen",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -45.467076,
+  "longitude": -72.820045,
+  "timezone": "America/Coyhaique",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pcha",
+    "id": "pcha",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.883,
+    "MHHW": 7.222,
+    "MHW": 7.006,
+    "MSL": 6.206,
+    "MTL": 6.187,
+    "MLW": 5.369,
+    "MLLW": 5.257,
+    "LAT": 4.655,
+    "MHWS": 7.275,
+    "MLWS": 5.137
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.785,
+      "phase": 144.21
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.284,
+      "phase": 157.23
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.197,
+      "phase": 117.98
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.087,
+      "phase": 152.53
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.198,
+      "phase": 68.75
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.136,
+      "phase": 25.38
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.062,
+      "phase": 63.43
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.027,
+      "phase": 359.11
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.016,
+      "phase": 67.44
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.013,
+      "phase": 78.51
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.008,
+      "phase": 31.82
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 3.12
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.026,
+      "phase": 84.15
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.018,
+      "phase": 118.52
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.039,
+      "phase": 119.31
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.027,
+      "phase": 127.58
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.012,
+      "phase": 145.19
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 169.77
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.016,
+      "phase": 104.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.01,
+      "phase": 348.49
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.013,
+      "phase": 337.15
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 206.91
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 105.33
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 357.48
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 105.45
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 157.79
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 331.73
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 11.13
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 15.91
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 296.21
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 18.84
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 167.24
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 0.3
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 357.82
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 27.68
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 14.04
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 350.99
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 165.48
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.016,
+      "phase": 165.12
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 246.25
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.01,
+      "phase": 80.79
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 179.72
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.028,
+      "phase": 74.56
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.027,
+      "phase": 161.06
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 111.41
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 266.53
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.014,
+      "phase": 21.41
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 170.62
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 283.49
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pcha2.json
+++ b/data/ioc/pcha2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Puerto_Chacabuco",
+  "region": "Aysen",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -45.467076,
+  "longitude": -72.820045,
+  "timezone": "America/Coyhaique",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pcha2",
+    "id": "pcha2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.883,
+    "MHHW": 7.222,
+    "MHW": 7.006,
+    "MSL": 6.206,
+    "MTL": 6.187,
+    "MLW": 5.369,
+    "MLLW": 5.257,
+    "LAT": 4.655,
+    "MHWS": 7.275,
+    "MLWS": 5.137
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.785,
+      "phase": 144.21
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.284,
+      "phase": 157.23
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.197,
+      "phase": 117.98
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.087,
+      "phase": 152.53
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.198,
+      "phase": 68.75
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.136,
+      "phase": 25.38
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.062,
+      "phase": 63.43
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.027,
+      "phase": 359.11
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.016,
+      "phase": 67.44
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.013,
+      "phase": 78.51
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.008,
+      "phase": 31.82
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 3.12
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.026,
+      "phase": 84.15
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.018,
+      "phase": 118.52
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.039,
+      "phase": 119.31
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.027,
+      "phase": 127.58
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.012,
+      "phase": 145.19
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 169.77
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.016,
+      "phase": 104.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.01,
+      "phase": 348.49
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.013,
+      "phase": 337.15
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 206.91
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 105.33
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 357.48
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 105.45
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 157.79
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 331.73
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 11.13
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 15.91
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 296.21
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 18.84
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 167.24
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 0.3
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 357.82
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 27.68
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 14.04
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 350.99
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 165.48
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.016,
+      "phase": 165.12
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 246.25
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.01,
+      "phase": 80.79
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 179.72
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.028,
+      "phase": 74.56
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.027,
+      "phase": 161.06
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 111.41
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 266.53
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.014,
+      "phase": 21.41
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 170.62
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 283.49
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pedn.json
+++ b/data/ioc/pedn.json
@@ -1,0 +1,288 @@
+{
+  "name": "Puerto Eden",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -49.129786,
+  "longitude": -74.408639,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pedn",
+    "id": "pedn",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.112,
+    "MHHW": 5.55,
+    "MHW": 5.322,
+    "MSL": 4.81,
+    "MTL": 4.803,
+    "MLW": 4.283,
+    "MLLW": 4.184,
+    "LAT": 3.757,
+    "MHWS": 5.479,
+    "MLWS": 4.141
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.492,
+      "phase": 144.57
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.177,
+      "phase": 124.61
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.146,
+      "phase": 116.29
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.056,
+      "phase": 122.26
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.199,
+      "phase": 75.68
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.142,
+      "phase": 33.58
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.061,
+      "phase": 70.96
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.028,
+      "phase": 9.47
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.008,
+      "phase": 181.64
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 289.75
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 133.2
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 118.07
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.021,
+      "phase": 83.26
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.027,
+      "phase": 93.09
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.026,
+      "phase": 121
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 119.38
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.01,
+      "phase": 100.33
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 127.15
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 123.68
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 45.38
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 354.44
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 337.51
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 62.2
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 10.37
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 106.99
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 169.11
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 335.05
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 21.11
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 356.73
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 309.21
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 94.31
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 180.53
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 76.33
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 178.4
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.005,
+      "phase": 190.94
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 300.8
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 239.05
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.014,
+      "phase": 200.17
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.021,
+      "phase": 155.19
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 276.98
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 73.65
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 160.53
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.06,
+      "phase": 35.98
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.014,
+      "phase": 171.99
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 64.58
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 161.02
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.012,
+      "phase": 16.35
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 209.06
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 321.08
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pedn2.json
+++ b/data/ioc/pedn2.json
@@ -1,0 +1,288 @@
+{
+  "name": "Puerto Eden",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -49.129786,
+  "longitude": -74.408639,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pedn2",
+    "id": "pedn2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.112,
+    "MHHW": 5.55,
+    "MHW": 5.322,
+    "MSL": 4.81,
+    "MTL": 4.803,
+    "MLW": 4.283,
+    "MLLW": 4.184,
+    "LAT": 3.757,
+    "MHWS": 5.479,
+    "MLWS": 4.141
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.492,
+      "phase": 144.57
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.177,
+      "phase": 124.61
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.146,
+      "phase": 116.29
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.056,
+      "phase": 122.26
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.199,
+      "phase": 75.68
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.142,
+      "phase": 33.58
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.061,
+      "phase": 70.96
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.028,
+      "phase": 9.47
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.008,
+      "phase": 181.64
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 289.75
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 133.2
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 118.07
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.021,
+      "phase": 83.26
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.027,
+      "phase": 93.09
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.026,
+      "phase": 121
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 119.38
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.01,
+      "phase": 100.33
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 127.15
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 123.68
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 45.38
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 354.44
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 337.51
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 62.2
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 10.37
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 106.99
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 169.11
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 335.05
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 21.11
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 356.73
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 309.21
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 94.31
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 180.53
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 76.33
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 178.4
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.005,
+      "phase": 190.94
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 300.8
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 239.05
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.014,
+      "phase": 200.17
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.021,
+      "phase": 155.19
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 276.98
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 73.65
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 160.53
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.06,
+      "phase": 35.98
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.014,
+      "phase": 171.99
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 64.58
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 161.02
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.012,
+      "phase": 16.35
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 209.06
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 321.08
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/peir.json
+++ b/data/ioc/peir.json
@@ -1,0 +1,289 @@
+{
+  "name": "Peiraias",
+  "region": "Attica",
+  "country": "Greece",
+  "continent": "Europe",
+  "latitude": 37.934733,
+  "longitude": 23.621217,
+  "timezone": "Europe/Athens",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=peir",
+    "id": "peir",
+    "published_harmonics": false,
+    "operator": "Hellenic Navy Hydrographic Service ( Greece )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Hellenic Navy Hydrographic Service ( Greece )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.802,
+    "MHHW": 0.686,
+    "MHW": 0.663,
+    "MSL": 0.654,
+    "MTL": 0.65,
+    "MLW": 0.638,
+    "MLLW": 0.622,
+    "LAT": 0.484,
+    "MHWS": 0.675,
+    "MLWS": 0.633
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.014,
+      "phase": 16.85
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.007,
+      "phase": 13.08
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.003,
+      "phase": 18.07
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.002,
+      "phase": 8.83
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.015,
+      "phase": 341.06
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.007,
+      "phase": 310.12
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.006,
+      "phase": 348.9
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0,
+      "phase": 85.5
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 104.76
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 134.32
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 57.91
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 145.56
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.001,
+      "phase": 45.52
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0,
+      "phase": 3.93
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.001,
+      "phase": 4.52
+    },
+    {
+      "name": "L2",
+      "amplitude": 0,
+      "phase": 332.35
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 120.57
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 52.76
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0,
+      "phase": 49.69
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 115.48
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 211.54
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 156.38
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 346.74
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 229.32
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.001,
+      "phase": 325.77
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 351.35
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 3.4
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0,
+      "phase": 215.69
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0,
+      "phase": 157.25
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 271.73
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 157.66
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 123.43
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 92.16
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 132.26
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 199.86
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 290.4
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 196.29
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 306.35
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.002,
+      "phase": 76.51
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 169.63
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 149.74
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 217.53
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.095,
+      "phase": 182.43
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.039,
+      "phase": 214.7
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0,
+      "phase": 348.12
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 141.65
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0,
+      "phase": 140.7
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 286.26
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 58.02
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/petr.json
+++ b/data/ioc/petr.json
@@ -1,0 +1,289 @@
+{
+  "name": "Petropavlovsk",
+  "region": "Kamchatka",
+  "country": "Russia",
+  "continent": "Asia",
+  "latitude": 53.016667,
+  "longitude": 158.65,
+  "timezone": "Asia/Kamchatka",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=petr",
+    "id": "petr",
+    "published_harmonics": false,
+    "operator": "Federal Service of Russia for Hydrometeorology and Environmental Monitoring ( Russia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Federal Service of Russia for Hydrometeorology and Environmental Monitoring ( Russia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.257,
+    "MHHW": 3.6,
+    "MHW": 3.611,
+    "MSL": 3.026,
+    "MTL": 3.118,
+    "MLW": 2.626,
+    "MLLW": 2.173,
+    "LAT": 1.447,
+    "MHWS": 3.387,
+    "MLWS": 2.665
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.283,
+      "phase": 123.91
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.078,
+      "phase": 190.28
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.047,
+      "phase": 76.91
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.014,
+      "phase": 141.24
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.416,
+      "phase": 351.34
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.267,
+      "phase": 325.26
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.08,
+      "phase": 358.6
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.06,
+      "phase": 330.99
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 304.38
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.008,
+      "phase": 114.15
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 235.09
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 335.81
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 48.12
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 332.31
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.007,
+      "phase": 49.1
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.029,
+      "phase": 117.3
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 153.29
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 78.17
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.013,
+      "phase": 44.45
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.006,
+      "phase": 359.62
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 197.1
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.011,
+      "phase": 268.79
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.013,
+      "phase": 176.05
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.01,
+      "phase": 122.4
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 102.82
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.016,
+      "phase": 355.77
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.009,
+      "phase": 303.36
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 221.12
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.012,
+      "phase": 64.05
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.008,
+      "phase": 304.14
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 268.83
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.006,
+      "phase": 278.92
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 134.76
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.004,
+      "phase": 233.01
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 150.42
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 138.95
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.008,
+      "phase": 132.3
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.139,
+      "phase": 226.18
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.149,
+      "phase": 35.66
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.062,
+      "phase": 49.45
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.09,
+      "phase": 275.11
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.018,
+      "phase": 293.75
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.1,
+      "phase": 359.51
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.12,
+      "phase": 303.21
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.011,
+      "phase": 204.89
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.013,
+      "phase": 18.5
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.039,
+      "phase": 354.2
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 334.84
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.01,
+      "phase": 289.51
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-06",
+    "end": "2026-08-12"
+  }
+}

--- a/data/ioc/pich.json
+++ b/data/ioc/pich.json
@@ -1,0 +1,289 @@
+{
+  "name": "Pichidangui",
+  "region": "Coquimbo Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -32.135611,
+  "longitude": -71.529306,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pich",
+    "id": "pich",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.386,
+    "MHHW": 4.99,
+    "MHW": 4.807,
+    "MSL": 4.365,
+    "MTL": 4.376,
+    "MLW": 3.946,
+    "MLLW": 3.907,
+    "LAT": 3.52,
+    "MHWS": 4.932,
+    "MLWS": 3.798
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.423,
+      "phase": 46.35
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.144,
+      "phase": 67.97
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.093,
+      "phase": 13.94
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.043,
+      "phase": 62.2
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 34.34
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.096,
+      "phase": 349.17
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.046,
+      "phase": 27.73
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.019,
+      "phase": 327.82
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 321.22
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 166.58
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 273.51
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 250.11
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 333.68
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 350.66
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 19.56
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 38.03
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 65.96
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 32.59
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 31.24
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 338.12
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 218.56
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 147.87
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 295.63
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 345.91
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 68.4
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 120.7
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 7.22
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 265.64
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 308.26
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 57.68
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 215.95
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 224.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 118.64
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 46.09
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 132.62
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 3.87
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 92.98
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 163.34
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.003,
+      "phase": 133.73
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 70.8
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 244.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 281.27
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.051,
+      "phase": 20.56
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.023,
+      "phase": 194.18
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.008,
+      "phase": 317.89
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 249.75
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 225.64
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 116.11
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 181.04
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pich2.json
+++ b/data/ioc/pich2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Pichidangui",
+  "region": "Coquimbo Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -32.135611,
+  "longitude": -71.529306,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pich2",
+    "id": "pich2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.386,
+    "MHHW": 4.99,
+    "MHW": 4.807,
+    "MSL": 4.365,
+    "MTL": 4.376,
+    "MLW": 3.946,
+    "MLLW": 3.907,
+    "LAT": 3.52,
+    "MHWS": 4.932,
+    "MLWS": 3.798
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.423,
+      "phase": 46.35
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.144,
+      "phase": 67.97
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.093,
+      "phase": 13.94
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.043,
+      "phase": 62.2
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 34.34
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.096,
+      "phase": 349.17
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.046,
+      "phase": 27.73
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.019,
+      "phase": 327.82
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 321.22
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 166.58
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 273.51
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 250.11
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 333.68
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 350.66
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 19.56
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 38.03
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 65.96
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 32.59
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 31.24
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 338.12
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 218.56
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 147.87
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 295.63
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 345.91
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 68.4
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 120.7
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 7.22
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 265.64
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 308.26
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 57.68
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 215.95
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 224.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 118.64
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 46.09
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 132.62
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 3.87
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 92.98
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 163.34
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.003,
+      "phase": 133.73
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 70.8
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 244.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 281.27
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.051,
+      "phase": 20.56
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.023,
+      "phase": 194.18
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.008,
+      "phase": 317.89
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 249.75
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 225.64
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 116.11
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 181.04
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pisa.json
+++ b/data/ioc/pisa.json
@@ -1,0 +1,289 @@
+{
+  "name": "Pisagua",
+  "region": "Arica y Parinacota Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -19.596907,
+  "longitude": -70.215639,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pisa",
+    "id": "pisa",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.257,
+    "MHHW": 4.911,
+    "MHW": 4.742,
+    "MSL": 4.401,
+    "MTL": 4.396,
+    "MLW": 4.05,
+    "MLLW": 4.027,
+    "LAT": 3.776,
+    "MHWS": 4.838,
+    "MLWS": 3.964
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.338,
+      "phase": 14.18
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.099,
+      "phase": 36.01
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.075,
+      "phase": 335.67
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.032,
+      "phase": 26.63
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 25.57
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.085,
+      "phase": 343.15
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.045,
+      "phase": 21.92
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 315.03
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 312.87
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 52.19
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 250.55
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 180.09
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 299.09
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.017,
+      "phase": 321.14
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 337
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 11.24
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 36.14
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 54.41
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 340.12
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 259.22
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 191.16
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 101.07
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 72
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 322.78
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 59.83
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 101.06
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 274.03
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 315.27
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 304.53
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 37.19
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 171.29
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 334.51
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 274.31
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 5.03
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 284.84
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 226.73
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 155.82
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 4.34
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 38.69
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 346.41
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 77.48
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 231.21
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.049,
+      "phase": 24.61
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.011,
+      "phase": 195.18
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 283.81
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 47.85
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 215.81
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 192.51
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 268.89
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pisa2.json
+++ b/data/ioc/pisa2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Pisagua",
+  "region": "Arica y Parinacota Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -19.596907,
+  "longitude": -70.215639,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pisa2",
+    "id": "pisa2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.257,
+    "MHHW": 4.911,
+    "MHW": 4.742,
+    "MSL": 4.401,
+    "MTL": 4.396,
+    "MLW": 4.05,
+    "MLLW": 4.027,
+    "LAT": 3.776,
+    "MHWS": 4.838,
+    "MLWS": 3.964
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.338,
+      "phase": 14.18
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.099,
+      "phase": 36.01
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.075,
+      "phase": 335.67
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.032,
+      "phase": 26.63
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 25.57
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.085,
+      "phase": 343.15
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.045,
+      "phase": 21.92
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.015,
+      "phase": 315.03
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 312.87
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 52.19
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 250.55
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 180.09
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 299.09
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.017,
+      "phase": 321.14
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 337
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 11.24
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 36.14
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 54.41
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 340.12
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 259.22
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 191.16
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 101.07
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 72
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 322.78
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 59.83
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 101.06
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 274.03
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 315.27
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 304.53
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 37.19
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 171.29
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 334.51
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 274.31
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 5.03
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 284.84
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 226.73
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 155.82
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 4.34
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 38.69
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 346.41
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 77.48
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 231.21
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.049,
+      "phase": 24.61
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.011,
+      "phase": 195.18
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 283.81
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 47.85
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 215.81
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 192.51
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 268.89
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pisco.json
+++ b/data/ioc/pisco.json
@@ -1,0 +1,289 @@
+{
+  "name": "Pisco,Ica",
+  "region": "Ica",
+  "country": "Peru",
+  "continent": "Americas",
+  "latitude": -13.8194,
+  "longitude": -76.25194,
+  "timezone": "America/Lima",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pisco",
+    "id": "pisco",
+    "published_harmonics": false,
+    "operator": "Dirección de Hidrografía y Navegación (Perú)"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dirección de Hidrografía y Navegación (Perú)). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 0.98,
+    "MHHW": 0.297,
+    "MHW": 0.291,
+    "MSL": 0,
+    "MTL": -0.029,
+    "MLW": -0.35,
+    "MLLW": -0.35,
+    "LAT": -0.809,
+    "MHWS": 0.399,
+    "MLWS": -0.399
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.308,
+      "phase": 321.6
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.091,
+      "phase": 353.65
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.087,
+      "phase": 286.42
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.035,
+      "phase": 344.49
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.201,
+      "phase": 23.39
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.097,
+      "phase": 335.48
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.059,
+      "phase": 16.91
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.021,
+      "phase": 344.07
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.006,
+      "phase": 167.78
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 11.15
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 316.15
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 127.52
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.017,
+      "phase": 263.32
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.03,
+      "phase": 269.34
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 59.14
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 278.33
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 337.16
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.008,
+      "phase": 21.32
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.008,
+      "phase": 2.02
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.012,
+      "phase": 283.17
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.012,
+      "phase": 211.98
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.009,
+      "phase": 270.5
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 225.14
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 346.4
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.013,
+      "phase": 51.13
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.012,
+      "phase": 84.92
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.009,
+      "phase": 187.05
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.011,
+      "phase": 210.5
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.01,
+      "phase": 346.96
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.012,
+      "phase": 52.11
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 139.33
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 160.23
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 81.51
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 27.94
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 137.18
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 162.92
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 253.1
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.081,
+      "phase": 353.71
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.043,
+      "phase": 255.28
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.031,
+      "phase": 266.85
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.052,
+      "phase": 48.51
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.02,
+      "phase": 79.57
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.1,
+      "phase": 52.17
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.03,
+      "phase": 127.42
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 12.61
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.011,
+      "phase": 259.43
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.027,
+      "phase": 207.19
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 260.34
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.006,
+      "phase": 348.54
+    }
+  ],
+  "epoch": {
+    "start": "2022-11-25",
+    "end": "2026-08-25"
+  }
+}

--- a/data/ioc/plat2.json
+++ b/data/ioc/plat2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Mar del Plata",
+  "region": "Buenos Aires",
+  "country": "Argentina",
+  "continent": "Americas",
+  "latitude": -38.00015278,
+  "longitude": -57.53850556,
+  "timezone": "America/Argentina/Buenos_Aires",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=plat2",
+    "id": "plat2",
+    "published_harmonics": false,
+    "operator": "Armada Argentina Servicio de Hidrografía Naval ( Argentina )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Armada Argentina Servicio de Hidrografía Naval ( Argentina )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.543,
+    "MHHW": 6.121,
+    "MHW": 5.921,
+    "MSL": 5.339,
+    "MTL": 5.489,
+    "MLW": 5.056,
+    "MLLW": 4.758,
+    "LAT": 4.343,
+    "MHWS": 5.769,
+    "MLWS": 4.909
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.356,
+      "phase": 290.99
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.074,
+      "phase": 7.71
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.079,
+      "phase": 260.68
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.014,
+      "phase": 9.46
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.148,
+      "phase": 168.39
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.178,
+      "phase": 73.14
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.047,
+      "phase": 154.5
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.053,
+      "phase": 32.22
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.037,
+      "phase": 146.55
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.02,
+      "phase": 191.24
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.023,
+      "phase": 95.15
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.012,
+      "phase": 355.26
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.027,
+      "phase": 219.01
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 51.55
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.027,
+      "phase": 269.13
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.023,
+      "phase": 342.76
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 339.12
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.01,
+      "phase": 179.1
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.009,
+      "phase": 20.38
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.009,
+      "phase": 117.5
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.012,
+      "phase": 77.13
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.013,
+      "phase": 114.06
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.025,
+      "phase": 231.31
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.01,
+      "phase": 157.84
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 202.08
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.016,
+      "phase": 350.51
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.012,
+      "phase": 6.16
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.015,
+      "phase": 301.28
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.01,
+      "phase": 17.29
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.013,
+      "phase": 122.78
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.007,
+      "phase": 315.37
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.011,
+      "phase": 355.06
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 339.03
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.006,
+      "phase": 174.64
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.011,
+      "phase": 52.3
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 350.2
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.006,
+      "phase": 50.15
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.049,
+      "phase": 22.71
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.02,
+      "phase": 10.13
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.024,
+      "phase": 140.68
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.02,
+      "phase": 69.04
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.023,
+      "phase": 73.11
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.136,
+      "phase": 80.31
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.049,
+      "phase": 77.62
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.008,
+      "phase": 275
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 278.09
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.009,
+      "phase": 227.78
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.014,
+      "phase": 45.39
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.032,
+      "phase": 138.46
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/plop.json
+++ b/data/ioc/plop.json
@@ -1,0 +1,289 @@
+{
+  "name": "Puerto López",
+  "region": "Manabi",
+  "country": "Ecuador",
+  "continent": "Americas",
+  "latitude": -1.561,
+  "longitude": -80.817,
+  "timezone": "America/Guayaquil",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=plop",
+    "id": "plop",
+    "published_harmonics": false,
+    "operator": "Instituto Oceanográfico y Antártico de la Armada ( Ecuador )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Instituto Oceanográfico y Antártico de la Armada ( Ecuador )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.274,
+    "MHHW": 3.633,
+    "MHW": 3.602,
+    "MSL": 2.828,
+    "MTL": 2.817,
+    "MLW": 2.031,
+    "MLLW": 1.94,
+    "LAT": 1.336,
+    "MHWS": 3.873,
+    "MLWS": 1.783
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.809,
+      "phase": 235.74
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.236,
+      "phase": 283.99
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.179,
+      "phase": 207.21
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.063,
+      "phase": 278.69
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.115,
+      "phase": 38.54
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.026,
+      "phase": 10.73
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.035,
+      "phase": 41.28
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 293.91
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 105.73
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 115.18
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 64.69
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 267.26
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.023,
+      "phase": 181.78
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.028,
+      "phase": 188.37
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.033,
+      "phase": 209.99
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.018,
+      "phase": 264.04
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.014,
+      "phase": 279.03
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 271.77
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 251.39
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 210.95
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 175.14
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 41.49
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.01,
+      "phase": 125.27
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 55.21
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 66.94
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 89.53
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 247.38
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.001,
+      "phase": 198.65
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 88.86
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 129.99
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 339.58
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 29.94
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 178.68
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 175.72
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 357.5
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 293.19
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 9.59
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.007,
+      "phase": 319.81
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.013,
+      "phase": 33.46
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 190.77
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 54.02
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 48.56
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.052,
+      "phase": 95.59
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.021,
+      "phase": 154.68
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 173.36
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 253.1
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 31.38
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 1.23
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 71.24
+    }
+  ],
+  "epoch": {
+    "start": "2023-08-08",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pmel.json
+++ b/data/ioc/pmel.json
@@ -1,0 +1,288 @@
+{
+  "name": "Puerto Melinka",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -43.898463,
+  "longitude": -73.748199,
+  "timezone": "America/Coyhaique",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pmel",
+    "id": "pmel",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.3,
+    "MHHW": 5.582,
+    "MHW": 5.377,
+    "MSL": 4.581,
+    "MTL": 4.581,
+    "MLW": 3.785,
+    "MLLW": 3.688,
+    "LAT": 3.081,
+    "MHWS": 5.636,
+    "MLWS": 3.526
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.766,
+      "phase": 127.69
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.289,
+      "phase": 143.5
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.19,
+      "phase": 102
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.089,
+      "phase": 138.94
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.188,
+      "phase": 60.89
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.131,
+      "phase": 17.66
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.058,
+      "phase": 57.04
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.026,
+      "phase": 352.76
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.008,
+      "phase": 295.12
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.008,
+      "phase": 310.18
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 273.29
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 193.24
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.025,
+      "phase": 68.45
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 115.41
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.038,
+      "phase": 101.56
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.027,
+      "phase": 106.64
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.013,
+      "phase": 131.73
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 161.83
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.015,
+      "phase": 81.51
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.011,
+      "phase": 322.66
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 324.97
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 201.74
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 44.7
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 342.08
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 98.3
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 149.9
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 323.71
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 354.11
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 354.31
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 272.87
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 356.65
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 241.28
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 230.15
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 257.83
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 216.58
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 333.22
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 275.95
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 200.09
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 171
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 226.63
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 95.51
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 167.29
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.079,
+      "phase": 70.99
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 221.08
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 103.07
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 229.82
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.013,
+      "phase": 6.68
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 130.87
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 213.98
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pmel2.json
+++ b/data/ioc/pmel2.json
@@ -1,0 +1,288 @@
+{
+  "name": "Puerto Melinka",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -43.898463,
+  "longitude": -73.748199,
+  "timezone": "America/Coyhaique",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pmel2",
+    "id": "pmel2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.3,
+    "MHHW": 5.582,
+    "MHW": 5.377,
+    "MSL": 4.581,
+    "MTL": 4.581,
+    "MLW": 3.785,
+    "MLLW": 3.688,
+    "LAT": 3.081,
+    "MHWS": 5.636,
+    "MLWS": 3.526
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.766,
+      "phase": 127.69
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.289,
+      "phase": 143.5
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.19,
+      "phase": 102
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.089,
+      "phase": 138.94
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.188,
+      "phase": 60.89
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.131,
+      "phase": 17.66
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.058,
+      "phase": 57.04
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.026,
+      "phase": 352.76
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.008,
+      "phase": 295.12
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.008,
+      "phase": 310.18
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 273.29
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 193.24
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.025,
+      "phase": 68.45
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 115.41
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.038,
+      "phase": 101.56
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.027,
+      "phase": 106.64
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.013,
+      "phase": 131.73
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 161.83
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.015,
+      "phase": 81.51
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.011,
+      "phase": 322.66
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 324.97
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 201.74
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 44.7
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 342.08
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 98.3
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 149.9
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 323.71
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 354.11
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 354.31
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 272.87
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 356.65
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 241.28
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 230.15
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 257.83
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 216.58
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 333.22
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 275.95
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 200.09
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 171
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 226.63
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 95.51
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 167.29
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.079,
+      "phase": 70.99
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 221.08
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 103.07
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 229.82
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.013,
+      "phase": 6.68
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 130.87
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 213.98
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pmur.json
+++ b/data/ioc/pmur.json
@@ -1,0 +1,289 @@
+{
+  "name": "PtMurat",
+  "region": "Western Australia",
+  "country": "Australia",
+  "continent": "Oceania",
+  "latitude": -21.8167,
+  "longitude": 114.191,
+  "timezone": "Australia/Perth",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pmur",
+    "id": "pmur",
+    "published_harmonics": false,
+    "operator": "National Tidal Centre/Australian Bureau of Meteorology ( Australia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Tidal Centre/Australian Bureau of Meteorology ( Australia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.758,
+    "MHHW": 2.243,
+    "MHW": 2.085,
+    "MSL": 1.563,
+    "MTL": 1.572,
+    "MLW": 1.059,
+    "MLLW": 0.903,
+    "LAT": 0.338,
+    "MHWS": 2.277,
+    "MLWS": 0.849
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.467,
+      "phase": 60.68
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.247,
+      "phase": 124.32
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.089,
+      "phase": 35.49
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.068,
+      "phase": 121.69
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.203,
+      "phase": 168.64
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.129,
+      "phase": 157.21
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.061,
+      "phase": 165.88
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.03,
+      "phase": 153.87
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.011,
+      "phase": 98.29
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.011,
+      "phase": 161.11
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 71.59
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 15.71
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 11.02
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.018,
+      "phase": 53.06
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 28.5
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.016,
+      "phase": 69.78
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.011,
+      "phase": 140.48
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 109.87
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 48.33
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 330.78
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 302.24
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 23.27
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.014,
+      "phase": 306.43
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 137.56
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.011,
+      "phase": 183.17
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 216.05
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 136.7
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 150.44
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.007,
+      "phase": 152.04
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 323.05
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 219.73
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 232.43
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 41.2
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 219.53
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.007,
+      "phase": 73.02
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 99.17
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 97.99
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 198.61
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 343.43
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.026,
+      "phase": 242.97
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 5.67
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 179.72
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.088,
+      "phase": 3.14
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.044,
+      "phase": 118.34
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 23.35
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 151.43
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 317.4
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 134.08
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 235.32
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-22",
+    "end": "2026-02-24"
+  }
+}

--- a/data/ioc/pnat.json
+++ b/data/ioc/pnat.json
@@ -1,0 +1,289 @@
+{
+  "name": "Puerto Natales",
+  "region": "Region of Magallanes",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -51.729134,
+  "longitude": -72.51567,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pnat",
+    "id": "pnat",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.193,
+    "MHHW": 3.825,
+    "MHW": 3.769,
+    "MSL": 3.705,
+    "MTL": 3.676,
+    "MLW": 3.582,
+    "MLLW": 3.556,
+    "LAT": 3.371,
+    "MHWS": 3.823,
+    "MLWS": 3.587
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.089,
+      "phase": 267.94
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.029,
+      "phase": 237.4
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.025,
+      "phase": 242.37
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.01,
+      "phase": 247.52
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.066,
+      "phase": 169.07
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.049,
+      "phase": 129.59
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.014,
+      "phase": 163.08
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 95.35
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 153.54
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 29.91
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 65.66
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 126.38
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 204.73
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.006,
+      "phase": 160.4
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.007,
+      "phase": 263.06
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 345.19
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 268.2
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 262.47
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 256.76
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 17.19
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 130.82
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 195.85
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 124.54
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 90.08
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 304.48
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 315.64
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 237.88
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 82.83
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0,
+      "phase": 351.43
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 107.04
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 349.19
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 249.97
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 224.7
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 269.94
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 338.95
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 356.38
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 291.26
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.04,
+      "phase": 350.09
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 104.04
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.049,
+      "phase": 292.37
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 298.35
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.037,
+      "phase": 201.2
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.071,
+      "phase": 358.12
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.068,
+      "phase": 357.8
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 77.31
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 317.63
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.01,
+      "phase": 85.86
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 40.75
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 230.59
+    }
+  ],
+  "epoch": {
+    "start": "2022-11-13",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/pnat2.json
+++ b/data/ioc/pnat2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Puerto Natales",
+  "region": "Region of Magallanes",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -51.729134,
+  "longitude": -72.51567,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=pnat2",
+    "id": "pnat2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.193,
+    "MHHW": 3.825,
+    "MHW": 3.769,
+    "MSL": 3.705,
+    "MTL": 3.676,
+    "MLW": 3.582,
+    "MLLW": 3.556,
+    "LAT": 3.371,
+    "MHWS": 3.823,
+    "MLWS": 3.587
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.089,
+      "phase": 267.94
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.029,
+      "phase": 237.4
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.025,
+      "phase": 242.37
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.01,
+      "phase": 247.52
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.066,
+      "phase": 169.07
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.049,
+      "phase": 129.59
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.014,
+      "phase": 163.08
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 95.35
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 153.54
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 29.91
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 65.66
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 126.38
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 204.73
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.006,
+      "phase": 160.4
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.007,
+      "phase": 263.06
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 345.19
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 268.2
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 262.47
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 256.76
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 17.19
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 130.82
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 195.85
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 124.54
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 90.08
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 304.48
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 315.64
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 237.88
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 82.83
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0,
+      "phase": 351.43
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 107.04
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 349.19
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 249.97
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 224.7
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 269.94
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 338.95
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 356.38
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 291.26
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.04,
+      "phase": 350.09
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 104.04
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.049,
+      "phase": 292.37
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 298.35
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.037,
+      "phase": 201.2
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.071,
+      "phase": 358.12
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.068,
+      "phase": 357.8
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 77.31
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 317.63
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.01,
+      "phase": 85.86
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 40.75
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 230.59
+    }
+  ],
+  "epoch": {
+    "start": "2022-11-13",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/prev.json
+++ b/data/ioc/prev.json
@@ -1,0 +1,289 @@
+{
+  "name": "Preveza, Epirus",
+  "region": "Epirus",
+  "country": "Greece",
+  "continent": "Europe",
+  "latitude": 38.94946,
+  "longitude": 20.728663,
+  "timezone": "Europe/Athens",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=prev",
+    "id": "prev",
+    "published_harmonics": false,
+    "operator": "National Observatory of Athens ( Greece )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Observatory of Athens ( Greece )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.486,
+    "MHHW": 0.285,
+    "MHW": 0.274,
+    "MSL": 0.217,
+    "MTL": 0.217,
+    "MLW": 0.16,
+    "MLLW": 0.147,
+    "LAT": -0.032,
+    "MHWS": 0.288,
+    "MLWS": 0.146
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.046,
+      "phase": 47.85
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.025,
+      "phase": 50.24
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.009,
+      "phase": 50.86
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.007,
+      "phase": 57.72
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.013,
+      "phase": 8.98
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.008,
+      "phase": 346.89
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.005,
+      "phase": 11.97
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 267.14
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 173.81
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 196.04
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 37.91
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 193.82
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.001,
+      "phase": 344.26
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.001,
+      "phase": 162.47
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 27.53
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.002,
+      "phase": 96.23
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 96.37
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 311.91
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 339.43
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 189.89
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 127.09
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 295.78
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.01,
+      "phase": 122.05
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 13.69
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.001,
+      "phase": 329.97
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.002,
+      "phase": 294.31
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 58.63
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 240.51
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 48.2
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 349.14
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 147.15
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 195.49
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 241.84
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 53.52
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 116.03
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 23.54
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 235.88
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.024,
+      "phase": 130.66
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.019,
+      "phase": 116.72
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.017,
+      "phase": 316.37
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.027,
+      "phase": 264.46
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.007,
+      "phase": 92.06
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.061,
+      "phase": 141.06
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.063,
+      "phase": 158.78
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 24.16
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 354.02
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 110.27
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 269.12
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 48.38
+    }
+  ],
+  "epoch": {
+    "start": "2020-07-20",
+    "end": "2026-09-01"
+  }
+}

--- a/data/ioc/ptal.json
+++ b/data/ioc/ptal.json
@@ -1,0 +1,289 @@
+{
+  "name": "Puerto Aldea",
+  "region": "Coquimbo Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -30.2923,
+  "longitude": -71.607564,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ptal",
+    "id": "ptal",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.031,
+    "MHHW": 4.628,
+    "MHW": 4.453,
+    "MSL": 4.037,
+    "MTL": 4.038,
+    "MLW": 3.623,
+    "MLLW": 3.6,
+    "LAT": 3.239,
+    "MHWS": 4.583,
+    "MLWS": 3.491
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.411,
+      "phase": 40
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.135,
+      "phase": 62.42
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.091,
+      "phase": 7.61
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.041,
+      "phase": 53.71
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.153,
+      "phase": 30.96
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.097,
+      "phase": 346.11
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 26.33
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.019,
+      "phase": 320.32
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 326.1
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 15.28
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 246.36
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 142.78
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 334.68
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 346.96
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 8.82
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 40.04
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 61.95
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 79.88
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 3.41
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 289.42
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 210.39
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 146.84
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 253.03
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 322.54
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 69.2
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 114.6
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 292.17
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 320.13
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 306.44
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 53.22
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 243.13
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 206.14
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 181.22
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 71.08
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 90.53
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 107.85
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 67.62
+    },
+    {
+      "name": "MM",
+      "amplitude": 0,
+      "phase": 82.95
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 106.73
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0,
+      "phase": 85.71
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 157.55
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 192.81
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.047,
+      "phase": 8.67
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.018,
+      "phase": 219.29
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 311.9
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 45.69
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 244.73
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 114.14
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 197.78
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ptal2.json
+++ b/data/ioc/ptal2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Puerto Aldea",
+  "region": "Coquimbo Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -30.2923,
+  "longitude": -71.607564,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ptal2",
+    "id": "ptal2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.031,
+    "MHHW": 4.628,
+    "MHW": 4.453,
+    "MSL": 4.037,
+    "MTL": 4.038,
+    "MLW": 3.623,
+    "MLLW": 3.6,
+    "LAT": 3.239,
+    "MHWS": 4.583,
+    "MLWS": 3.491
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.411,
+      "phase": 40
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.135,
+      "phase": 62.42
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.091,
+      "phase": 7.61
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.041,
+      "phase": 53.71
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.153,
+      "phase": 30.96
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.097,
+      "phase": 346.11
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 26.33
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.019,
+      "phase": 320.32
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 326.1
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 15.28
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 246.36
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 142.78
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 334.68
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 346.96
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 8.82
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 40.04
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 61.95
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 79.88
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 3.41
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 289.42
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 210.39
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 146.84
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 253.03
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 322.54
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 69.2
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 114.6
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 292.17
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 320.13
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 306.44
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 53.22
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 243.13
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 206.14
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 181.22
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 71.08
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 90.53
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 107.85
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 67.62
+    },
+    {
+      "name": "MM",
+      "amplitude": 0,
+      "phase": 82.95
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 106.73
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0,
+      "phase": 85.71
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 157.55
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 192.81
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.047,
+      "phase": 8.67
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.018,
+      "phase": 219.29
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 311.9
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 45.69
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 244.73
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 114.14
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 197.78
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ptar.json
+++ b/data/ioc/ptar.json
@@ -1,0 +1,289 @@
+{
+  "name": "Punta Arenas",
+  "region": "Region of Magallanes",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -53.123727,
+  "longitude": -70.861985,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ptar",
+    "id": "ptar",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.955,
+    "MHHW": 5.517,
+    "MHW": 5.223,
+    "MSL": 4.713,
+    "MTL": 4.729,
+    "MLW": 4.236,
+    "MLLW": 4.041,
+    "LAT": 3.559,
+    "MHWS": 5.382,
+    "MLWS": 4.044
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.474,
+      "phase": 95.8
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.195,
+      "phase": 191.32
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.077,
+      "phase": 55.84
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.058,
+      "phase": 194.18
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.298,
+      "phase": 119.94
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.213,
+      "phase": 71.5
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.083,
+      "phase": 111.63
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.043,
+      "phase": 46.51
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 32.15
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 57.42
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 17.4
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.043,
+      "phase": 43.34
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 346.46
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.04,
+      "phase": 257.21
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.023,
+      "phase": 79.16
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.049,
+      "phase": 136.06
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.014,
+      "phase": 176.48
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 215.91
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.026,
+      "phase": 134.9
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.01,
+      "phase": 72.18
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 339.46
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.008,
+      "phase": 173.07
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.015,
+      "phase": 98.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 51.35
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 171.91
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 231.29
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 22.43
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 55.11
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.008,
+      "phase": 20.97
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 89.78
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 226.64
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 26.18
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 5.55
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.004,
+      "phase": 52.52
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.032,
+      "phase": 106.15
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 150.25
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 17.89
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 202.67
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.018,
+      "phase": 140.12
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.013,
+      "phase": 328.03
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.012,
+      "phase": 116.12
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 201.04
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.024,
+      "phase": 358.25
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.015,
+      "phase": 84.87
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.019,
+      "phase": 219.93
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.01,
+      "phase": 286.82
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 120.27
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 333.9
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 67.95
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ptar2.json
+++ b/data/ioc/ptar2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Punta Arenas",
+  "region": "Region of Magallanes",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -53.123727,
+  "longitude": -70.861985,
+  "timezone": "America/Punta_Arenas",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ptar2",
+    "id": "ptar2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.955,
+    "MHHW": 5.517,
+    "MHW": 5.223,
+    "MSL": 4.713,
+    "MTL": 4.729,
+    "MLW": 4.236,
+    "MLLW": 4.041,
+    "LAT": 3.559,
+    "MHWS": 5.382,
+    "MLWS": 4.044
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.474,
+      "phase": 95.8
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.195,
+      "phase": 191.32
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.077,
+      "phase": 55.84
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.058,
+      "phase": 194.18
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.298,
+      "phase": 119.94
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.213,
+      "phase": 71.5
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.083,
+      "phase": 111.63
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.043,
+      "phase": 46.51
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 32.15
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 57.42
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 17.4
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.043,
+      "phase": 43.34
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 346.46
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.04,
+      "phase": 257.21
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.023,
+      "phase": 79.16
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.049,
+      "phase": 136.06
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.014,
+      "phase": 176.48
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 215.91
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.026,
+      "phase": 134.9
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.01,
+      "phase": 72.18
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 339.46
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.008,
+      "phase": 173.07
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.015,
+      "phase": 98.94
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 51.35
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 171.91
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 231.29
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 22.43
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 55.11
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.008,
+      "phase": 20.97
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 89.78
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 226.64
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 26.18
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 5.55
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.004,
+      "phase": 52.52
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.032,
+      "phase": 106.15
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 150.25
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 17.89
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 202.67
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.018,
+      "phase": 140.12
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.013,
+      "phase": 328.03
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.012,
+      "phase": 116.12
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 201.04
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.024,
+      "phase": 358.25
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.015,
+      "phase": 84.87
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.019,
+      "phase": 219.93
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.01,
+      "phase": 286.82
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 120.27
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 333.9
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 67.95
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ptbc.json
+++ b/data/ioc/ptbc.json
@@ -1,0 +1,289 @@
+{
+  "name": "Port-de-Bouc",
+  "region": "Provence-Alpes-Cote d'Azur",
+  "country": "France",
+  "continent": "Europe",
+  "latitude": 43.398056,
+  "longitude": 4.982778,
+  "timezone": "Europe/Paris",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ptbc",
+    "id": "ptbc",
+    "published_harmonics": false,
+    "operator": "Service hydrographique et océanographique de la marine ( France )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Service hydrographique et océanographique de la marine ( France )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.718,
+    "MHHW": 0.652,
+    "MHW": 0.621,
+    "MSL": 0.561,
+    "MTL": 0.569,
+    "MLW": 0.518,
+    "MLLW": 0.497,
+    "LAT": 0.407,
+    "MHWS": 0.637,
+    "MLWS": 0.485
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.055,
+      "phase": 214.95
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.021,
+      "phase": 233.64
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.012,
+      "phase": 203.96
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.007,
+      "phase": 231.82
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.029,
+      "phase": 171.11
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.017,
+      "phase": 99.21
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.01,
+      "phase": 163.76
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 40.32
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 336.66
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 54.2
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 290.16
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 70.03
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.001,
+      "phase": 193.65
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 189.49
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.003,
+      "phase": 213.51
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 239.24
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 207.68
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 324.62
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 219.67
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 175.49
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 227.94
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 57.82
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 26.09
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 129.43
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.001,
+      "phase": 188.2
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 203.35
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 325.74
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.001,
+      "phase": 25.21
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0,
+      "phase": 124.08
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 329.9
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 159.98
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 250.92
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 195.98
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 18.84
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 121
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 28.76
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 2.74
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 229.84
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 179.19
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 141.98
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 81.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 335.65
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.02,
+      "phase": 206.5
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.012,
+      "phase": 39.09
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 166.9
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 283.09
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0,
+      "phase": 315.16
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 12.25
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 118.71
+    }
+  ],
+  "epoch": {
+    "start": "2023-05-04",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ptbc2.json
+++ b/data/ioc/ptbc2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Port-de-Bouc2",
+  "region": "Provence-Alpes-Cote d'Azur",
+  "country": "France",
+  "continent": "Europe",
+  "latitude": 43.398056,
+  "longitude": 4.982778,
+  "timezone": "Europe/Paris",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ptbc2",
+    "id": "ptbc2",
+    "published_harmonics": false,
+    "operator": "Service hydrographique et océanographique de la marine ( France )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Service hydrographique et océanographique de la marine ( France )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.718,
+    "MHHW": 0.652,
+    "MHW": 0.621,
+    "MSL": 0.561,
+    "MTL": 0.569,
+    "MLW": 0.518,
+    "MLLW": 0.497,
+    "LAT": 0.407,
+    "MHWS": 0.637,
+    "MLWS": 0.485
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.055,
+      "phase": 214.95
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.021,
+      "phase": 233.64
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.012,
+      "phase": 203.96
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.007,
+      "phase": 231.82
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.029,
+      "phase": 171.11
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.017,
+      "phase": 99.21
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.01,
+      "phase": 163.76
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 40.32
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 336.66
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 54.2
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 290.16
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 70.03
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.001,
+      "phase": 193.65
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 189.49
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.003,
+      "phase": 213.51
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 239.24
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 207.68
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 324.62
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 219.67
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 175.49
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 227.94
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 57.82
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 26.09
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 129.43
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.001,
+      "phase": 188.2
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 203.35
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 325.74
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.001,
+      "phase": 25.21
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0,
+      "phase": 124.08
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 329.9
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 159.98
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 250.92
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 195.98
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 18.84
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 121
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 28.76
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 2.74
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 229.84
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 179.19
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 141.98
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 81.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 335.65
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.02,
+      "phase": 206.5
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.012,
+      "phase": 39.09
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 166.9
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 283.09
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0,
+      "phase": 315.16
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 12.25
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 118.71
+    }
+  ],
+  "epoch": {
+    "start": "2023-05-04",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ptch.json
+++ b/data/ioc/ptch.json
@@ -1,0 +1,289 @@
+{
+  "name": "Punta de Choros",
+  "region": "Coquimbo Region",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -29.245858,
+  "longitude": -71.46865,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ptch",
+    "id": "ptch",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.091,
+    "MHHW": 4.691,
+    "MHW": 4.516,
+    "MSL": 4.109,
+    "MTL": 4.107,
+    "MLW": 3.698,
+    "MLLW": 3.663,
+    "LAT": 3.32,
+    "MHWS": 4.647,
+    "MLWS": 3.571
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.406,
+      "phase": 39.16
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.132,
+      "phase": 63.29
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.088,
+      "phase": 6.36
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.04,
+      "phase": 54.2
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.152,
+      "phase": 32.17
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.096,
+      "phase": 347.35
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 27.85
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.019,
+      "phase": 321.5
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 332.93
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 130.04
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 264.63
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 148.94
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 334.17
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 347.74
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 8.84
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 39.14
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 58.9
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 95.26
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 349.23
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 299.75
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 217.28
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 211.61
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 253.06
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 329.24
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 67.01
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 114.52
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 279.78
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 324.58
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 314.32
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 54.35
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 245.14
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 211.4
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 255.98
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 305.07
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 112.61
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 122.49
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 86.59
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.002,
+      "phase": 153.6
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.005,
+      "phase": 101.33
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 23.88
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 144.04
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 221.74
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.049,
+      "phase": 11.12
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.02,
+      "phase": 209.73
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 310.93
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 61.29
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 241.17
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 124.08
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 201.39
+    }
+  ],
+  "epoch": {
+    "start": "2020-04-14",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ptmd2.json
+++ b/data/ioc/ptmd2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Portsmouth, Dominica",
+  "region": "Saint John Parish",
+  "country": "Dominica",
+  "continent": "Americas",
+  "latitude": 15.5768,
+  "longitude": -61.4582,
+  "timezone": "America/Dominica",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ptmd2",
+    "id": "ptmd2",
+    "published_harmonics": false,
+    "operator": "Dominica Meteorological Service ( Dominica )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Dominica Meteorological Service ( Dominica )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.702,
+    "MHHW": 3.544,
+    "MHW": 3.539,
+    "MSL": 3.411,
+    "MTL": 3.45,
+    "MLW": 3.361,
+    "MLLW": 3.241,
+    "LAT": 3.063,
+    "MHWS": 3.488,
+    "MLWS": 3.334
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.059,
+      "phase": 218.08
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.018,
+      "phase": 239.26
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.016,
+      "phase": 196
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.005,
+      "phase": 229.66
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.08,
+      "phase": 229.92
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.063,
+      "phase": 222.99
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.026,
+      "phase": 230.41
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 208.51
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 254.73
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 317.73
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 181.03
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 221.32
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.003,
+      "phase": 153.18
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 153.56
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.004,
+      "phase": 183.93
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 276.56
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 196.53
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 313.23
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 184.06
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 90.73
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 171.93
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 37.08
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 192.01
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 190.56
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 229.16
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 228.69
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 200.29
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 177.45
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 233.77
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 160.51
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 157.82
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 75.27
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 94.74
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 143.88
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 41.15
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 283.99
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 111.67
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.023,
+      "phase": 349.55
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.014,
+      "phase": 15.73
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 29.32
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 359.83
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 92.49
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.079,
+      "phase": 160.04
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.038,
+      "phase": 57.6
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 165.68
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 44.78
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 135.74
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 192.07
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 155.67
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/qing.json
+++ b/data/ioc/qing.json
@@ -1,0 +1,290 @@
+{
+  "name": "Qinglan",
+  "region": "Hainan",
+  "country": "China",
+  "continent": "Asia",
+  "latitude": 19.57,
+  "longitude": 110.82,
+  "timezone": "Asia/Shanghai",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=qing",
+    "id": "qing",
+    "published_harmonics": false,
+    "operator": "China Meteorological Administration ( China )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (China Meteorological Administration ( China )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.236,
+    "MHHW": 1.72,
+    "MHW": 1.559,
+    "MSL": 1.106,
+    "MTL": 1.092,
+    "MLW": 0.625,
+    "MLLW": 0.505,
+    "LAT": 0.016,
+    "MHWS": 1.443,
+    "MLWS": 0.769,
+    "TLT": 0.041
+  },
+  "datums_source": "observed",
+  "chart_datum": "TLT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.245,
+      "phase": 75.32
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.092,
+      "phase": 109.86
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.051,
+      "phase": 61.95
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.027,
+      "phase": 99.78
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.307,
+      "phase": 194.51
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.249,
+      "phase": 154.6
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.091,
+      "phase": 189.08
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.052,
+      "phase": 139.67
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 226
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 279.94
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 230.22
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 275.37
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 63.49
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 64.76
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.004,
+      "phase": 59.83
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 83.36
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 49.77
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.009,
+      "phase": 292.91
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 10.12
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 285.4
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.018,
+      "phase": 24
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.012,
+      "phase": 357.25
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.01,
+      "phase": 253.63
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 185.54
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 225.44
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 258.18
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.007,
+      "phase": 128.29
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 143.16
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.008,
+      "phase": 180.52
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 188.57
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 233.01
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 19.59
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 309.09
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 184.34
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 333.33
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 19.77
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 293.1
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 356.39
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.005,
+      "phase": 77.72
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.014,
+      "phase": 73.24
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 306.74
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 21.14
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.126,
+      "phase": 235.78
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.057,
+      "phase": 84.93
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 56.87
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 218.89
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 203.77
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 325.87
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 58.82
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-09",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/qtro.json
+++ b/data/ioc/qtro.json
@@ -1,0 +1,289 @@
+{
+  "name": "Quintero",
+  "region": "Valparaiso",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -32.775493,
+  "longitude": -71.525427,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=qtro",
+    "id": "qtro",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.09,
+    "MHHW": 4.673,
+    "MHW": 4.497,
+    "MSL": 4.071,
+    "MTL": 4.072,
+    "MLW": 3.647,
+    "MLLW": 3.618,
+    "LAT": 3.245,
+    "MHWS": 4.636,
+    "MLWS": 3.506
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.421,
+      "phase": 46.97
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.144,
+      "phase": 68.49
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.094,
+      "phase": 16.44
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.044,
+      "phase": 60.56
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.151,
+      "phase": 34.24
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.099,
+      "phase": 349.77
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 30.76
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.02,
+      "phase": 324.48
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 330.19
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 321.1
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 255.26
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 60.7
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.012,
+      "phase": 345.4
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 354.97
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 18.01
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 47.31
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 64.85
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 85.08
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 15.91
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 297.29
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 221.57
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 163.92
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 288.93
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 325.08
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 73.24
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 118.24
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 294.88
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 323.96
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 308.9
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 63.11
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 261.12
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 202.8
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 124.19
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 46.5
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 113.95
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 111.79
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 60.18
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.001,
+      "phase": 196.24
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 125.23
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 120.16
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 202.04
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 191.78
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.042,
+      "phase": 10.59
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.022,
+      "phase": 214.06
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 320.72
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 69.52
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 255.63
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 96.64
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 189.9
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/qtro2.json
+++ b/data/ioc/qtro2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Quintero",
+  "region": "Valparaiso",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -32.775493,
+  "longitude": -71.525427,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=qtro2",
+    "id": "qtro2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.09,
+    "MHHW": 4.673,
+    "MHW": 4.497,
+    "MSL": 4.071,
+    "MTL": 4.072,
+    "MLW": 3.647,
+    "MLLW": 3.618,
+    "LAT": 3.245,
+    "MHWS": 4.636,
+    "MLWS": 3.506
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.421,
+      "phase": 46.97
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.144,
+      "phase": 68.49
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.094,
+      "phase": 16.44
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.044,
+      "phase": 60.56
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.151,
+      "phase": 34.24
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.099,
+      "phase": 349.77
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 30.76
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.02,
+      "phase": 324.48
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 330.19
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 321.1
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 255.26
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 60.7
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.012,
+      "phase": 345.4
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 354.97
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 18.01
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 47.31
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 64.85
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 85.08
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 15.91
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 297.29
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 221.57
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 163.92
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 288.93
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 325.08
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 73.24
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 118.24
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 294.88
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 323.96
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 308.9
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 63.11
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 261.12
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 202.8
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 124.19
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 46.5
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 113.95
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 111.79
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 60.18
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.001,
+      "phase": 196.24
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 125.23
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.001,
+      "phase": 120.16
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 202.04
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 191.78
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.042,
+      "phase": 10.59
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.022,
+      "phase": 214.06
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 320.72
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 69.52
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 255.63
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 96.64
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 189.9
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/quel.json
+++ b/data/ioc/quel.json
@@ -1,0 +1,289 @@
+{
+  "name": "Queule",
+  "region": "Araucania",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -39.39762,
+  "longitude": -73.215057,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=quel",
+    "id": "quel",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.367,
+    "MHHW": 3.887,
+    "MHW": 3.722,
+    "MSL": 3.369,
+    "MTL": 3.372,
+    "MLW": 3.022,
+    "MLLW": 2.999,
+    "LAT": 2.77,
+    "MHWS": 3.814,
+    "MLWS": 2.924
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.328,
+      "phase": 87.43
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.117,
+      "phase": 102.82
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.072,
+      "phase": 61.67
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.035,
+      "phase": 100.02
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.131,
+      "phase": 58.68
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.096,
+      "phase": 16.12
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.041,
+      "phase": 58.28
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.019,
+      "phase": 353.64
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.02,
+      "phase": 116.05
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.014,
+      "phase": 137.34
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.009,
+      "phase": 98.07
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 333.63
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 31.49
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 18.02
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 62.51
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 84.13
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 89.92
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 186.01
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 67.13
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 292.59
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 185.45
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 332.72
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 133.76
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 349.23
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 116.82
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 150.38
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 334.31
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 359.27
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 111.48
+    },
+    {
+      "name": "M3",
+      "amplitude": 0,
+      "phase": 221.98
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 290.55
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 176.99
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 84.26
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 9.21
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 342.93
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 327.55
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 283.18
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.015,
+      "phase": 30.58
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.005,
+      "phase": 178.98
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.031,
+      "phase": 24.7
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 55.99
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 157.01
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.113,
+      "phase": 101.83
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.038,
+      "phase": 216.34
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 300.43
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 54.58
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 309.95
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 77.73
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 122.41
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/quel2.json
+++ b/data/ioc/quel2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Queule",
+  "region": "Araucania",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -39.39762,
+  "longitude": -73.215057,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=quel2",
+    "id": "quel2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.367,
+    "MHHW": 3.887,
+    "MHW": 3.722,
+    "MSL": 3.369,
+    "MTL": 3.372,
+    "MLW": 3.022,
+    "MLLW": 2.999,
+    "LAT": 2.77,
+    "MHWS": 3.814,
+    "MLWS": 2.924
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.328,
+      "phase": 87.43
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.117,
+      "phase": 102.82
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.072,
+      "phase": 61.67
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.035,
+      "phase": 100.02
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.131,
+      "phase": 58.68
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.096,
+      "phase": 16.12
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.041,
+      "phase": 58.28
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.019,
+      "phase": 353.64
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.02,
+      "phase": 116.05
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.014,
+      "phase": 137.34
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.009,
+      "phase": 98.07
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 333.63
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 31.49
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 18.02
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 62.51
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 84.13
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 89.92
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 186.01
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 67.13
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 292.59
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 185.45
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 332.72
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 133.76
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 349.23
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 116.82
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 150.38
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 334.31
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 359.27
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 111.48
+    },
+    {
+      "name": "M3",
+      "amplitude": 0,
+      "phase": 221.98
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 290.55
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 176.99
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 84.26
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 9.21
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 342.93
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 327.55
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 283.18
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.015,
+      "phase": 30.58
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.005,
+      "phase": 178.98
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.031,
+      "phase": 24.7
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 55.99
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 157.01
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.113,
+      "phase": 101.83
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.038,
+      "phase": 216.34
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 300.43
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 54.58
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 309.95
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 77.73
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 122.41
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/quir.json
+++ b/data/ioc/quir.json
@@ -1,0 +1,289 @@
+{
+  "name": "Quiriquina",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -36.636139,
+  "longitude": -73.057257,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=quir",
+    "id": "quir",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.824,
+    "MHHW": 5.351,
+    "MHW": 5.162,
+    "MSL": 4.709,
+    "MTL": 4.709,
+    "MLW": 4.257,
+    "MLLW": 4.21,
+    "LAT": 3.827,
+    "MHWS": 5.316,
+    "MLWS": 4.102
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.446,
+      "phase": 63.31
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.161,
+      "phase": 82
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.103,
+      "phase": 34.8
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.048,
+      "phase": 74.92
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.159,
+      "phase": 40.21
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.108,
+      "phase": 356.23
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 36.5
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 332
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 358.52
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 15.41
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 272.64
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 93.1
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 4.6
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 10.99
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 36.15
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 60.41
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 77.64
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 83.76
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 36.44
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 310.71
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 214.43
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 128.85
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 357.42
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 330.44
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 80.35
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 128.57
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 291.45
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 330.19
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 321.26
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 108.71
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 286.64
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 207.53
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 172.88
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 287.78
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 147
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 125.88
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 77.09
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 160.37
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 152.54
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 99.56
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0,
+      "phase": 221.79
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 73.24
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.043,
+      "phase": 54.37
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.034,
+      "phase": 215.78
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 339.43
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 126.16
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 278.25
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 94.61
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 191.16
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/quir2.json
+++ b/data/ioc/quir2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Quiriquina",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -36.636139,
+  "longitude": -73.057257,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=quir2",
+    "id": "quir2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.824,
+    "MHHW": 5.351,
+    "MHW": 5.162,
+    "MSL": 4.709,
+    "MTL": 4.709,
+    "MLW": 4.257,
+    "MLLW": 4.21,
+    "LAT": 3.827,
+    "MHWS": 5.316,
+    "MLWS": 4.102
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.446,
+      "phase": 63.31
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.161,
+      "phase": 82
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.103,
+      "phase": 34.8
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.048,
+      "phase": 74.92
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.159,
+      "phase": 40.21
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.108,
+      "phase": 356.23
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.048,
+      "phase": 36.5
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 332
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 358.52
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 15.41
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 272.64
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 93.1
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.013,
+      "phase": 4.6
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 10.99
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 36.15
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 60.41
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 77.64
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 83.76
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 36.44
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 310.71
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 214.43
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 128.85
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 357.42
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 330.44
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 80.35
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 128.57
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 291.45
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 330.19
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 321.26
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 108.71
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 286.64
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 207.53
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 172.88
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 287.78
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 147
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 125.88
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 77.09
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 160.37
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 152.54
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 99.56
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0,
+      "phase": 221.79
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 73.24
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.043,
+      "phase": 54.37
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.034,
+      "phase": 215.78
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 339.43
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 126.16
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 278.25
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 94.61
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 191.16
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/rbct.json
+++ b/data/ioc/rbct.json
@@ -1,0 +1,288 @@
+{
+  "name": "Raoul Island Boat Cove",
+  "country": "New Zealand",
+  "continent": "Oceania",
+  "latitude": -29.280016,
+  "longitude": -177.8944,
+  "timezone": "Pacific/Auckland",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=rbct",
+    "id": "rbct",
+    "published_harmonics": false,
+    "operator": "Land Information New Zealand ( New Zealand )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Land Information New Zealand ( New Zealand )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.603,
+    "MHHW": 6.913,
+    "MHW": 6.877,
+    "MSL": 6.396,
+    "MTL": 6.394,
+    "MLW": 5.91,
+    "MLLW": 5.863,
+    "LAT": 5.119,
+    "MHWS": 6.975,
+    "MLWS": 5.817
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.495,
+      "phase": 195.16
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.084,
+      "phase": 271.69
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.106,
+      "phase": 161.82
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.018,
+      "phase": 267.86
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.06,
+      "phase": 40.38
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.03,
+      "phase": 38.56
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.017,
+      "phase": 9.8
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.004,
+      "phase": 19.7
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 208.36
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 262.4
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 186.43
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 28.7
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 137.37
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.016,
+      "phase": 136.77
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.021,
+      "phase": 169.19
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 242.22
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 274.66
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 122.5
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 236.84
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 187.61
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 306.48
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 236.81
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.02,
+      "phase": 215.97
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 55.49
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 26.25
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.002,
+      "phase": 76.77
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 112.91
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.001,
+      "phase": 81.25
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 177
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 168.71
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 203.88
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 109.69
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 210.24
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 293.24
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 72.92
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 192.97
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 71.12
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.019,
+      "phase": 288.89
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.004,
+      "phase": 170.37
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 223.06
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 218.96
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 70.67
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.463,
+      "phase": 328.22
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.039,
+      "phase": 138.39
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 105.71
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 82.01
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.008,
+      "phase": 340.16
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 24.28
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 342.93
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/sano.json
+++ b/data/ioc/sano.json
@@ -1,0 +1,289 @@
+{
+  "name": "San_Antonio",
+  "region": "Valparaiso",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -33.581625,
+  "longitude": -71.618188,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=sano",
+    "id": "sano",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.793,
+    "MHHW": 5.364,
+    "MHW": 5.185,
+    "MSL": 4.753,
+    "MTL": 4.754,
+    "MLW": 4.323,
+    "MLLW": 4.295,
+    "LAT": 3.917,
+    "MHWS": 5.326,
+    "MLWS": 4.18
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.425,
+      "phase": 48.99
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.148,
+      "phase": 70.25
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.095,
+      "phase": 19.26
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.045,
+      "phase": 62.55
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.154,
+      "phase": 36.13
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.102,
+      "phase": 350.66
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 32.01
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.02,
+      "phase": 325.49
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 344.86
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 91.71
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 254.01
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 59.24
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.012,
+      "phase": 348.28
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 356.95
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 21.34
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 49.29
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 64.05
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 90.06
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 19.34
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 296.45
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 213.94
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 156.61
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 321.73
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 322.87
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 73.43
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 119.86
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 295.74
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 325.19
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 312.97
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 65.82
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 260.6
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 193.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 4.73
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 0.17
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 118.41
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 111.37
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 48.41
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.002,
+      "phase": 170.74
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 128.16
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 100.7
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 227.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 154.23
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.042,
+      "phase": 9.29
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.025,
+      "phase": 215.42
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 323.31
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 24.81
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 255.52
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 96.32
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 187.56
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/sano2.json
+++ b/data/ioc/sano2.json
@@ -1,0 +1,289 @@
+{
+  "name": "San_Antonio",
+  "region": "Valparaiso",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -33.581625,
+  "longitude": -71.618188,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=sano2",
+    "id": "sano2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.793,
+    "MHHW": 5.364,
+    "MHW": 5.185,
+    "MSL": 4.753,
+    "MTL": 4.754,
+    "MLW": 4.323,
+    "MLLW": 4.295,
+    "LAT": 3.917,
+    "MHWS": 5.326,
+    "MLWS": 4.18
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.425,
+      "phase": 48.99
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.148,
+      "phase": 70.25
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.095,
+      "phase": 19.26
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.045,
+      "phase": 62.55
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.154,
+      "phase": 36.13
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.102,
+      "phase": 350.66
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 32.01
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.02,
+      "phase": 325.49
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 344.86
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 91.71
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 254.01
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 59.24
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.012,
+      "phase": 348.28
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.021,
+      "phase": 356.95
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 21.34
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 49.29
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 64.05
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 90.06
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 19.34
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 296.45
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 213.94
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 156.61
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 321.73
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 322.87
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 73.43
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 119.86
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 295.74
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 325.19
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 312.97
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 65.82
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 260.6
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 193.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 4.73
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 0.17
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 118.41
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 111.37
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 48.41
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.002,
+      "phase": 170.74
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 128.16
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.002,
+      "phase": 100.7
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 227.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 154.23
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.042,
+      "phase": 9.29
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.025,
+      "phase": 215.42
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 323.31
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 24.81
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 255.52
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 96.32
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 187.56
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/sema.json
+++ b/data/ioc/sema.json
@@ -1,0 +1,289 @@
+{
+  "name": "Semarang",
+  "region": "Central Java",
+  "country": "Indonesia",
+  "continent": "Asia",
+  "latitude": -6.9479,
+  "longitude": 110.42012,
+  "timezone": "Asia/Jakarta",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=sema",
+    "id": "sema",
+    "published_harmonics": false,
+    "operator": "Geospacial Agency of Indonesia ( Indonesia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Geospacial Agency of Indonesia ( Indonesia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.174,
+    "MHHW": 1.728,
+    "MHW": 1.529,
+    "MSL": 1.407,
+    "MTL": 1.392,
+    "MLW": 1.255,
+    "MLLW": 1.129,
+    "LAT": 0.809,
+    "MHWS": 1.575,
+    "MLWS": 1.239
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.094,
+      "phase": 45.47
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.074,
+      "phase": 291.38
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.037,
+      "phase": 12.37
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.033,
+      "phase": 326.88
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.208,
+      "phase": 240.79
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.066,
+      "phase": 128.92
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.059,
+      "phase": 241.43
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.011,
+      "phase": 39.48
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 109.13
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.004,
+      "phase": 124.7
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 118.65
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 180.88
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 318.04
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 277.72
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.009,
+      "phase": 16.07
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.003,
+      "phase": 89.91
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 123.91
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.01,
+      "phase": 296.58
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 188.17
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 170.89
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.015,
+      "phase": 114.35
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.015,
+      "phase": 22.4
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.016,
+      "phase": 207
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 242.96
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.014,
+      "phase": 306.16
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.011,
+      "phase": 297.61
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 1.3
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 27.22
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 181.1
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 259.84
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 62.15
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 132.42
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 90.99
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 29.3
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 276.41
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.005,
+      "phase": 226.16
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.004,
+      "phase": 130
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 100.63
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.014,
+      "phase": 359.17
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.019,
+      "phase": 83.51
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.008,
+      "phase": 15.71
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 99.23
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.204,
+      "phase": 182.92
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.088,
+      "phase": 98.35
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 312.29
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 180.06
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 63.11
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 358.92
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 107.78
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/shek.json
+++ b/data/ioc/shek.json
@@ -1,0 +1,289 @@
+{
+  "name": "Shek Pik",
+  "region": "Islands",
+  "country": "Hong Kong",
+  "continent": "Asia",
+  "latitude": 22.220278,
+  "longitude": 113.894444,
+  "timezone": "Asia/Hong_Kong",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=shek",
+    "id": "shek",
+    "published_harmonics": false,
+    "operator": "Hong Kong Observatory ( Hong Kong - China )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Hong Kong Observatory ( Hong Kong - China )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.939,
+    "MHHW": 2.264,
+    "MHW": 1.969,
+    "MSL": 1.458,
+    "MTL": 1.458,
+    "MLW": 0.947,
+    "MLLW": 0.808,
+    "LAT": -0.039,
+    "MHWS": 2.068,
+    "MLWS": 0.848
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.438,
+      "phase": 27.93
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.172,
+      "phase": 48.28
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.093,
+      "phase": 16.33
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.053,
+      "phase": 46.1
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.376,
+      "phase": 171.97
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.297,
+      "phase": 132.63
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.116,
+      "phase": 167.21
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.057,
+      "phase": 115.41
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.039,
+      "phase": 217.77
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.025,
+      "phase": 263.73
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.015,
+      "phase": 189.43
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 147.8
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.012,
+      "phase": 359.77
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 340.03
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 21.22
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 41.37
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.01,
+      "phase": 38.98
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 260.6
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 32.22
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 138.62
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 283.89
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 126.7
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 7.52
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 114.81
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.013,
+      "phase": 187.12
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 242.68
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.008,
+      "phase": 106.4
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.011,
+      "phase": 113.51
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.006,
+      "phase": 130.24
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.016,
+      "phase": 163.63
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 85.88
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 297.06
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 158.89
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 255.07
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 208.96
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 64.9
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.004,
+      "phase": 29.8
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.015,
+      "phase": 25.78
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.002,
+      "phase": 40.86
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.02,
+      "phase": 44.37
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 264.47
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 105.29
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.119,
+      "phase": 228.54
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.063,
+      "phase": 72.51
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 310.72
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 98.28
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 37.05
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 350.12
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.007,
+      "phase": 94.78
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/shen.json
+++ b/data/ioc/shen.json
@@ -1,0 +1,290 @@
+{
+  "name": "Shenzhen",
+  "region": "Guangdong",
+  "country": "China",
+  "continent": "Asia",
+  "latitude": 22.47,
+  "longitude": 113.88,
+  "timezone": "Asia/Shanghai",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=shen",
+    "id": "shen",
+    "published_harmonics": false,
+    "operator": "China Meteorological Administration ( China )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (China Meteorological Administration ( China )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.255,
+    "MHHW": 2.689,
+    "MHW": 2.378,
+    "MSL": 1.986,
+    "MTL": 2.06,
+    "MLW": 1.742,
+    "MLLW": 1.274,
+    "LAT": 0.694,
+    "MHWS": 2.462,
+    "MLWS": 1.51,
+    "TLT": 0.756
+  },
+  "datums_source": "observed",
+  "chart_datum": "TLT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.341,
+      "phase": 15.71
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.135,
+      "phase": 30.73
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.074,
+      "phase": 5.97
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.041,
+      "phase": 28.14
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.345,
+      "phase": 169.83
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.273,
+      "phase": 131.25
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.109,
+      "phase": 164.87
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.053,
+      "phase": 114.56
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.086,
+      "phase": 150.22
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.057,
+      "phase": 205.78
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.029,
+      "phase": 114.08
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.034,
+      "phase": 82.52
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 354.52
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 328.01
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.01,
+      "phase": 7.36
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 31.67
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 29.49
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 254.56
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0,
+      "phase": 77.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 111.9
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 261.39
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 10.45
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 349.44
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 124.63
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.013,
+      "phase": 185.82
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 238.03
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.008,
+      "phase": 106.12
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.01,
+      "phase": 111.53
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.006,
+      "phase": 108.18
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.017,
+      "phase": 130.18
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 352.5
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.007,
+      "phase": 254.29
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.006,
+      "phase": 81.11
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 101.89
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.033,
+      "phase": 136.79
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.007,
+      "phase": 301.72
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.004,
+      "phase": 269.42
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.017,
+      "phase": 15.36
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 106.55
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.022,
+      "phase": 56.65
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 102.73
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 58.76
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.115,
+      "phase": 219.3
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.051,
+      "phase": 56.58
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 305.9
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 80.36
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 20.83
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.005,
+      "phase": 318.38
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.012,
+      "phase": 67.23
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-07",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/sipa.json
+++ b/data/ioc/sipa.json
@@ -1,0 +1,289 @@
+{
+  "name": "Sipacate",
+  "region": "Escuintla",
+  "country": "Guatemala",
+  "continent": "Americas",
+  "latitude": 13.920126,
+  "longitude": -91.083132,
+  "timezone": "America/Guatemala",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=sipa",
+    "id": "sipa",
+    "published_harmonics": false,
+    "operator": "Instituto Nacional de Sismología, Vulcanología, Meteorología e Hidrología ( Guatemala )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Instituto Nacional de Sismología, Vulcanología, Meteorología e Hidrología ( Guatemala )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.842,
+    "MHHW": 2.298,
+    "MHW": 2.183,
+    "MSL": 1.501,
+    "MTL": 1.497,
+    "MLW": 0.811,
+    "MLLW": 0.769,
+    "LAT": 0.248,
+    "MHWS": 2.342,
+    "MLWS": 0.66
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.7,
+      "phase": 229.35
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.141,
+      "phase": 299.04
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.159,
+      "phase": 194.17
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.033,
+      "phase": 291.47
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.097,
+      "phase": 92.06
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.057,
+      "phase": 119.83
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.03,
+      "phase": 91.11
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 133.74
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 25.75
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 144.92
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 323.79
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 140.14
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.02,
+      "phase": 162.41
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.028,
+      "phase": 165.92
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.027,
+      "phase": 199.06
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.016,
+      "phase": 231.19
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.011,
+      "phase": 318.88
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 298.13
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 284.46
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 230.64
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 348.24
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 348.18
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.01,
+      "phase": 163.93
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 129.04
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 102.47
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 108.51
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 110
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 121.43
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 147.97
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 253.96
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 297.24
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 181.67
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 224.82
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 128.12
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 129.76
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 269.2
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 114.52
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 343.78
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 21.5
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.012,
+      "phase": 228.85
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 1.39
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 257.06
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.118,
+      "phase": 110.84
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.037,
+      "phase": 166.49
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 137.88
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 215.73
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.009,
+      "phase": 295.64
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 69.49
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 196.41
+    }
+  ],
+  "epoch": {
+    "start": "2025-01-30",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/slor.json
+++ b/data/ioc/slor.json
@@ -1,0 +1,289 @@
+{
+  "name": "San Lorenzo",
+  "region": "Esmeraldas",
+  "country": "Ecuador",
+  "continent": "Americas",
+  "latitude": 1.293352,
+  "longitude": -78.836194,
+  "timezone": "America/Guayaquil",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=slor",
+    "id": "slor",
+    "published_harmonics": false,
+    "operator": "Instituto Oceanográfico y Antártico de la Armada ( Ecuador )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Instituto Oceanográfico y Antártico de la Armada ( Ecuador )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.595,
+    "MHHW": 5.636,
+    "MHW": 5.558,
+    "MSL": 4.239,
+    "MTL": 4.261,
+    "MLW": 2.964,
+    "MLLW": 2.871,
+    "LAT": 2.004,
+    "MHWS": 5.907,
+    "MLWS": 2.571
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.305,
+      "phase": 239.92
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.363,
+      "phase": 297.05
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.283,
+      "phase": 210.75
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.095,
+      "phase": 291.92
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.113,
+      "phase": 51.61
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.019,
+      "phase": 56.2
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.034,
+      "phase": 51.46
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.004,
+      "phase": 173.22
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.04,
+      "phase": 163.95
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.021,
+      "phase": 233.1
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.016,
+      "phase": 147.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.032,
+      "phase": 95.9
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.036,
+      "phase": 186.44
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.05,
+      "phase": 210.64
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.05,
+      "phase": 213.75
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.032,
+      "phase": 259.72
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.02,
+      "phase": 293.52
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 241.42
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.013,
+      "phase": 216.86
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 131.59
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 166.51
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 103.73
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.018,
+      "phase": 168.8
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 71.43
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 85.49
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 91.7
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 123.94
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.001,
+      "phase": 200.55
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 112.83
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 192.14
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 332.91
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.006,
+      "phase": 299.81
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 138.15
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.011,
+      "phase": 113.1
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.018,
+      "phase": 156.58
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 280.73
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 157.57
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.017,
+      "phase": 27.67
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.017,
+      "phase": 44.56
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 84.55
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 82.34
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 323.32
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.057,
+      "phase": 96.73
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.062,
+      "phase": 132.4
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.013,
+      "phase": 201.5
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 265.82
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.015,
+      "phase": 17.25
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.007,
+      "phase": 29.72
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 135.03
+    }
+  ],
+  "epoch": {
+    "start": "2022-09-29",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/sobr.json
+++ b/data/ioc/sobr.json
@@ -1,0 +1,289 @@
+{
+  "name": "Sobra",
+  "region": "Dubrovnik-Neretva",
+  "country": "Croatia",
+  "continent": "Europe",
+  "latitude": 42.793,
+  "longitude": 17.62,
+  "timezone": "Europe/Zagreb",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=sobr",
+    "id": "sobr",
+    "published_harmonics": false,
+    "operator": "Institute of Oceanography and Fisheries ( Croatia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Institute of Oceanography and Fisheries ( Croatia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.337,
+    "MHHW": 0.155,
+    "MHW": 0.1,
+    "MSL": -0.003,
+    "MTL": 0.005,
+    "MLW": -0.09,
+    "MLLW": -0.128,
+    "LAT": -0.291,
+    "MHWS": 0.153,
+    "MLWS": -0.159
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.096,
+      "phase": 64.5
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.06,
+      "phase": 68.87
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.016,
+      "phase": 64.14
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.018,
+      "phase": 63.36
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.052,
+      "phase": 33.62
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.018,
+      "phase": 22.72
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.017,
+      "phase": 32.66
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 48.16
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 224.33
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 263.22
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 192.35
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 135.27
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.002,
+      "phase": 68.35
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 68.43
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.003,
+      "phase": 70.46
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.003,
+      "phase": 62.58
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 85.02
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 144.07
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 61.37
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 252.54
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 277.31
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 262.41
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 22.21
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 16.36
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.003,
+      "phase": 59.7
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.002,
+      "phase": 64.34
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 54.94
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0,
+      "phase": 3.31
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 58.76
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 26.4
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 75.96
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 275.68
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 122.77
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 17.11
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 186.55
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 209.26
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 236.27
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.007,
+      "phase": 295.28
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.003,
+      "phase": 159.01
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 313.36
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 139.45
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 133.16
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.06,
+      "phase": 211.82
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.03,
+      "phase": 146.9
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 77.37
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 280.56
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 126.73
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 25.75
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 125.92
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/sole.json
+++ b/data/ioc/sole.json
@@ -1,0 +1,289 @@
+{
+  "name": "Solenzara",
+  "region": "Corsica",
+  "country": "France",
+  "continent": "Europe",
+  "latitude": 41.8358,
+  "longitude": 9.3738,
+  "timezone": "Europe/Paris",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=sole",
+    "id": "sole",
+    "published_harmonics": false,
+    "operator": "Service hydrographique et océanographique de la marine ( France )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Service hydrographique et océanographique de la marine ( France )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.899,
+    "MHHW": 0.732,
+    "MHW": 0.723,
+    "MSL": 0.622,
+    "MTL": 0.622,
+    "MLW": 0.52,
+    "MLLW": 0.501,
+    "LAT": 0.325,
+    "MHWS": 0.762,
+    "MLWS": 0.482
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.103,
+      "phase": 213.35
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.037,
+      "phase": 235.89
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.021,
+      "phase": 199.26
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.01,
+      "phase": 231.81
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.025,
+      "phase": 175.5
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.014,
+      "phase": 91.91
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.008,
+      "phase": 169.69
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 26.79
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 101.65
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 153.82
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 63.69
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 269.21
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.003,
+      "phase": 187.08
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 175.59
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.004,
+      "phase": 204.46
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.002,
+      "phase": 221.63
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 231.14
+    },
+    {
+      "name": "R2",
+      "amplitude": 0,
+      "phase": 276.92
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 221.18
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 344.38
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0,
+      "phase": 125.06
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 132.4
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 3.71
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 96.62
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.001,
+      "phase": 207.74
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0,
+      "phase": 223.13
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 317.05
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0,
+      "phase": 20.9
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 298.01
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 152.09
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 273.44
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 90.93
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 12.65
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 40.69
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 180.94
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 203.17
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 350.48
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 238.04
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.001,
+      "phase": 214.2
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 112.56
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 92
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 43.91
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.08,
+      "phase": 168.67
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.018,
+      "phase": 112.46
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 163.76
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 242.68
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0,
+      "phase": 53.71
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 179.48
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 281.1
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/sole2.json
+++ b/data/ioc/sole2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Solenzara2",
+  "region": "Corsica",
+  "country": "France",
+  "continent": "Europe",
+  "latitude": 41.8358,
+  "longitude": 9.3738,
+  "timezone": "Europe/Paris",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=sole2",
+    "id": "sole2",
+    "published_harmonics": false,
+    "operator": "Service hydrographique et océanographique de la marine ( France )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Service hydrographique et océanographique de la marine ( France )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.899,
+    "MHHW": 0.732,
+    "MHW": 0.723,
+    "MSL": 0.622,
+    "MTL": 0.622,
+    "MLW": 0.52,
+    "MLLW": 0.501,
+    "LAT": 0.325,
+    "MHWS": 0.762,
+    "MLWS": 0.482
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.103,
+      "phase": 213.35
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.037,
+      "phase": 235.89
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.021,
+      "phase": 199.26
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.01,
+      "phase": 231.81
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.025,
+      "phase": 175.5
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.014,
+      "phase": 91.91
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.008,
+      "phase": 169.69
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 26.79
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 101.65
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 153.82
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 63.69
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 269.21
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.003,
+      "phase": 187.08
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 175.59
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.004,
+      "phase": 204.46
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.002,
+      "phase": 221.63
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 231.14
+    },
+    {
+      "name": "R2",
+      "amplitude": 0,
+      "phase": 276.92
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 221.18
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 344.38
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0,
+      "phase": 125.06
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 132.4
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 3.71
+    },
+    {
+      "name": "M1",
+      "amplitude": 0,
+      "phase": 96.62
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.001,
+      "phase": 207.74
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0,
+      "phase": 223.13
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 317.05
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0,
+      "phase": 20.9
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 298.01
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 152.09
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 273.44
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 90.93
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 12.65
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 40.69
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 180.94
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 203.17
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 350.48
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 238.04
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.001,
+      "phase": 214.2
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 112.56
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 92
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 43.91
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.08,
+      "phase": 168.67
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.018,
+      "phase": 112.46
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 163.76
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 242.68
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0,
+      "phase": 53.71
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 179.48
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 281.1
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/spjy.json
+++ b/data/ioc/spjy.json
@@ -1,0 +1,289 @@
+{
+  "name": "Southport_Jetty",
+  "region": "Tasmania",
+  "country": "Australia",
+  "continent": "Oceania",
+  "latitude": -43.4333,
+  "longitude": 146.9748,
+  "timezone": "Australia/Hobart",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=spjy",
+    "id": "spjy",
+    "published_harmonics": false,
+    "operator": "National Tidal Centre/Australian Bureau of Meteorology ( Australia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Tidal Centre/Australian Bureau of Meteorology ( Australia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.353,
+    "MHHW": 0.991,
+    "MHW": 0.916,
+    "MSL": 0.714,
+    "MTL": 0.706,
+    "MLW": 0.496,
+    "MLLW": 0.309,
+    "LAT": -0.032,
+    "MHWS": 0.901,
+    "MLWS": 0.527
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.157,
+      "phase": 292.43
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.03,
+      "phase": 154.51
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.054,
+      "phase": 272.55
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.009,
+      "phase": 171.77
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.215,
+      "phase": 271.52
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.148,
+      "phase": 251.91
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.065,
+      "phase": 268.12
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.035,
+      "phase": 236.87
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 229.32
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 242.66
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 218.74
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 145.88
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 237.06
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.012,
+      "phase": 250.95
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.009,
+      "phase": 278.09
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.002,
+      "phase": 292.41
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 112.28
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 109.37
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 240.1
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 124.02
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 48.13
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 103.81
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 359.79
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 240.73
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.011,
+      "phase": 293.06
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.01,
+      "phase": 319.26
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 203.76
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 240.64
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.006,
+      "phase": 215.94
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 190.18
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 130.2
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 175.51
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 209.93
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 213.6
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 287.67
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 347.91
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 318.7
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 218.66
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 152.69
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 24.83
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 31.02
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 79.98
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.05,
+      "phase": 109.52
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.012,
+      "phase": 152.16
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 232.34
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 319.57
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 50.97
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 239.13
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 331.83
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/stari.json
+++ b/data/ioc/stari.json
@@ -1,0 +1,289 @@
+{
+  "name": "Stari Grad",
+  "region": "Split-Dalmatia",
+  "country": "Croatia",
+  "continent": "Europe",
+  "latitude": 43.181,
+  "longitude": 16.576,
+  "timezone": "Europe/Zagreb",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=stari",
+    "id": "stari",
+    "published_harmonics": false,
+    "operator": "Institute of Oceanography and Fisheries ( Croatia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Institute of Oceanography and Fisheries ( Croatia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.279,
+    "MHHW": 0.099,
+    "MHW": 0.027,
+    "MSL": -0.07,
+    "MTL": -0.066,
+    "MLW": -0.159,
+    "MLLW": -0.208,
+    "LAT": -0.354,
+    "MHWS": 0.061,
+    "MLWS": -0.201
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.077,
+      "phase": 79.62
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.054,
+      "phase": 80.43
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.012,
+      "phase": 81.02
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.016,
+      "phase": 74.69
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.082,
+      "phase": 33.33
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.026,
+      "phase": 22.93
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.027,
+      "phase": 30.81
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.004,
+      "phase": 44.41
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 300.9
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 352.65
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 261.57
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 271.22
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.001,
+      "phase": 91.04
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.002,
+      "phase": 97.14
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.002,
+      "phase": 92.87
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.003,
+      "phase": 76.17
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 96.8
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 152.51
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 74.15
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 248.7
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 298.37
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 318.27
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 40.12
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 20.76
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 56.94
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 63.35
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 49.51
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0,
+      "phase": 22.47
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 47.44
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 120.26
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 283.42
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 351.64
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 206.71
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 18.16
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 319.96
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 17.69
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 86.86
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 296.68
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.003,
+      "phase": 161.78
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 295.75
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 12.01
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 112.78
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.059,
+      "phase": 209.11
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.032,
+      "phase": 144.24
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 103.04
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 60.05
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 132.83
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 131.77
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 231.96
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/stlu3.json
+++ b/data/ioc/stlu3.json
@@ -1,0 +1,289 @@
+{
+  "name": "Soufriere",
+  "region": "Soufriere",
+  "country": "Saint Lucia",
+  "continent": "Americas",
+  "latitude": 13.8535,
+  "longitude": -61.0596,
+  "timezone": "America/St_Lucia",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=stlu3",
+    "id": "stlu3",
+    "published_harmonics": false,
+    "operator": "Saint Lucia Met Service ( Saint Lucia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Saint Lucia Met Service ( Saint Lucia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.185,
+    "MHHW": 3.061,
+    "MHW": 2.981,
+    "MSL": 2.906,
+    "MTL": 2.915,
+    "MLW": 2.85,
+    "MLLW": 2.785,
+    "LAT": 2.577,
+    "MHWS": 2.962,
+    "MLWS": 2.85
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.044,
+      "phase": 167.93
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.012,
+      "phase": 203.26
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.013,
+      "phase": 153.25
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.003,
+      "phase": 205.13
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.085,
+      "phase": 231.09
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.064,
+      "phase": 222.77
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.026,
+      "phase": 231.58
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 205.05
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.007,
+      "phase": 296.73
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 329.74
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 267.06
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 236.32
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.002,
+      "phase": 135.03
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 132.13
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.004,
+      "phase": 139.47
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 63.22
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 198.23
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 196.13
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.001,
+      "phase": 208.82
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 319.62
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.022,
+      "phase": 214.51
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 184.65
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 144.74
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 231.93
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 234.03
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 236.68
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 200.94
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 210.25
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 206.75
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 138.59
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 80.96
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 60.15
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 301
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 189.54
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 316.86
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 51.68
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 132.49
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.005,
+      "phase": 326.86
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.014,
+      "phase": 0.4
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 296.76
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 7.17
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 83.81
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.066,
+      "phase": 147.71
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.015,
+      "phase": 32.41
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 125.42
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 228.51
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 174.11
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 250.59
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 311.46
+    }
+  ],
+  "epoch": {
+    "start": "2021-10-20",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/subi.json
+++ b/data/ioc/subi.json
@@ -1,0 +1,289 @@
+{
+  "name": "Subic_Bay",
+  "region": "Central Luzon",
+  "country": "Philippines",
+  "continent": "Asia",
+  "latitude": 14.8167,
+  "longitude": 120.2833,
+  "timezone": "Asia/Manila",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=subi",
+    "id": "subi",
+    "published_harmonics": false,
+    "operator": "National Mapping and Resource Information Authority ( Philippines )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Mapping and Resource Information Authority ( Philippines )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.355,
+    "MHHW": 6.672,
+    "MHW": 6.743,
+    "MSL": 6.025,
+    "MTL": 6.481,
+    "MLW": 6.219,
+    "MLLW": 5.598,
+    "LAT": 4.832,
+    "MHWS": 6.251,
+    "MLWS": 5.799
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLLW",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.124,
+      "phase": 45.72
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.102,
+      "phase": 78.1
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.026,
+      "phase": 32.86
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.041,
+      "phase": 108.26
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.255,
+      "phase": 185.2
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.18,
+      "phase": 149.14
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.076,
+      "phase": 186.18
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.032,
+      "phase": 137.71
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 247.6
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 93
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 226.29
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 100.69
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.002,
+      "phase": 26.85
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.006,
+      "phase": 32.77
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.006,
+      "phase": 50.59
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.005,
+      "phase": 160.49
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 189.68
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.01,
+      "phase": 161.01
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 275.25
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 0.43
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 48.89
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.01,
+      "phase": 46.24
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.127,
+      "phase": 255.85
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 162.5
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 140.88
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 263.64
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.007,
+      "phase": 19.63
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 221.56
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 242.02
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 27.03
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.037,
+      "phase": 48.64
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.029,
+      "phase": 65.09
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 178.64
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 174.23
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 136.35
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.004,
+      "phase": 28.5
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 88.65
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.108,
+      "phase": 86.8
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.02,
+      "phase": 119.43
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.047,
+      "phase": 16.72
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.023,
+      "phase": 213.77
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.023,
+      "phase": 209.39
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.385,
+      "phase": 193.69
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.196,
+      "phase": 137.22
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 262.87
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 116.55
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 309.23
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.015,
+      "phase": 88.99
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.011,
+      "phase": 176.94
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-03"
+  }
+}

--- a/data/ioc/syro.json
+++ b/data/ioc/syro.json
@@ -1,0 +1,289 @@
+{
+  "name": "Syros",
+  "region": "South Aegean",
+  "country": "Greece",
+  "continent": "Europe",
+  "latitude": 37.438,
+  "longitude": 24.9411,
+  "timezone": "Europe/Athens",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=syro",
+    "id": "syro",
+    "published_harmonics": false,
+    "operator": "Hellenic Navy Hydrographic Service ( Greece )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Hellenic Navy Hydrographic Service ( Greece )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 0.408,
+    "MHHW": 0.026,
+    "MHW": 0.026,
+    "MSL": 0,
+    "MTL": -0.002,
+    "MLW": -0.029,
+    "MLLW": -0.029,
+    "LAT": -0.376,
+    "MHWS": 0.024,
+    "MLWS": -0.024
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.015,
+      "phase": 31.98
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.009,
+      "phase": 342.66
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.005,
+      "phase": 6.9
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.002,
+      "phase": 26.78
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.029,
+      "phase": 322.61
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.004,
+      "phase": 277.75
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.006,
+      "phase": 318.83
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.008,
+      "phase": 198.9
+    },
+    {
+      "name": "M4",
+      "amplitude": 0,
+      "phase": 175.71
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 160.77
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 345.34
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 79.7
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 5.28
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 147.87
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.001,
+      "phase": 351.9
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.003,
+      "phase": 164.51
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.004,
+      "phase": 77.69
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 312.86
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 16.36
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 8.49
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.001,
+      "phase": 12.43
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 305.27
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 201.45
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 156.14
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.003,
+      "phase": 6.49
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 51.92
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.008,
+      "phase": 352.72
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 39.08
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 27.34
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.002,
+      "phase": 259.65
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 232.78
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 228.97
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 256.12
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 321.01
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 186.84
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 130.28
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 64.77
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.096,
+      "phase": 231.94
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 336.59
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.073,
+      "phase": 320.2
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.032,
+      "phase": 278.49
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.031,
+      "phase": 157.76
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.033,
+      "phase": 256.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.108,
+      "phase": 149.72
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 288.77
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 263.53
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 93.77
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 103.95
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 336.41
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-26",
+    "end": "2026-05-19"
+  }
+}

--- a/data/ioc/talc.json
+++ b/data/ioc/talc.json
@@ -1,0 +1,289 @@
+{
+  "name": "Talcahuano",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -36.700933,
+  "longitude": -73.105992,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=talc",
+    "id": "talc",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.846,
+    "MHHW": 5.363,
+    "MHW": 5.162,
+    "MSL": 4.714,
+    "MTL": 4.716,
+    "MLW": 4.271,
+    "MLLW": 4.212,
+    "LAT": 3.817,
+    "MHWS": 5.328,
+    "MLWS": 4.1
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.451,
+      "phase": 60.12
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.163,
+      "phase": 78.85
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.104,
+      "phase": 31.7
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.049,
+      "phase": 71.7
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.16,
+      "phase": 38.76
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.108,
+      "phase": 354.86
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 35.15
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 330.05
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 350.29
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 352.32
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 264.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 81.94
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 1.74
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 8.5
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 33.93
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 57.69
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 68.79
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 100.83
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 30.96
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 305.15
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 237.44
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 253.53
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 14.05
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 329.64
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 78.77
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 124.94
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 291.71
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 328.61
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 320.82
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 108.57
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 278.31
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 198.13
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 198.19
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 305.97
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 136.02
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 109.91
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 65.88
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 163.31
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 148.89
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 93.91
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 238.54
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 46.44
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.046,
+      "phase": 56.82
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.036,
+      "phase": 219.02
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 336.07
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 61.32
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 278.02
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 87.33
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 185.6
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/talc2.json
+++ b/data/ioc/talc2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Talcahuano",
+  "region": "Biobio",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -36.700933,
+  "longitude": -73.105992,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=talc2",
+    "id": "talc2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 5.846,
+    "MHHW": 5.363,
+    "MHW": 5.162,
+    "MSL": 4.714,
+    "MTL": 4.716,
+    "MLW": 4.271,
+    "MLLW": 4.212,
+    "LAT": 3.817,
+    "MHWS": 5.328,
+    "MLWS": 4.1
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.451,
+      "phase": 60.12
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.163,
+      "phase": 78.85
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.104,
+      "phase": 31.7
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.049,
+      "phase": 71.7
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.16,
+      "phase": 38.76
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.108,
+      "phase": 354.86
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.049,
+      "phase": 35.15
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 330.05
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 350.29
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 352.32
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 264.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 81.94
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 1.74
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.022,
+      "phase": 8.5
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 33.93
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.009,
+      "phase": 57.69
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 68.79
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 100.83
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 30.96
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 305.15
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 237.44
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 253.53
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 14.05
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 329.64
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 78.77
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 124.94
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 291.71
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 328.61
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 320.82
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 108.57
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 278.31
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 198.13
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 198.19
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 305.97
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 136.02
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 109.91
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 65.88
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 163.31
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.009,
+      "phase": 148.89
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 93.91
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 238.54
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 46.44
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.046,
+      "phase": 56.82
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.036,
+      "phase": 219.02
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 336.07
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 61.32
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 278.02
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 87.33
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 185.6
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/talt.json
+++ b/data/ioc/talt.json
@@ -1,0 +1,289 @@
+{
+  "name": "Taltal",
+  "region": "Antofagasta",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -25.407269,
+  "longitude": -70.48979433,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=talt",
+    "id": "talt",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.324,
+    "MHHW": 5.857,
+    "MHW": 5.69,
+    "MSL": 5.307,
+    "MTL": 5.304,
+    "MLW": 4.918,
+    "MLLW": 4.903,
+    "LAT": 4.585,
+    "MHWS": 5.804,
+    "MLWS": 4.81
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.378,
+      "phase": 26.81
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.119,
+      "phase": 49.5
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.082,
+      "phase": 352
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.037,
+      "phase": 40.25
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.151,
+      "phase": 26.82
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.09,
+      "phase": 343.58
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.047,
+      "phase": 22.49
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.017,
+      "phase": 320.46
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 322.12
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 107.04
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 232.78
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 134.2
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 317.58
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 334.96
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 353.34
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 24.98
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 52.21
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 78.53
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 336.75
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 272.76
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 189.25
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 169.59
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 167.74
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 334.45
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 64.91
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 105.63
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 285.54
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 327.85
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 323.7
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 45.82
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 206.02
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 61.79
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 7.32
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 4.43
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 4.15
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 112.37
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 118.13
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 28.98
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 70.92
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 325.76
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 159.22
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 175.49
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.079,
+      "phase": 274.09
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.038,
+      "phase": 188.07
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 298.65
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 43.94
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 228.92
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 163.46
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 253.7
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/talt2.json
+++ b/data/ioc/talt2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Taltal",
+  "region": "Antofagasta",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -25.4072698,
+  "longitude": -70.48979433,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=talt2",
+    "id": "talt2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 6.324,
+    "MHHW": 5.857,
+    "MHW": 5.69,
+    "MSL": 5.307,
+    "MTL": 5.304,
+    "MLW": 4.918,
+    "MLLW": 4.903,
+    "LAT": 4.585,
+    "MHWS": 5.804,
+    "MLWS": 4.81
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.378,
+      "phase": 26.81
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.119,
+      "phase": 49.5
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.082,
+      "phase": 352
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.037,
+      "phase": 40.25
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.151,
+      "phase": 26.82
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.09,
+      "phase": 343.58
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.047,
+      "phase": 22.49
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.017,
+      "phase": 320.46
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 322.12
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 107.04
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 232.78
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 134.2
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 317.58
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.019,
+      "phase": 334.96
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 353.34
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 24.98
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 52.21
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 78.53
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 336.75
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 272.76
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 189.25
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 169.59
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 167.74
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 334.45
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 64.91
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 105.63
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 285.54
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 327.85
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 323.7
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 45.82
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 206.02
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 61.79
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 7.32
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 4.43
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 4.15
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 112.37
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 118.13
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.004,
+      "phase": 28.98
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 70.92
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 325.76
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 159.22
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 175.49
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.079,
+      "phase": 274.09
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.038,
+      "phase": 188.07
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 298.65
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0,
+      "phase": 43.94
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 228.92
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 163.46
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 253.7
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tanp.json
+++ b/data/ioc/tanp.json
@@ -1,0 +1,289 @@
+{
+  "name": "Anping",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 22.9883,
+  "longitude": 120.1497,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tanp",
+    "id": "tanp",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.158,
+    "MHHW": 0.804,
+    "MHW": 0.661,
+    "MSL": 0.381,
+    "MTL": 0.379,
+    "MLW": 0.098,
+    "MLLW": -0.089,
+    "LAT": -0.492,
+    "MHWS": 0.695,
+    "MLWS": 0.067
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.259,
+      "phase": 28.68
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.055,
+      "phase": 37.88
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.054,
+      "phase": 6.91
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.018,
+      "phase": 52.48
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.179,
+      "phase": 156.3
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.165,
+      "phase": 123.88
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.05,
+      "phase": 159
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.035,
+      "phase": 104.89
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.01,
+      "phase": 213.14
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 257.31
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 192.35
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 26.61
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 315.33
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.013,
+      "phase": 210.98
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.01,
+      "phase": 39.39
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.018,
+      "phase": 86.4
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 118.16
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.007,
+      "phase": 116.7
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.009,
+      "phase": 68.49
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 332.14
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 293.35
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.018,
+      "phase": 172.54
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 171.38
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 131.25
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 170.01
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 231.57
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 30.06
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 131.67
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 109.64
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 50.93
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 233.17
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 274.57
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 183.17
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 151.84
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 74.34
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 348.02
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 292.39
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.015,
+      "phase": 238
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.002,
+      "phase": 87.77
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 309.97
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 187.1
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 288.22
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.143,
+      "phase": 127.88
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.039,
+      "phase": 5.44
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 175.05
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 59.1
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 186.03
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 170.48
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 330.16
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tare.json
+++ b/data/ioc/tare.json
@@ -1,0 +1,288 @@
+{
+  "name": "Tarekukure_Wharf",
+  "region": "Choiseul Province",
+  "country": "Solomon Islands",
+  "continent": "Oceania",
+  "latitude": -6.6928,
+  "longitude": 156.4086,
+  "timezone": "Pacific/Guadalcanal",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tare",
+    "id": "tare",
+    "published_harmonics": false
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator. Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.726,
+    "MHHW": 1.298,
+    "MHW": 1.142,
+    "MSL": 0.791,
+    "MTL": 0.785,
+    "MLW": 0.428,
+    "MLLW": 0.339,
+    "LAT": -0.025,
+    "MHWS": 1.283,
+    "MLWS": 0.299
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.287,
+      "phase": 123.69
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.205,
+      "phase": 142.4
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.053,
+      "phase": 135.63
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.06,
+      "phase": 136.72
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.219,
+      "phase": 45.99
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.118,
+      "phase": 27.22
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.071,
+      "phase": 43.33
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.021,
+      "phase": 12.2
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.009,
+      "phase": 284.06
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 289.6
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 269.53
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 265.64
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 126.3
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.009,
+      "phase": 140.11
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.01,
+      "phase": 138.74
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 109.7
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.013,
+      "phase": 145.6
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 158.15
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 89.53
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 308.45
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 302.92
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 107.62
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 26.26
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 335.25
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.011,
+      "phase": 61.63
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 97.86
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 351.41
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 24.17
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 15.81
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 249.92
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 307.69
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 309.12
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 263.53
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 165.06
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 175.53
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 218.42
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 117.25
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.005,
+      "phase": 321.66
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.01,
+      "phase": 356.88
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.009,
+      "phase": 192.16
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 32.93
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.001,
+      "phase": 235.83
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.043,
+      "phase": 3.39
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.038,
+      "phase": 51.9
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 153.07
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 192.5
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 232.25
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 269.2
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 276.16
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tasw.json
+++ b/data/ioc/tasw.json
@@ -1,0 +1,289 @@
+{
+  "name": "Tasiilaq Harbour",
+  "region": "Sermersooq",
+  "country": "Greenland",
+  "continent": "Americas",
+  "latitude": 65.614,
+  "longitude": -37.626,
+  "timezone": "America/Nuuk",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tasw",
+    "id": "tasw",
+    "published_harmonics": false,
+    "operator": "Danish National Space Centre, Technical University of Denmark ( Denmark )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Danish National Space Centre, Technical University of Denmark ( Denmark )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.833,
+    "MHHW": 1.044,
+    "MHW": 0.948,
+    "MSL": -0.059,
+    "MTL": -0.062,
+    "MLW": -1.071,
+    "MLLW": -1.169,
+    "LAT": -1.974,
+    "MHWS": 1.313,
+    "MLWS": -1.431
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.98,
+      "phase": 185.01
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.392,
+      "phase": 222.9
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.191,
+      "phase": 164.13
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.111,
+      "phase": 220.59
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.144,
+      "phase": 142.04
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.066,
+      "phase": 104.04
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.044,
+      "phase": 135.64
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.007,
+      "phase": 59.32
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.009,
+      "phase": 199.65
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.006,
+      "phase": 268.94
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 168.28
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 116.38
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.027,
+      "phase": 145.47
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.029,
+      "phase": 136.49
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.036,
+      "phase": 166.68
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.026,
+      "phase": 194.35
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.022,
+      "phase": 218.19
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.005,
+      "phase": 229.83
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 199.19
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 85.75
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 354.89
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 245.61
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 64.63
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 222.21
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 152.87
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 126.28
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 266.28
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.001,
+      "phase": 168.99
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 83.13
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 79.07
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 186.01
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 347.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 73.85
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 241.48
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.007,
+      "phase": 187.1
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 343.69
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 7.46
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.052,
+      "phase": 226.3
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 248.5
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 23.19
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.028,
+      "phase": 95.48
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.009,
+      "phase": 97.12
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.093,
+      "phase": 284.27
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.054,
+      "phase": 12.78
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 110.89
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 190.09
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 137.45
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 204.08
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 311.23
+    }
+  ],
+  "epoch": {
+    "start": "2025-08-14",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tboz.json
+++ b/data/ioc/tboz.json
@@ -1,0 +1,289 @@
+{
+  "name": "Bozihlia",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.6186,
+  "longitude": 120.1375,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tboz",
+    "id": "tboz",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 2.418,
+    "MHHW": 1.046,
+    "MHW": 0.458,
+    "MSL": 0,
+    "MTL": -0.205,
+    "MLW": -0.869,
+    "MLLW": -1.06,
+    "LAT": -3.109,
+    "MHWS": 1.177,
+    "MLWS": -1.177
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.96,
+      "phase": 84.04
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.217,
+      "phase": 133.92
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.13,
+      "phase": 20.98
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.074,
+      "phase": 132.03
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.244,
+      "phase": 146.25
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.259,
+      "phase": 120.24
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.241,
+      "phase": 147.79
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.054,
+      "phase": 159.37
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.034,
+      "phase": 114.74
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.014,
+      "phase": 22.96
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.036,
+      "phase": 163.35
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.109,
+      "phase": 82.31
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.05,
+      "phase": 326.05
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.089,
+      "phase": 220.89
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.016,
+      "phase": 105.93
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.151,
+      "phase": 106.62
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.03,
+      "phase": 337.76
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.078,
+      "phase": 166.57
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.034,
+      "phase": 13.91
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.059,
+      "phase": 315.71
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.061,
+      "phase": 351.09
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.089,
+      "phase": 239.98
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.091,
+      "phase": 203.8
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.055,
+      "phase": 65.05
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.015,
+      "phase": 23.47
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 26.2
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.025,
+      "phase": 223.24
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.093,
+      "phase": 206.28
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.029,
+      "phase": 328.05
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.033,
+      "phase": 146.31
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.011,
+      "phase": 259.22
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.025,
+      "phase": 259.48
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.028,
+      "phase": 330
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.024,
+      "phase": 356.04
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.081,
+      "phase": 125.39
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.05,
+      "phase": 152.05
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.03,
+      "phase": 74.05
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.125,
+      "phase": 119.55
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.095,
+      "phase": 353.02
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.049,
+      "phase": 308.03
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.056,
+      "phase": 305.73
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.016,
+      "phase": 213.39
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.583,
+      "phase": 78.13
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.268,
+      "phase": 297.51
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.075,
+      "phase": 274.61
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.005,
+      "phase": 94.54
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.09,
+      "phase": 181.04
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.047,
+      "phase": 83.15
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.013,
+      "phase": 85.5
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/tbwc.json
+++ b/data/ioc/tbwc.json
@@ -1,0 +1,289 @@
+{
+  "name": "Twofold_Bay",
+  "region": "New South Wales",
+  "country": "Australia",
+  "continent": "Oceania",
+  "latitude": -37.1003,
+  "longitude": 149.9266,
+  "timezone": "Australia/Sydney",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tbwc",
+    "id": "tbwc",
+    "published_harmonics": false,
+    "operator": "National Tidal Centre/Australian Bureau of Meteorology ( Australia )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Tidal Centre/Australian Bureau of Meteorology ( Australia )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 2.151,
+    "MHHW": 1.708,
+    "MHW": 1.543,
+    "MSL": 1.089,
+    "MTL": 1.088,
+    "MLW": 0.633,
+    "MLLW": 0.518,
+    "LAT": 0.149,
+    "MHWS": 1.639,
+    "MLWS": 0.539
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.449,
+      "phase": 294.53
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.101,
+      "phase": 306.69
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.103,
+      "phase": 285.43
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.031,
+      "phase": 294.17
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.176,
+      "phase": 312.61
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.107,
+      "phase": 280.32
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.053,
+      "phase": 306.53
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.025,
+      "phase": 261.62
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 218.45
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 274.61
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 186.09
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 201.24
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.019,
+      "phase": 265.6
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 277.5
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.019,
+      "phase": 286.15
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 296.31
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 331.84
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 231.91
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 275.35
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 176.85
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.005,
+      "phase": 77.28
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 11.65
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 248.08
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 277.04
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 336.64
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 12.28
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 232.35
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 260.58
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 230.56
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 80.05
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 82.65
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 43.11
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 193.59
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 141.27
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 268.14
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 207.44
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 74.58
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 221.24
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.008,
+      "phase": 138.87
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 65.38
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 97.08
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 144.87
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.038,
+      "phase": 78.54
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.03,
+      "phase": 122.38
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 258.83
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 18.07
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.006,
+      "phase": 73.54
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 265.68
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 352.25
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tche.json
+++ b/data/ioc/tche.json
@@ -1,0 +1,289 @@
+{
+  "name": "Chenggong",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.0972,
+  "longitude": 121.3799,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tche",
+    "id": "tche",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.353,
+    "MHHW": 0.866,
+    "MHW": 0.736,
+    "MSL": 0.29,
+    "MTL": 0.3,
+    "MLW": -0.136,
+    "MLLW": -0.228,
+    "LAT": -0.834,
+    "MHWS": 0.958,
+    "MLWS": -0.378
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.476,
+      "phase": 303.29
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.192,
+      "phase": 326.13
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.088,
+      "phase": 289.13
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.054,
+      "phase": 321.78
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.168,
+      "phase": 101.51
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.141,
+      "phase": 80.73
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.054,
+      "phase": 103.24
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.027,
+      "phase": 68.46
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 281.31
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 180.67
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 221.96
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 161.61
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.011,
+      "phase": 249.59
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.006,
+      "phase": 310.82
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 310.75
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.03,
+      "phase": 337.74
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 331.45
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.005,
+      "phase": 334.05
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.01,
+      "phase": 326.26
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 183.64
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.01,
+      "phase": 162.96
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.011,
+      "phase": 74.71
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 195.71
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 105.61
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 117.59
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 161.85
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 39.64
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 85.63
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 84.45
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 7.67
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 256.61
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 314.91
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 198.37
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 236.42
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 267.24
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 72.46
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 31.25
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 31.59
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.005,
+      "phase": 15.82
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.009,
+      "phase": 312.17
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 136.77
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.009,
+      "phase": 43.38
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.093,
+      "phase": 146.46
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.013,
+      "phase": 2.58
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 86.64
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.007,
+      "phase": 66.39
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.018,
+      "phase": 62.96
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 255.02
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 318.21
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tcim.json
+++ b/data/ioc/tcim.json
@@ -1,0 +1,289 @@
+{
+  "name": "Cimei",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.19,
+  "longitude": 119.42,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tcim",
+    "id": "tcim",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.247,
+    "MHHW": 0.753,
+    "MHW": 0.688,
+    "MSL": 0.136,
+    "MTL": 0.191,
+    "MLW": -0.306,
+    "MLLW": -0.587,
+    "LAT": -1.059,
+    "MHWS": 0.777,
+    "MLWS": -0.505
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.525,
+      "phase": 81.72
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.116,
+      "phase": 123.24
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.093,
+      "phase": 57.34
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.035,
+      "phase": 125.18
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.221,
+      "phase": 158.62
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.191,
+      "phase": 125.94
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.064,
+      "phase": 154.63
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.037,
+      "phase": 108.65
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.047,
+      "phase": 173.83
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.029,
+      "phase": 221.07
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.017,
+      "phase": 145.95
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 350.53
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 349.34
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.031,
+      "phase": 220.48
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.028,
+      "phase": 71.36
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.048,
+      "phase": 130.72
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 113.5
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.007,
+      "phase": 201.51
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.02,
+      "phase": 109.67
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.009,
+      "phase": 20.19
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.013,
+      "phase": 50.87
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.028,
+      "phase": 260.96
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 138.76
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 152.03
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 183.41
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 240.49
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 82.31
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 102.37
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 118.55
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 85.5
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 79.77
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 259.64
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 113.47
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 130.92
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 21.09
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 329.73
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 308.03
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.005,
+      "phase": 124.98
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.004,
+      "phase": 101.73
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.009,
+      "phase": 273.49
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.01,
+      "phase": 173.82
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 61.59
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.144,
+      "phase": 166.28
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.055,
+      "phase": 351.38
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.011,
+      "phase": 200.66
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 206.21
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.025,
+      "phase": 206.32
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 148.41
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 289.23
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tcsb.json
+++ b/data/ioc/tcsb.json
@@ -1,0 +1,288 @@
+{
+  "name": "Sapodilla Bay, Providenciales",
+  "country": "Turks and Caicos Islands",
+  "continent": "Americas",
+  "latitude": 21.741204,
+  "longitude": -72.284877,
+  "timezone": "America/Grand_Turk",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tcsb",
+    "id": "tcsb",
+    "published_harmonics": false,
+    "operator": "UK Hydrographic Office ( UK )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (UK Hydrographic Office ( UK )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.714,
+    "MHHW": 0.434,
+    "MHW": 0.342,
+    "MSL": 0.087,
+    "MTL": 0.084,
+    "MLW": -0.174,
+    "MLLW": -0.21,
+    "LAT": -0.558,
+    "MHWS": 0.382,
+    "MLWS": -0.208
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.254,
+      "phase": 15.09
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.041,
+      "phase": 44.78
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.057,
+      "phase": 354.28
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.011,
+      "phase": 40.69
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.078,
+      "phase": 210.48
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.058,
+      "phase": 209.24
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.023,
+      "phase": 207.9
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 198.9
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 293.95
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 300.77
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 297.9
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 26.03
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 335.91
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 10.54
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 354.39
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 12.99
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 17.57
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 29.24
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 14.79
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 53
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 313.65
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0,
+      "phase": 70.57
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 16.27
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 217.31
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 216.45
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 215.95
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 195.58
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 219.46
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0,
+      "phase": 171.96
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 243.03
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 272.46
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 260.94
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 304.25
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 52.88
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 79.97
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 226.12
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 210.6
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.014,
+      "phase": 138.59
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.013,
+      "phase": 3.23
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.011,
+      "phase": 40.12
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.003,
+      "phase": 354.78
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 54.73
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.131,
+      "phase": 144.16
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.089,
+      "phase": 116.02
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 17.97
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 261.62
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.003,
+      "phase": 336.24
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 257.16
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 356.52
+    }
+  ],
+  "epoch": {
+    "start": "2022-01-23",
+    "end": "2026-07-27"
+  }
+}

--- a/data/ioc/tdan.json
+++ b/data/ioc/tdan.json
@@ -1,0 +1,289 @@
+{
+  "name": "Danhai",
+  "region": "Taipei",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 25.1839,
+  "longitude": 121.4075,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tdan",
+    "id": "tdan",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 2.056,
+    "MHHW": 1.124,
+    "MHW": 1.124,
+    "MSL": 0,
+    "MTL": 0.031,
+    "MLW": -1.062,
+    "MLLW": -1.062,
+    "LAT": -1.915,
+    "MHWS": 1.305,
+    "MLWS": -1.305
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.024,
+      "phase": 79.43
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.281,
+      "phase": 112.76
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.158,
+      "phase": 44.38
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.091,
+      "phase": 134.02
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.199,
+      "phase": 118.28
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.149,
+      "phase": 102.54
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.052,
+      "phase": 135.3
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 89.14
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.03,
+      "phase": 139.73
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.017,
+      "phase": 181.56
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 96.08
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.007,
+      "phase": 142.15
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.038,
+      "phase": 346.29
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.1,
+      "phase": 224.37
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.027,
+      "phase": 145.9
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.216,
+      "phase": 130.2
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.035,
+      "phase": 233.2
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.046,
+      "phase": 146.07
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.057,
+      "phase": 118.39
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.045,
+      "phase": 324.86
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.056,
+      "phase": 297.76
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.05,
+      "phase": 223.02
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.017,
+      "phase": 145.75
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.013,
+      "phase": 56.47
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.014,
+      "phase": 330.72
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 278.72
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 313.58
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.01,
+      "phase": 194.78
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.014,
+      "phase": 255.4
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.01,
+      "phase": 272.05
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.011,
+      "phase": 200.56
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.008,
+      "phase": 335.39
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 27.49
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 279.47
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 98.82
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.009,
+      "phase": 229.76
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.004,
+      "phase": 101.25
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.017,
+      "phase": 16.24
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.019,
+      "phase": 315.72
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.011,
+      "phase": 274.04
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 94.67
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.019,
+      "phase": 319.95
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.194,
+      "phase": 130.83
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.032,
+      "phase": 332.73
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.036,
+      "phase": 226.39
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.021,
+      "phase": 169.64
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.17,
+      "phase": 201.33
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.009,
+      "phase": 204.19
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 53
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tdas.json
+++ b/data/ioc/tdas.json
@@ -1,0 +1,289 @@
+{
+  "name": "Danshuei",
+  "region": "Taipei",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 25.1757,
+  "longitude": 121.4248,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tdas",
+    "id": "tdas",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 1.683,
+    "MHHW": 0.901,
+    "MHW": 0.9,
+    "MSL": 0,
+    "MTL": 0.012,
+    "MLW": -0.876,
+    "MLLW": -0.874,
+    "LAT": -1.671,
+    "MHWS": 1.03,
+    "MLWS": -1.03
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.854,
+      "phase": 88.86
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.176,
+      "phase": 116.58
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.107,
+      "phase": 33.18
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.106,
+      "phase": 150.32
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.156,
+      "phase": 123.94
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.126,
+      "phase": 96.76
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.044,
+      "phase": 103.49
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.025,
+      "phase": 108.89
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.018,
+      "phase": 88.71
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.021,
+      "phase": 76.26
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.022,
+      "phase": 71.49
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.019,
+      "phase": 125.85
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 321.72
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.146,
+      "phase": 227.41
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.028,
+      "phase": 155.15
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.18,
+      "phase": 143.14
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.024,
+      "phase": 259.67
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.071,
+      "phase": 154.75
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.069,
+      "phase": 123.45
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.052,
+      "phase": 342.05
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.053,
+      "phase": 321.67
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.074,
+      "phase": 232.28
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.037,
+      "phase": 149.05
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.023,
+      "phase": 341.11
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.02,
+      "phase": 341.79
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.011,
+      "phase": 221.1
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.017,
+      "phase": 204.59
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.018,
+      "phase": 284.27
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.03,
+      "phase": 265.51
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.021,
+      "phase": 35.21
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.008,
+      "phase": 170
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.008,
+      "phase": 98.6
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.007,
+      "phase": 68.67
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.006,
+      "phase": 158.56
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.01,
+      "phase": 139.14
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.008,
+      "phase": 190.48
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 101.72
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.032,
+      "phase": 50.51
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.028,
+      "phase": 269.65
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.033,
+      "phase": 243.59
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.025,
+      "phase": 243.49
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.026,
+      "phase": 319.28
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.207,
+      "phase": 127.76
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.025,
+      "phase": 289.81
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.051,
+      "phase": 229.91
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.04,
+      "phase": 178.14
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.14,
+      "phase": 223.66
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.007,
+      "phase": 182.41
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.012,
+      "phase": 180.94
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tdog.json
+++ b/data/ioc/tdog.json
@@ -1,0 +1,289 @@
+{
+  "name": "Dongshih",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.45,
+  "longitude": 120.1394,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tdog",
+    "id": "tdog",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.577,
+    "MHHW": 1.063,
+    "MHW": 0.985,
+    "MSL": 0.399,
+    "MTL": 0.442,
+    "MLW": -0.101,
+    "MLLW": -0.187,
+    "LAT": -0.962,
+    "MHWS": 1.21,
+    "MLWS": -0.412
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.67,
+      "phase": 72.97
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.141,
+      "phase": 113.14
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.098,
+      "phase": 45.7
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.046,
+      "phase": 119.46
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.199,
+      "phase": 158.18
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.154,
+      "phase": 128.42
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.037,
+      "phase": 161.77
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.027,
+      "phase": 111.22
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.036,
+      "phase": 213.68
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.025,
+      "phase": 265.4
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.008,
+      "phase": 179.88
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.017,
+      "phase": 146.79
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.014,
+      "phase": 332.98
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.069,
+      "phase": 210.8
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.027,
+      "phase": 63.71
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.075,
+      "phase": 121.44
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 101.53
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.017,
+      "phase": 149.63
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.039,
+      "phase": 100.95
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.023,
+      "phase": 334.82
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.01,
+      "phase": 46.39
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.034,
+      "phase": 238.3
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.012,
+      "phase": 165.71
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 105.85
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 161.69
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 270.01
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 45.19
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 117.83
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.013,
+      "phase": 242.65
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 111.96
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.004,
+      "phase": 222.79
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.004,
+      "phase": 348.2
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 154.41
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 285.31
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.013,
+      "phase": 198.56
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.005,
+      "phase": 188.07
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 109.9
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.024,
+      "phase": 218.39
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.002,
+      "phase": 348.77
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.02,
+      "phase": 238.59
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 91.84
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.009,
+      "phase": 255.73
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.185,
+      "phase": 130.83
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.036,
+      "phase": 24.99
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.027,
+      "phase": 199.27
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.01,
+      "phase": 216.94
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.044,
+      "phase": 204.65
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 169.15
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.004,
+      "phase": 242.24
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tdoj.json
+++ b/data/ioc/tdoj.json
@@ -1,0 +1,289 @@
+{
+  "name": "Dongjidao",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.2546,
+  "longitude": 119.6678,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tdoj",
+    "id": "tdoj",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.155,
+    "MHHW": 0.774,
+    "MHW": 0.712,
+    "MSL": 0.151,
+    "MTL": 0.203,
+    "MLW": -0.306,
+    "MLLW": -0.571,
+    "LAT": -1.018,
+    "MHWS": 0.78,
+    "MLWS": -0.478
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.516,
+      "phase": 74.5
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.113,
+      "phase": 114.76
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.092,
+      "phase": 49.42
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.034,
+      "phase": 116.21
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.209,
+      "phase": 157.17
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.181,
+      "phase": 124.98
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.062,
+      "phase": 154.93
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.036,
+      "phase": 107.45
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.042,
+      "phase": 180.92
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.028,
+      "phase": 222.5
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.014,
+      "phase": 156.19
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 315.41
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.016,
+      "phase": 348.53
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.033,
+      "phase": 221.23
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.028,
+      "phase": 69.42
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.047,
+      "phase": 127.15
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 99.31
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.009,
+      "phase": 197.16
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.021,
+      "phase": 103.27
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.009,
+      "phase": 7.2
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.016,
+      "phase": 39.93
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.031,
+      "phase": 247
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 275.64
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 158.93
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 182.13
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 230.83
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 62.56
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 112.04
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 135.46
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 104.66
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 312.38
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.003,
+      "phase": 247.42
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 119.48
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.002,
+      "phase": 136.63
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 320.91
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 297.52
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 263.45
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 192.38
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.003,
+      "phase": 39.19
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.011,
+      "phase": 277.28
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.008,
+      "phase": 175.68
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 42.53
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.108,
+      "phase": 155.62
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.029,
+      "phase": 39.39
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.012,
+      "phase": 193.14
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 187.44
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.023,
+      "phase": 208.66
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 233.23
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 294.97
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tdon.json
+++ b/data/ioc/tdon.json
@@ -1,0 +1,289 @@
+{
+  "name": "Donggang",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 22.4651,
+  "longitude": 120.4383,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tdon",
+    "id": "tdon",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.365,
+    "MHHW": 0.924,
+    "MHW": 0.678,
+    "MSL": 0.435,
+    "MTL": 0.41,
+    "MLW": 0.143,
+    "MLLW": 0.047,
+    "LAT": -0.293,
+    "MHWS": 0.745,
+    "MLWS": 0.125
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.235,
+      "phase": 353.9
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.075,
+      "phase": 358.83
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.048,
+      "phase": 337.82
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.021,
+      "phase": 358.28
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.196,
+      "phase": 169.14
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.172,
+      "phase": 133.1
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.063,
+      "phase": 165.31
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.034,
+      "phase": 109.17
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.004,
+      "phase": 277.59
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 306.26
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 239.81
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 50.01
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 318.01
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 262.62
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.01,
+      "phase": 359.5
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 35.93
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 23.68
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.005,
+      "phase": 69
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.007,
+      "phase": 20.27
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 317.28
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 184.66
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.019,
+      "phase": 153.22
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.002,
+      "phase": 298.6
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 167.62
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 179.61
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 245.75
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 90.85
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 115.32
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 120.08
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 44.55
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 287.38
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 213.03
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 205.73
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 305.8
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 100.85
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 339.18
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 207.08
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 180.76
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 25.63
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.01,
+      "phase": 334.24
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 149.87
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0,
+      "phase": 57.03
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.118,
+      "phase": 145
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.029,
+      "phase": 15.69
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 238.16
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 19.04
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0,
+      "phase": 125.77
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 176.3
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 279.76
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tdos.json
+++ b/data/ioc/tdos.json
@@ -1,0 +1,288 @@
+{
+  "name": "Dongshadao(Pratas)",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 20.7,
+  "longitude": 116.69,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tdos",
+    "id": "tdos",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.763,
+    "MHHW": 0.331,
+    "MHW": 0.176,
+    "MSL": -0.138,
+    "MTL": -0.132,
+    "MLW": -0.44,
+    "MLLW": -0.538,
+    "LAT": -0.85,
+    "MHWS": 0.039,
+    "MLWS": -0.315
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.133,
+      "phase": 22.69
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.044,
+      "phase": 29.86
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.029,
+      "phase": 9.16
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.012,
+      "phase": 39.8
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.263,
+      "phase": 182.42
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.232,
+      "phase": 141.87
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.074,
+      "phase": 180.55
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.043,
+      "phase": 121.86
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 117
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 110.95
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 160.36
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 79.74
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.005,
+      "phase": 353.74
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 323.28
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.003,
+      "phase": 43
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.006,
+      "phase": 65.21
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 319.07
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 32.39
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 71.5
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 172.06
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 176.77
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 155.47
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.011,
+      "phase": 142.22
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.008,
+      "phase": 165.38
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 185.47
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 262.27
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 85.34
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 152.26
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 154.07
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 54.02
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 230.65
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 243.8
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 3.11
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 27.43
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 153.75
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 274.83
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 246.32
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.015,
+      "phase": 55.76
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 44.79
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 65.49
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.01,
+      "phase": 300.02
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.011,
+      "phase": 344.15
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.091,
+      "phase": 168.09
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.007,
+      "phase": 19.64
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 253.51
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 46.57
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 103.42
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 296.66
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 30.63
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tfan.json
+++ b/data/ioc/tfan.json
@@ -1,0 +1,289 @@
+{
+  "name": "Fangliao",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 22.3636,
+  "longitude": 120.5931,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tfan",
+    "id": "tfan",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.346,
+    "MHHW": 0.912,
+    "MHW": 0.624,
+    "MSL": 0.427,
+    "MTL": 0.394,
+    "MLW": 0.165,
+    "MLLW": 0.075,
+    "LAT": -0.282,
+    "MHWS": 0.714,
+    "MLWS": 0.14
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.209,
+      "phase": 336.62
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.078,
+      "phase": 345.75
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.043,
+      "phase": 325.65
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.022,
+      "phase": 351.1
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.208,
+      "phase": 168.76
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.176,
+      "phase": 131.57
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.055,
+      "phase": 165.43
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.033,
+      "phase": 108.33
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 271.8
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 348.25
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 233.56
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 57.61
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.005,
+      "phase": 282.52
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 274.5
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.007,
+      "phase": 340.98
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.011,
+      "phase": 30.37
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 347.58
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.008,
+      "phase": 13.38
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 6.31
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 149.07
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 248.3
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.015,
+      "phase": 69.95
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.014,
+      "phase": 127.36
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 139.58
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 173.6
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 261.76
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 72.91
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 116.98
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 180.91
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 33.78
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 283.44
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 237.38
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 231.48
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 16.19
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 111.54
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 340.31
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 297.39
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 253.3
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.005,
+      "phase": 90.27
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.004,
+      "phase": 285.4
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.001,
+      "phase": 239.03
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 154.41
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.143,
+      "phase": 130.5
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.037,
+      "phase": 14.53
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 181.63
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.007,
+      "phase": 347.56
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.008,
+      "phase": 145.46
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 212.91
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 299.31
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tfug.json
+++ b/data/ioc/tfug.json
@@ -1,0 +1,289 @@
+{
+  "name": "Fugang",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 22.7908,
+  "longitude": 121.1931,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tfug",
+    "id": "tfug",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.256,
+    "MHHW": 0.757,
+    "MHW": 0.631,
+    "MSL": 0.209,
+    "MTL": 0.22,
+    "MLW": -0.19,
+    "MLLW": -0.285,
+    "LAT": -0.864,
+    "MHWS": 0.798,
+    "MLWS": -0.38
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.416,
+      "phase": 300.77
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.173,
+      "phase": 322.76
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.075,
+      "phase": 288.37
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.052,
+      "phase": 326.31
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.167,
+      "phase": 112.14
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.153,
+      "phase": 83.66
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.037,
+      "phase": 113.1
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 69.95
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 33.41
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 102.54
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 261.96
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 96.49
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 242.75
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 289.9
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 314.28
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.03,
+      "phase": 340.32
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 263.84
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.012,
+      "phase": 358.07
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.009,
+      "phase": 328.4
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.006,
+      "phase": 189.51
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.022,
+      "phase": 190.42
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.018,
+      "phase": 55.4
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.015,
+      "phase": 57.82
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 77.19
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 109.07
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 184.19
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 39.64
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 70.91
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 68.65
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 8.58
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.004,
+      "phase": 262.33
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 133.44
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 274.65
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 154.23
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 151.88
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 359.9
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 38.55
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 294.67
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.004,
+      "phase": 66.04
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.01,
+      "phase": 283.23
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 215.47
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.013,
+      "phase": 18.34
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.14,
+      "phase": 113.88
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.044,
+      "phase": 2.99
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 103.88
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.01,
+      "phase": 8.73
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.019,
+      "phase": 63.74
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 189.83
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 218.57
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tful.json
+++ b/data/ioc/tful.json
@@ -1,0 +1,289 @@
+{
+  "name": "Fulong",
+  "region": "Taipei",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 25.0217,
+  "longitude": 121.9503,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tful",
+    "id": "tful",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.891,
+    "MHHW": 0.462,
+    "MHW": 0.367,
+    "MSL": 0.13,
+    "MTL": 0.175,
+    "MLW": -0.018,
+    "MLLW": -0.182,
+    "LAT": -0.825,
+    "MHWS": 0.437,
+    "MLWS": -0.177
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.204,
+      "phase": 328.76
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.103,
+      "phase": 338.01
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.046,
+      "phase": 324.09
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.029,
+      "phase": 332.78
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.189,
+      "phase": 100.28
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.151,
+      "phase": 76.64
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.058,
+      "phase": 100.02
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.03,
+      "phase": 64.41
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.018,
+      "phase": 208.94
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.011,
+      "phase": 236.78
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.008,
+      "phase": 190.34
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 227.92
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 305.03
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.018,
+      "phase": 255.15
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.005,
+      "phase": 355.42
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.001,
+      "phase": 332.71
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 292.61
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 15.37
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 65.69
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 231.13
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.012,
+      "phase": 244.3
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.003,
+      "phase": 178.74
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 333.1
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 103.03
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 123.93
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 143.38
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 61.55
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 67.75
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 67.66
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 354.31
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 44.19
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 278.49
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 155.37
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 47.16
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 265.94
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 233.63
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 240.59
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 0.35
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 326.99
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.013,
+      "phase": 267.7
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 173.74
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.009,
+      "phase": 11.13
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.168,
+      "phase": 131.39
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.029,
+      "phase": 336.74
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 203.71
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 16.84
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0,
+      "phase": 129.39
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 188.67
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 358.44
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/thou.json
+++ b/data/ioc/thou.json
@@ -1,0 +1,289 @@
+{
+  "name": "Houbihu",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 21.9458,
+  "longitude": 120.7453,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=thou",
+    "id": "thou",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.271,
+    "MHHW": 0.843,
+    "MHW": 0.593,
+    "MSL": 0.308,
+    "MTL": 0.308,
+    "MLW": 0.024,
+    "MLLW": -0.099,
+    "LAT": -0.634,
+    "MHWS": 0.687,
+    "MLWS": -0.071
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.265,
+      "phase": 321
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.114,
+      "phase": 334.56
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.051,
+      "phase": 312.11
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.03,
+      "phase": 327.09
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.222,
+      "phase": 137.83
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.199,
+      "phase": 111.54
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.07,
+      "phase": 135.42
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.04,
+      "phase": 94.65
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 250.89
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 301.36
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 238.4
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 39.89
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 293.25
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 289.38
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.009,
+      "phase": 319.18
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.013,
+      "phase": 359.18
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.007,
+      "phase": 317.15
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 61.46
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 330.82
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 203.91
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 232.31
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 174.05
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 322.84
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 130.23
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 160.39
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 189.45
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.007,
+      "phase": 73.2
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.007,
+      "phase": 96.05
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 126.04
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 33.97
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 300.2
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 28.39
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 217.45
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 340.91
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 72.95
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 330.38
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 314.75
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.008,
+      "phase": 102.72
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.011,
+      "phase": 26.14
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.006,
+      "phase": 326.89
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 149.18
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 11.55
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.112,
+      "phase": 133.41
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.034,
+      "phase": 25.59
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 237.92
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 41.9
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.009,
+      "phase": 77.25
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 215.62
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 348.03
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/thsi.json
+++ b/data/ioc/thsi.json
@@ -1,0 +1,289 @@
+{
+  "name": "Hsinchu",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 24.8486,
+  "longitude": 120.9206,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=thsi",
+    "id": "thsi",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 3.748,
+    "MHHW": 1.67,
+    "MHW": 1.614,
+    "MSL": 0,
+    "MTL": 0.06,
+    "MLW": -1.495,
+    "MLLW": -1.525,
+    "LAT": -3.064,
+    "MHWS": 1.785,
+    "MLWS": -1.785
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.424,
+      "phase": 87.33
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.361,
+      "phase": 118.64
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.156,
+      "phase": 33.29
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.174,
+      "phase": 148.4
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.193,
+      "phase": 130.32
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.118,
+      "phase": 119.21
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.092,
+      "phase": 155.03
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.06,
+      "phase": 51.5
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.089,
+      "phase": 106.54
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.076,
+      "phase": 182.81
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.062,
+      "phase": 8.57
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.02,
+      "phase": 64.24
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.065,
+      "phase": 329.92
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.148,
+      "phase": 217.69
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.062,
+      "phase": 235.38
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.517,
+      "phase": 152.02
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.084,
+      "phase": 315.58
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.133,
+      "phase": 183.44
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.2,
+      "phase": 116.78
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.046,
+      "phase": 348.82
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.129,
+      "phase": 305.19
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.124,
+      "phase": 205.09
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.079,
+      "phase": 32.6
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.023,
+      "phase": 195.85
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.037,
+      "phase": 295.5
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.043,
+      "phase": 0
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.046,
+      "phase": 197.34
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.101,
+      "phase": 225.43
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.047,
+      "phase": 273.9
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.059,
+      "phase": 54.72
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.022,
+      "phase": 203.25
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.046,
+      "phase": 11.35
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.01,
+      "phase": 325.13
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.018,
+      "phase": 64.75
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.023,
+      "phase": 37.79
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.019,
+      "phase": 85.57
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.025,
+      "phase": 132.52
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.064,
+      "phase": 188.98
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.028,
+      "phase": 102.74
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.094,
+      "phase": 186.06
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.062,
+      "phase": 302.25
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.014,
+      "phase": 137.7
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.171,
+      "phase": 99.17
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.068,
+      "phase": 276.52
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.078,
+      "phase": 228.52
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.095,
+      "phase": 140.01
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.467,
+      "phase": 219.78
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.04,
+      "phase": 229.82
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.028,
+      "phase": 239.3
+    }
+  ],
+  "epoch": {
+    "start": "2024-02-09",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/thua.json
+++ b/data/ioc/thua.json
@@ -1,0 +1,289 @@
+{
+  "name": "Hualien",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.9806,
+  "longitude": 121.6236,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=thua",
+    "id": "thua",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.092,
+    "MHHW": 0.513,
+    "MHW": 0.401,
+    "MSL": -0.028,
+    "MTL": -0.022,
+    "MLW": -0.446,
+    "MLLW": -0.538,
+    "LAT": -1.17,
+    "MHWS": 0.602,
+    "MLWS": -0.658
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.439,
+      "phase": 304.83
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.191,
+      "phase": 324.95
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.085,
+      "phase": 292.56
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.054,
+      "phase": 320.93
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.156,
+      "phase": 99.1
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.139,
+      "phase": 82.34
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.052,
+      "phase": 95.18
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 64.47
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.007,
+      "phase": 340.32
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 39.18
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 309.14
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 30.27
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 261.09
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.009,
+      "phase": 286.4
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.012,
+      "phase": 302.36
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.028,
+      "phase": 333.26
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 327.15
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 277.75
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.008,
+      "phase": 344.09
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 198.8
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.009,
+      "phase": 203.86
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 112.75
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 294.47
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 108.86
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.009,
+      "phase": 125.56
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 159.97
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 22.09
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.008,
+      "phase": 82.18
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.006,
+      "phase": 61.98
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.003,
+      "phase": 8.21
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 307.44
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 87.62
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 231.21
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 6.59
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 11.97
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 164.41
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 180.55
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.02,
+      "phase": 328.11
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.008,
+      "phase": 26.37
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.009,
+      "phase": 17.35
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.008,
+      "phase": 87.67
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.014,
+      "phase": 34.33
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.13,
+      "phase": 137.25
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.064,
+      "phase": 266.88
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 233.48
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 32.87
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.016,
+      "phase": 43.38
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 255.65
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 312.89
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/thul.json
+++ b/data/ioc/thul.json
@@ -1,0 +1,288 @@
+{
+  "name": "Thule - Pituffik",
+  "country": "Greenland",
+  "continent": "Americas",
+  "latitude": 76.5434,
+  "longitude": -68.8626,
+  "timezone": "America/Thule",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=thul",
+    "id": "thul",
+    "published_harmonics": false,
+    "operator": "Danish National Space Centre, Technical University of Denmark ( Denmark )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Danish National Space Centre, Technical University of Denmark ( Denmark )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.956,
+    "MHHW": 1.173,
+    "MHW": 0.837,
+    "MSL": 0.03,
+    "MTL": 0.009,
+    "MLW": -0.82,
+    "MLLW": -0.919,
+    "LAT": -1.66,
+    "MHWS": 1.119,
+    "MLWS": -1.059
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.786,
+      "phase": 84.51
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.303,
+      "phase": 122.61
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.163,
+      "phase": 61.62
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.086,
+      "phase": 120.38
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.341,
+      "phase": 246.98
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.126,
+      "phase": 208.15
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.104,
+      "phase": 242.69
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.011,
+      "phase": 178.44
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 80.7
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 178.15
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 4.28
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 159.64
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.024,
+      "phase": 35.21
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.026,
+      "phase": 24.6
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.03,
+      "phase": 66.08
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.018,
+      "phase": 101.6
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.019,
+      "phase": 121.73
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 114.47
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 105.02
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 251.71
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 142.01
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.007,
+      "phase": 114.45
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.015,
+      "phase": 141.25
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.008,
+      "phase": 260.36
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.019,
+      "phase": 275.4
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.008,
+      "phase": 275.38
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 352.05
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 201.13
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 329.68
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 75.83
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 259.41
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 193.6
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 240.19
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 326.7
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 230.4
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 92.15
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 312.94
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.028,
+      "phase": 189.91
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.024,
+      "phase": 197.73
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.014,
+      "phase": 119.21
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.002,
+      "phase": 4.65
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.007,
+      "phase": 359.34
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.1,
+      "phase": 227.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.027,
+      "phase": 225.73
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 348.41
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.002,
+      "phase": 37.63
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 343.66
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 80.12
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 185.72
+    }
+  ],
+  "epoch": {
+    "start": "2023-09-02",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tjhu.json
+++ b/data/ioc/tjhu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Jhuwei",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 25.1181,
+  "longitude": 121.2433,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tjhu",
+    "id": "tjhu",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 2.314,
+    "MHHW": 1.144,
+    "MHW": 1.139,
+    "MSL": 0,
+    "MTL": 0.034,
+    "MLW": -1.071,
+    "MLLW": -1.07,
+    "LAT": -2.124,
+    "MHWS": 1.292,
+    "MLWS": -1.292
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.081,
+      "phase": 79.34
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.211,
+      "phase": 109.82
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.132,
+      "phase": 53.38
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.146,
+      "phase": 143.96
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.186,
+      "phase": 121.55
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.158,
+      "phase": 100.08
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.04,
+      "phase": 86.93
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.036,
+      "phase": 81.28
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.029,
+      "phase": 81.78
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.023,
+      "phase": 100.42
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.019,
+      "phase": 84.13
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.02,
+      "phase": 108.13
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.027,
+      "phase": 34.11
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.128,
+      "phase": 224.9
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.014,
+      "phase": 130.26
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.233,
+      "phase": 151.82
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.053,
+      "phase": 282.12
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.152,
+      "phase": 142.81
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.096,
+      "phase": 105.37
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.062,
+      "phase": 329.88
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.106,
+      "phase": 330.1
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.143,
+      "phase": 214.04
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.062,
+      "phase": 135.71
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.018,
+      "phase": 273.51
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.017,
+      "phase": 325.77
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 226.99
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.016,
+      "phase": 203.35
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.034,
+      "phase": 247.26
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.026,
+      "phase": 221.69
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.031,
+      "phase": 354.66
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.028,
+      "phase": 148.74
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.015,
+      "phase": 0.72
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.005,
+      "phase": 239.76
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.005,
+      "phase": 199.68
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.015,
+      "phase": 160.21
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.009,
+      "phase": 147.23
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.005,
+      "phase": 205.8
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.033,
+      "phase": 13.95
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 2.39
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.033,
+      "phase": 271.98
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.021,
+      "phase": 331.21
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.014,
+      "phase": 343.39
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.181,
+      "phase": 130.89
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.054,
+      "phase": 30.03
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.03,
+      "phase": 224.49
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.06,
+      "phase": 138.22
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.202,
+      "phase": 227.99
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.006,
+      "phase": 63.7
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.014,
+      "phase": 191.81
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/tjia.json
+++ b/data/ioc/tjia.json
@@ -1,0 +1,289 @@
+{
+  "name": "Jiangjun",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.2116,
+  "longitude": 120.083,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tjia",
+    "id": "tjia",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.419,
+    "MHHW": 1.029,
+    "MHW": 0.93,
+    "MSL": 0.401,
+    "MTL": 0.421,
+    "MLW": -0.088,
+    "MLLW": -0.319,
+    "LAT": -0.895,
+    "MHWS": 1.049,
+    "MLWS": -0.247
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.528,
+      "phase": 63.05
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.12,
+      "phase": 101.16
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.096,
+      "phase": 38.95
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.037,
+      "phase": 103.81
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.202,
+      "phase": 155.82
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.175,
+      "phase": 124.04
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.06,
+      "phase": 153.66
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.035,
+      "phase": 107.37
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.032,
+      "phase": 190.42
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.023,
+      "phase": 234.59
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.011,
+      "phase": 167.66
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.005,
+      "phase": 78.55
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.016,
+      "phase": 344.37
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.029,
+      "phase": 203.95
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.025,
+      "phase": 58.21
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.045,
+      "phase": 114.25
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.011,
+      "phase": 86.41
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.008,
+      "phase": 211.82
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.019,
+      "phase": 96.79
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.007,
+      "phase": 350.16
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.016,
+      "phase": 59.01
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.029,
+      "phase": 261.85
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 250.17
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 153.17
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 179.39
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 235.53
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 61.18
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 106.12
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 129.9
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 107.59
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 270.6
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 271.65
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.003,
+      "phase": 143.57
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 245.68
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 147.63
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 294.93
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 261.18
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.007,
+      "phase": 200.64
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.005,
+      "phase": 358.58
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.01,
+      "phase": 289.01
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 151.09
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.004,
+      "phase": 306.55
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.142,
+      "phase": 135.47
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 28.14
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.011,
+      "phase": 180.23
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 175.48
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.024,
+      "phase": 195
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 205.82
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.003,
+      "phase": 308.56
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tjib.json
+++ b/data/ioc/tjib.json
@@ -1,0 +1,289 @@
+{
+  "name": "Jibei",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.7386,
+  "longitude": 119.6132,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tjib",
+    "id": "tjib",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 2.26,
+    "MHHW": 1.189,
+    "MHW": 1.177,
+    "MSL": 0,
+    "MTL": 0.037,
+    "MLW": -1.103,
+    "MLLW": -1.108,
+    "LAT": -2.394,
+    "MHWS": 1.325,
+    "MLWS": -1.325
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.101,
+      "phase": 91.51
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.224,
+      "phase": 133.85
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.125,
+      "phase": 58.81
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.167,
+      "phase": 161.53
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.194,
+      "phase": 151.16
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.165,
+      "phase": 127.47
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.03,
+      "phase": 129.61
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.044,
+      "phase": 94.6
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.01,
+      "phase": 133.15
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.023,
+      "phase": 270.77
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.024,
+      "phase": 120.31
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.022,
+      "phase": 108.57
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.021,
+      "phase": 9.01
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.148,
+      "phase": 232.03
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.037,
+      "phase": 83.12
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.28,
+      "phase": 155.96
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.065,
+      "phase": 351
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.155,
+      "phase": 163.41
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.087,
+      "phase": 108.93
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.056,
+      "phase": 354.6
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.129,
+      "phase": 358.11
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.186,
+      "phase": 223.75
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.074,
+      "phase": 137.8
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.015,
+      "phase": 353.45
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.02,
+      "phase": 12.95
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.013,
+      "phase": 262.53
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.017,
+      "phase": 181.1
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.044,
+      "phase": 261.48
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.039,
+      "phase": 257.43
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.04,
+      "phase": 26.92
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.011,
+      "phase": 185.45
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.023,
+      "phase": 353.92
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.002,
+      "phase": 107.39
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.003,
+      "phase": 146.01
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.019,
+      "phase": 198.87
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.01,
+      "phase": 151.1
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.009,
+      "phase": 10.84
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.024,
+      "phase": 29.96
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 227.95
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.011,
+      "phase": 279.27
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.03,
+      "phase": 60.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.02,
+      "phase": 339.48
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.103,
+      "phase": 192.67
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.049,
+      "phase": 83.62
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.041,
+      "phase": 250.66
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.073,
+      "phase": 154.58
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.232,
+      "phase": 232.34
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.005,
+      "phase": 193.37
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.013,
+      "phase": 220.05
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/tlan.json
+++ b/data/ioc/tlan.json
@@ -1,0 +1,288 @@
+{
+  "name": "Lanyu",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 22.0577,
+  "longitude": 121.5079,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tlan",
+    "id": "tlan",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.135,
+    "MHHW": 0.627,
+    "MHW": 0.471,
+    "MSL": 0.046,
+    "MTL": 0.055,
+    "MLW": -0.362,
+    "MLLW": -0.429,
+    "LAT": -1.034,
+    "MHWS": 0.678,
+    "MLWS": -0.586
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.443,
+      "phase": 303.84
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.189,
+      "phase": 325.35
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.085,
+      "phase": 291.67
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.059,
+      "phase": 326.62
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.131,
+      "phase": 120.69
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.126,
+      "phase": 97.39
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.042,
+      "phase": 117.04
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.025,
+      "phase": 80.2
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 215.11
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 245.51
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 193.62
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 54.67
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 263.54
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 291.34
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.013,
+      "phase": 301.7
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.021,
+      "phase": 344.81
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.008,
+      "phase": 318.48
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 338.83
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.011,
+      "phase": 319.17
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.005,
+      "phase": 179.17
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 183.11
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.006,
+      "phase": 104.63
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.005,
+      "phase": 301.5
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 121.28
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.005,
+      "phase": 138.02
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 195.02
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 70.81
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 83.25
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 84.79
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 8.72
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 33.25
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 128.2
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 153.68
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 223.54
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 89.62
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 8.83
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 74.75
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.013,
+      "phase": 14.29
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 357.42
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.003,
+      "phase": 300.87
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 152.9
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 25.28
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.151,
+      "phase": 119.91
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.039,
+      "phase": 24.58
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 26.09
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 11.3
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.012,
+      "phase": 75.71
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 130.92
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 232.39
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tlia.json
+++ b/data/ioc/tlia.json
@@ -1,0 +1,289 @@
+{
+  "name": "Liaoluowan",
+  "region": "Fukien",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 24.4075,
+  "longitude": 118.4267,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tlia",
+    "id": "tlia",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 3.114,
+    "MHHW": 1.629,
+    "MHW": 1.574,
+    "MSL": 0,
+    "MTL": 0.015,
+    "MLW": -1.544,
+    "MLLW": -1.595,
+    "LAT": -3.583,
+    "MHWS": 1.665,
+    "MLWS": -1.665
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.308,
+      "phase": 100.52
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.357,
+      "phase": 127.13
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.262,
+      "phase": 87.38
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.299,
+      "phase": 167.27
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.289,
+      "phase": 159.52
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.261,
+      "phase": 113.07
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.057,
+      "phase": 231.68
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.051,
+      "phase": 145.22
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.02,
+      "phase": 100.09
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.071,
+      "phase": 263.17
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.025,
+      "phase": 317.45
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.024,
+      "phase": 18.53
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 45.97
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.191,
+      "phase": 238.94
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.076,
+      "phase": 99.39
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.319,
+      "phase": 161.78
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.179,
+      "phase": 46.41
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.34,
+      "phase": 178.06
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.071,
+      "phase": 119.25
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.081,
+      "phase": 71.24
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.46,
+      "phase": 27.69
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.533,
+      "phase": 220.91
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.127,
+      "phase": 149.1
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.049,
+      "phase": 54.31
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.014,
+      "phase": 311.98
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.01,
+      "phase": 293.08
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.01,
+      "phase": 196.91
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.063,
+      "phase": 240.25
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.027,
+      "phase": 213.57
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.046,
+      "phase": 208.86
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.012,
+      "phase": 100.73
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.032,
+      "phase": 110.3
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.031,
+      "phase": 120.07
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.009,
+      "phase": 170.84
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.009,
+      "phase": 310.69
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.014,
+      "phase": 96.94
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.022,
+      "phase": 5.17
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.11,
+      "phase": 1.97
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.053,
+      "phase": 233.88
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.075,
+      "phase": 33.99
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.087,
+      "phase": 357.14
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.05,
+      "phase": 6.66
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.202,
+      "phase": 241.64
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.101,
+      "phase": 148.49
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.073,
+      "phase": 205.07
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.221,
+      "phase": 133.97
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.234,
+      "phase": 233.98
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.059,
+      "phase": 24.73
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.008,
+      "phase": 117.6
+    }
+  ],
+  "epoch": {
+    "start": "2024-02-09",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/tlin.json
+++ b/data/ioc/tlin.json
@@ -1,0 +1,289 @@
+{
+  "name": "Linshanbi",
+  "region": "Taipei",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 25.2839,
+  "longitude": 121.5103,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tlin",
+    "id": "tlin",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.286,
+    "MHHW": 0.617,
+    "MHW": 0.583,
+    "MSL": -0.066,
+    "MTL": 0.05,
+    "MLW": -0.484,
+    "MLLW": -0.588,
+    "LAT": -1.378,
+    "MHWS": 0.812,
+    "MLWS": -0.944
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.718,
+      "phase": 76.96
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.16,
+      "phase": 107.83
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.117,
+      "phase": 44.97
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.051,
+      "phase": 123.03
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.199,
+      "phase": 116.51
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.147,
+      "phase": 94.66
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.036,
+      "phase": 121.98
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.022,
+      "phase": 75.26
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.066,
+      "phase": 116.73
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.032,
+      "phase": 146.31
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.022,
+      "phase": 81.57
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 77.52
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.016,
+      "phase": 338.59
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.077,
+      "phase": 219.08
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.028,
+      "phase": 80.38
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.077,
+      "phase": 132.56
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.014,
+      "phase": 218.61
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.015,
+      "phase": 142.58
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.037,
+      "phase": 112
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.026,
+      "phase": 335.11
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.026,
+      "phase": 305.88
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.018,
+      "phase": 254.27
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.011,
+      "phase": 123.78
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 28.49
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.003,
+      "phase": 88.41
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.007,
+      "phase": 247.98
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 315.6
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 84.26
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.012,
+      "phase": 227.44
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 314.58
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.004,
+      "phase": 200.27
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.004,
+      "phase": 33.23
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.004,
+      "phase": 18
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.003,
+      "phase": 159.78
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.005,
+      "phase": 52.69
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.006,
+      "phase": 98.16
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.004,
+      "phase": 76.63
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.005,
+      "phase": 182.65
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.015,
+      "phase": 256.15
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.073,
+      "phase": 228.37
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.011,
+      "phase": 210.88
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.017,
+      "phase": 356.67
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.196,
+      "phase": 126.77
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.026,
+      "phase": 321.64
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.026,
+      "phase": 207.13
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.008,
+      "phase": 205.7
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.051,
+      "phase": 214.66
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 154.03
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 194.13
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tlon.json
+++ b/data/ioc/tlon.json
@@ -1,0 +1,289 @@
+{
+  "name": "Longdong",
+  "region": "Taipei",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 25.0975,
+  "longitude": 121.9181,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tlon",
+    "id": "tlon",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.875,
+    "MHHW": 0.444,
+    "MHW": 0.376,
+    "MSL": 0.124,
+    "MTL": 0.151,
+    "MLW": -0.074,
+    "MLLW": -0.204,
+    "LAT": -0.91,
+    "MHWS": 0.449,
+    "MLWS": -0.201
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.223,
+      "phase": 342.27
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.102,
+      "phase": 346.94
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.052,
+      "phase": 333
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.029,
+      "phase": 343.8
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.195,
+      "phase": 101.08
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.156,
+      "phase": 77.71
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.06,
+      "phase": 100.47
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.031,
+      "phase": 63.88
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.013,
+      "phase": 186.28
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.008,
+      "phase": 214.53
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.005,
+      "phase": 173.91
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.004,
+      "phase": 255.21
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 314.19
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 256.49
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.007,
+      "phase": 4.73
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.002,
+      "phase": 75.35
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.004,
+      "phase": 315.76
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 37.78
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 83.25
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 265.24
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.01,
+      "phase": 236.77
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 173.47
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 342.34
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 104.3
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 125.14
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 152.13
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.004,
+      "phase": 51.25
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 68.76
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 52.92
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 351.8
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 30.92
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 264.39
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 161.64
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 41.53
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.004,
+      "phase": 300.34
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 320.05
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 284.74
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.006,
+      "phase": 324.25
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 311.37
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.015,
+      "phase": 254.45
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 92.76
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.006,
+      "phase": 348.83
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.173,
+      "phase": 128.45
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.03,
+      "phase": 328.02
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.005,
+      "phase": 216.23
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 21.4
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 242.2
+    },
+    {
+      "name": "T3",
+      "amplitude": 0,
+      "phase": 230.88
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 34.75
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tlyu.json
+++ b/data/ioc/tlyu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Lyudao",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 22.6605,
+  "longitude": 121.473,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tlyu",
+    "id": "tlyu",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.163,
+    "MHHW": 0.699,
+    "MHW": 0.583,
+    "MSL": 0.163,
+    "MTL": 0.179,
+    "MLW": -0.224,
+    "MLLW": -0.302,
+    "LAT": -0.84,
+    "MHWS": 0.749,
+    "MLWS": -0.423
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.411,
+      "phase": 299.12
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.175,
+      "phase": 321.15
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.077,
+      "phase": 291.05
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.05,
+      "phase": 324.54
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.138,
+      "phase": 107.07
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.133,
+      "phase": 88.72
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.037,
+      "phase": 105.17
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.029,
+      "phase": 75.06
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 305.54
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 359.68
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 256.55
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 102.45
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 246.11
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.005,
+      "phase": 308.78
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 323.68
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.034,
+      "phase": 340.36
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.006,
+      "phase": 242.77
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.015,
+      "phase": 0.87
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.012,
+      "phase": 306.26
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.007,
+      "phase": 193.13
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.016,
+      "phase": 218.34
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.024,
+      "phase": 71.7
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.004,
+      "phase": 83.8
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 78.44
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 114.42
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.001,
+      "phase": 171.96
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 59.11
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 98.32
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 91.57
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 10.04
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 206.5
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 118.25
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 255.17
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 235.08
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 143.93
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 336.22
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 254.26
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 311.68
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.001,
+      "phase": 4.78
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 238.4
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 182.54
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.012,
+      "phase": 356.13
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.141,
+      "phase": 126.4
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.036,
+      "phase": 53.6
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 62.42
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.01,
+      "phase": 358.36
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.024,
+      "phase": 68.68
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.004,
+      "phase": 162.92
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 230.24
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tmai.json
+++ b/data/ioc/tmai.json
@@ -1,0 +1,289 @@
+{
+  "name": "Mailiao",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.7861,
+  "longitude": 120.1603,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tmai",
+    "id": "tmai",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 2.368,
+    "MHHW": 1.107,
+    "MHW": 1.063,
+    "MSL": 0,
+    "MTL": 0.011,
+    "MLW": -1.042,
+    "MLLW": -1.066,
+    "LAT": -1.998,
+    "MHWS": 1.217,
+    "MLWS": -1.217
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.979,
+      "phase": 77.15
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.238,
+      "phase": 113.18
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.16,
+      "phase": 52.15
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.146,
+      "phase": 152.49
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.187,
+      "phase": 146.87
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.162,
+      "phase": 127.71
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.014,
+      "phase": 319.58
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.028,
+      "phase": 79.07
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.034,
+      "phase": 252.34
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 305.36
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.007,
+      "phase": 74.04
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.019,
+      "phase": 172.75
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.05,
+      "phase": 47.34
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.145,
+      "phase": 218.25
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.041,
+      "phase": 115.61
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.148,
+      "phase": 139.54
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.05,
+      "phase": 287.01
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.136,
+      "phase": 160.83
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.061,
+      "phase": 111.03
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.056,
+      "phase": 13.13
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.202,
+      "phase": 357.12
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.345,
+      "phase": 202.9
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.083,
+      "phase": 172.38
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 56.25
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.027,
+      "phase": 326.14
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.01,
+      "phase": 191.15
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.017,
+      "phase": 117.86
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.038,
+      "phase": 222.97
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.039,
+      "phase": 223.66
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.02,
+      "phase": 67.84
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 233.86
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.042,
+      "phase": 183.13
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.016,
+      "phase": 86.78
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.011,
+      "phase": 226.11
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.008,
+      "phase": 274.25
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.011,
+      "phase": 184.13
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.017,
+      "phase": 353.48
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.051,
+      "phase": 343.91
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 275.14
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.052,
+      "phase": 317.78
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.045,
+      "phase": 93.06
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 306.58
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.332,
+      "phase": 118.67
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.115,
+      "phase": 17.72
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.049,
+      "phase": 228.26
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.149,
+      "phase": 112.02
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.124,
+      "phase": 234.54
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.011,
+      "phase": 63.18
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.02,
+      "phase": 248.84
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/tmat.json
+++ b/data/ioc/tmat.json
@@ -1,0 +1,289 @@
+{
+  "name": "Matsu",
+  "region": "Fukien",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 26.1617,
+  "longitude": 119.9428,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tmat",
+    "id": "tmat",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 4.389,
+    "MHHW": 1.99,
+    "MHW": 1.911,
+    "MSL": 0,
+    "MTL": 0.016,
+    "MLW": -1.879,
+    "MLLW": -2.014,
+    "LAT": -4.45,
+    "MHWS": 2.247,
+    "MLWS": -2.247
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.774,
+      "phase": 64.61
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.473,
+      "phase": 95.89
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.349,
+      "phase": 37.08
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.212,
+      "phase": 128.7
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.193,
+      "phase": 113.42
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.165,
+      "phase": 79.47
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.146,
+      "phase": 115.75
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.035,
+      "phase": 93.34
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.1,
+      "phase": 43.79
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.022,
+      "phase": 53.82
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.055,
+      "phase": 230.43
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.035,
+      "phase": 104.66
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.109,
+      "phase": 209.57
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.117,
+      "phase": 183.42
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.033,
+      "phase": 198.26
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.55,
+      "phase": 144.76
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.069,
+      "phase": 239.52
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.145,
+      "phase": 115.15
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.097,
+      "phase": 63.86
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.094,
+      "phase": 309.44
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.248,
+      "phase": 296.47
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.439,
+      "phase": 204.46
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.092,
+      "phase": 124.22
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.046,
+      "phase": 347.5
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.027,
+      "phase": 192.55
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.039,
+      "phase": 326.13
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.053,
+      "phase": 294.92
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.063,
+      "phase": 107.6
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.065,
+      "phase": 254.25
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.071,
+      "phase": 50.17
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.052,
+      "phase": 193.84
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.064,
+      "phase": 166.94
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.029,
+      "phase": 2.15
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.025,
+      "phase": 278.53
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.056,
+      "phase": 237.39
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.028,
+      "phase": 230.06
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.013,
+      "phase": 318.67
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.13,
+      "phase": 108.18
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.073,
+      "phase": 140.62
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.061,
+      "phase": 141.09
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.025,
+      "phase": 355.18
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.07,
+      "phase": 174.52
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.122,
+      "phase": 338.71
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.159,
+      "phase": 329.96
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.113,
+      "phase": 215.48
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.252,
+      "phase": 147.56
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.492,
+      "phase": 225.32
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.043,
+      "phase": 214.77
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.059,
+      "phase": 192.34
+    }
+  ],
+  "epoch": {
+    "start": "2024-02-09",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/toco.json
+++ b/data/ioc/toco.json
@@ -1,0 +1,289 @@
+{
+  "name": "Tocopilla",
+  "region": "Antofagasta",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -22.093748,
+  "longitude": -70.211537,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=toco",
+    "id": "toco",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.088,
+    "MHHW": 3.26,
+    "MHW": 3.088,
+    "MSL": 2.726,
+    "MTL": 2.708,
+    "MLW": 2.329,
+    "MLLW": 2.332,
+    "LAT": 1.715,
+    "MHWS": 3.194,
+    "MLWS": 2.258
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.36,
+      "phase": 18.57
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.108,
+      "phase": 40.56
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.08,
+      "phase": 341.5
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.035,
+      "phase": 32.3
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.155,
+      "phase": 25.96
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.089,
+      "phase": 341.47
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.046,
+      "phase": 21.59
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.017,
+      "phase": 314.59
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 307.9
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 202.44
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 253.09
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 167.54
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 310.32
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 326.51
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 342.95
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 27.14
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 36.94
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 71.98
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 347.2
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 270.38
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 193.48
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 145.31
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 98.8
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 316.63
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 67.62
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 101.72
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 230.35
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 322.77
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 351.29
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 39.28
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 172.7
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 329.32
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 213.68
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 295.93
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 301.14
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 240.8
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 86.53
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.044,
+      "phase": 208.53
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.025,
+      "phase": 10.31
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.024,
+      "phase": 294.47
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.017,
+      "phase": 46.81
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.011,
+      "phase": 297.79
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.312,
+      "phase": 231.39
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.307,
+      "phase": 99.55
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 290.08
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 53.14
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 208.65
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 179.55
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 266.43
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/toco2.json
+++ b/data/ioc/toco2.json
@@ -1,0 +1,289 @@
+{
+  "name": "Tocopilla",
+  "region": "Antofagasta",
+  "country": "Chile",
+  "continent": "Americas",
+  "latitude": -22.093748,
+  "longitude": -70.211537,
+  "timezone": "America/Santiago",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=toco2",
+    "id": "toco2",
+    "published_harmonics": false,
+    "operator": "Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Servicio Hidrográfico y Oceanográfico de la Armada ( Chile )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 4.088,
+    "MHHW": 3.26,
+    "MHW": 3.088,
+    "MSL": 2.726,
+    "MTL": 2.708,
+    "MLW": 2.329,
+    "MLLW": 2.332,
+    "LAT": 1.715,
+    "MHWS": 3.194,
+    "MLWS": 2.258
+  },
+  "datums_source": "observed",
+  "chart_datum": "MLWS",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.36,
+      "phase": 18.57
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.108,
+      "phase": 40.56
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.08,
+      "phase": 341.5
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.035,
+      "phase": 32.3
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.155,
+      "phase": 25.96
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.089,
+      "phase": 341.47
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.046,
+      "phase": 21.59
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.017,
+      "phase": 314.59
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 307.9
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0,
+      "phase": 202.44
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 253.09
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 167.54
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.01,
+      "phase": 310.32
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.02,
+      "phase": 326.51
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.015,
+      "phase": 342.95
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.007,
+      "phase": 27.14
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 36.94
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 71.98
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 347.2
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 270.38
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 193.48
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.002,
+      "phase": 145.31
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 98.8
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 316.63
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 67.62
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 101.72
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 230.35
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 322.77
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 351.29
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.007,
+      "phase": 39.28
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 172.7
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 329.32
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 213.68
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 295.93
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 301.14
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 240.8
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 86.53
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.044,
+      "phase": 208.53
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.025,
+      "phase": 10.31
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.024,
+      "phase": 294.47
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.017,
+      "phase": 46.81
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.011,
+      "phase": 297.79
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.312,
+      "phase": 231.39
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.307,
+      "phase": 99.55
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 290.08
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 53.14
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 208.65
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 179.55
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 266.43
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tpen.json
+++ b/data/ioc/tpen.json
@@ -1,0 +1,289 @@
+{
+  "name": "Penghu",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.5619,
+  "longitude": 119.5782,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tpen",
+    "id": "tpen",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.315,
+    "MHHW": 0.55,
+    "MHW": 0.546,
+    "MSL": -0.122,
+    "MTL": 0.025,
+    "MLW": -0.497,
+    "MLLW": -0.539,
+    "LAT": -1.724,
+    "MHWS": 0.883,
+    "MLWS": -1.127
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.836,
+      "phase": 91.61
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.169,
+      "phase": 138.02
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.117,
+      "phase": 46.59
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.077,
+      "phase": 154.56
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.206,
+      "phase": 155.36
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.156,
+      "phase": 131.05
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.033,
+      "phase": 147.24
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.038,
+      "phase": 103.84
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.037,
+      "phase": 207.8
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.02,
+      "phase": 313.98
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.016,
+      "phase": 113.82
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.014,
+      "phase": 140.67
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.027,
+      "phase": 333.82
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.108,
+      "phase": 215.41
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.02,
+      "phase": 112.05
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.123,
+      "phase": 139.34
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.01,
+      "phase": 262.8
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.049,
+      "phase": 178.39
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.061,
+      "phase": 122.29
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.039,
+      "phase": 351
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.039,
+      "phase": 349.47
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.073,
+      "phase": 255.94
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.041,
+      "phase": 157.33
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.011,
+      "phase": 29.52
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.014,
+      "phase": 18.16
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.012,
+      "phase": 262.15
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.006,
+      "phase": 70.16
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.012,
+      "phase": 232.38
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.032,
+      "phase": 243.22
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.016,
+      "phase": 75.69
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.005,
+      "phase": 214.72
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.018,
+      "phase": 41.87
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.007,
+      "phase": 91.32
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.004,
+      "phase": 196.15
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.009,
+      "phase": 189.1
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.008,
+      "phase": 210.59
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 118.77
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 130.98
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 258.38
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.03,
+      "phase": 216.36
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.013,
+      "phase": 306.53
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.007,
+      "phase": 359.46
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.111,
+      "phase": 164.7
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.033,
+      "phase": 56.69
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.031,
+      "phase": 222.72
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.025,
+      "phase": 188.95
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.08,
+      "phase": 222.47
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.009,
+      "phase": 273.91
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 123.04
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/trin.json
+++ b/data/ioc/trin.json
@@ -1,0 +1,289 @@
+{
+  "name": "Trincomalee",
+  "region": "Eastern Province",
+  "country": "Sri Lanka",
+  "continent": "Asia",
+  "latitude": 8.5637,
+  "longitude": 81.1996,
+  "timezone": "Asia/Colombo",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=trin",
+    "id": "trin",
+    "published_harmonics": false,
+    "operator": "National Aquatic Resources Research and Development Agency ( Sri Lanka )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (National Aquatic Resources Research and Development Agency ( Sri Lanka )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 3.562,
+    "MHHW": 3.202,
+    "MHW": 3.094,
+    "MSL": 2.947,
+    "MTL": 2.927,
+    "MLW": 2.76,
+    "MLLW": 2.728,
+    "LAT": 2.37,
+    "MHWS": 3.189,
+    "MLWS": 2.705
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.174,
+      "phase": 51.71
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.068,
+      "phase": 81.64
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.043,
+      "phase": 48.64
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.019,
+      "phase": 85.65
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.067,
+      "phase": 238.97
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.02,
+      "phase": 222.42
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.021,
+      "phase": 237.34
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.003,
+      "phase": 67.37
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 151.49
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 146.59
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 332.15
+    },
+    {
+      "name": "M6",
+      "amplitude": 0,
+      "phase": 143.21
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 33.08
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.006,
+      "phase": 349.53
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.008,
+      "phase": 73.03
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.005,
+      "phase": 85.28
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 80.49
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.006,
+      "phase": 197.87
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 348.39
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 36.23
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.006,
+      "phase": 342.61
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 111.84
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.011,
+      "phase": 319.05
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.001,
+      "phase": 127.82
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 231.59
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 216.62
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 31.68
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.001,
+      "phase": 123.61
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 173.38
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.001,
+      "phase": 38.86
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.002,
+      "phase": 38.76
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 180.43
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 178.35
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 29.34
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0,
+      "phase": 276.9
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 200.26
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 109.5
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.025,
+      "phase": 276.54
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.021,
+      "phase": 10.34
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.016,
+      "phase": 180.82
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.013,
+      "phase": 352.77
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 178.32
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.224,
+      "phase": 269.33
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 153.25
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 337.92
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 272.18
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.002,
+      "phase": 328.81
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 28.03
+    },
+    {
+      "name": "R3",
+      "amplitude": 0,
+      "phase": 23.01
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-02",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tshi.json
+++ b/data/ioc/tshi.json
@@ -1,0 +1,288 @@
+{
+  "name": "Shihti",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.4947,
+  "longitude": 121.5062,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tshi",
+    "id": "tshi",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.268,
+    "MHHW": 0.803,
+    "MHW": 0.686,
+    "MSL": 0.268,
+    "MTL": 0.272,
+    "MLW": -0.141,
+    "MLLW": -0.238,
+    "LAT": -0.752,
+    "MHWS": 0.876,
+    "MLWS": -0.34
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.428,
+      "phase": 292.64
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.18,
+      "phase": 313.83
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.074,
+      "phase": 279.8
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.062,
+      "phase": 320.58
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.164,
+      "phase": 97.87
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.133,
+      "phase": 80
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.042,
+      "phase": 98.5
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.028,
+      "phase": 69.59
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 312.95
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 6.19
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 281.63
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 135.75
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 238.26
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.006,
+      "phase": 318.15
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.01,
+      "phase": 298.7
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.032,
+      "phase": 331.4
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.01,
+      "phase": 253.04
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.024,
+      "phase": 338.61
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.015,
+      "phase": 316.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.008,
+      "phase": 208.43
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.012,
+      "phase": 204.5
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.029,
+      "phase": 44
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 54.65
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.005,
+      "phase": 82.89
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 111.91
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.004,
+      "phase": 156.79
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 48.68
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 86.39
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 56
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.008,
+      "phase": 4.21
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 215.51
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 119.58
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 231.98
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 84.33
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 184.8
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 222.46
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 34.73
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.009,
+      "phase": 302.31
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 105.95
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.015,
+      "phase": 291.74
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 187.04
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.011,
+      "phase": 55.12
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.118,
+      "phase": 133.25
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.044,
+      "phase": 7.14
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 72.8
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.009,
+      "phase": 358.07
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.02,
+      "phase": 59.51
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 198.63
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 123.93
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tshu.json
+++ b/data/ioc/tshu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Shueitou",
+  "region": "Fukien",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 24.4211,
+  "longitude": 118.2892,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tshu",
+    "id": "tshu",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 3.277,
+    "MHHW": 1.669,
+    "MHW": 1.602,
+    "MSL": 0,
+    "MTL": 0.015,
+    "MLW": -1.573,
+    "MLLW": -1.632,
+    "LAT": -3.802,
+    "MHWS": 1.683,
+    "MLWS": -1.683
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.333,
+      "phase": 108.34
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.35,
+      "phase": 131.74
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.295,
+      "phase": 91.08
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.318,
+      "phase": 171.23
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.26,
+      "phase": 152.2
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.265,
+      "phase": 116.37
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.056,
+      "phase": 246.02
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.045,
+      "phase": 164.25
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.005,
+      "phase": 234.94
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.053,
+      "phase": 285.31
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.036,
+      "phase": 316.59
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.025,
+      "phase": 7.97
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.048,
+      "phase": 129.22
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.24,
+      "phase": 233.89
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.082,
+      "phase": 67.48
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.335,
+      "phase": 178.9
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.158,
+      "phase": 42.55
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.326,
+      "phase": 187.27
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.092,
+      "phase": 170.48
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.044,
+      "phase": 129.87
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.456,
+      "phase": 26.11
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.528,
+      "phase": 224.9
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.169,
+      "phase": 151.41
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.031,
+      "phase": 78.2
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.01,
+      "phase": 255.18
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.017,
+      "phase": 258.08
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.041,
+      "phase": 183.19
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.043,
+      "phase": 267.35
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.041,
+      "phase": 245.85
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.035,
+      "phase": 190.96
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.021,
+      "phase": 217.45
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.037,
+      "phase": 139.95
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.059,
+      "phase": 153.45
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.008,
+      "phase": 269.74
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.008,
+      "phase": 24.85
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.018,
+      "phase": 176.26
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.021,
+      "phase": 349.44
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.071,
+      "phase": 57.62
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.051,
+      "phase": 244.05
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.105,
+      "phase": 6.97
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.058,
+      "phase": 4.5
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.03,
+      "phase": 52.17
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.169,
+      "phase": 221.91
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.042,
+      "phase": 107.55
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.077,
+      "phase": 221.72
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.215,
+      "phase": 148.97
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.286,
+      "phase": 242.37
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.087,
+      "phase": 23.74
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.033,
+      "phase": 43.52
+    }
+  ],
+  "epoch": {
+    "start": "2024-02-09",
+    "end": "2026-08-28"
+  }
+}

--- a/data/ioc/tsic.json
+++ b/data/ioc/tsic.json
@@ -1,0 +1,289 @@
+{
+  "name": "Sicao",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.0236,
+  "longitude": 120.1119,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tsic",
+    "id": "tsic",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.224,
+    "MHHW": 0.863,
+    "MHW": 0.743,
+    "MSL": 0.482,
+    "MTL": 0.484,
+    "MLW": 0.226,
+    "MLLW": 0.094,
+    "LAT": -0.246,
+    "MHWS": 0.75,
+    "MLWS": 0.214
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.224,
+      "phase": 45.15
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.044,
+      "phase": 52.66
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.044,
+      "phase": 22.87
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.02,
+      "phase": 74.56
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.155,
+      "phase": 167.3
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.139,
+      "phase": 133.8
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.042,
+      "phase": 181.68
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.028,
+      "phase": 116.39
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 176.63
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 278.92
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 68.31
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 64.29
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 334.86
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.015,
+      "phase": 220.01
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.008,
+      "phase": 49.03
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.018,
+      "phase": 97.5
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 116.97
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.008,
+      "phase": 151.26
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.008,
+      "phase": 78.51
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 2.34
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.006,
+      "phase": 294.96
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.015,
+      "phase": 177.85
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.009,
+      "phase": 82.59
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 125.9
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.004,
+      "phase": 224.08
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 260.69
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0,
+      "phase": 348.49
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 136.04
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 93.75
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 57.61
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 285.38
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 254.97
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 279.8
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 93.55
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 125.65
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.003,
+      "phase": 343.36
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.003,
+      "phase": 301.38
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.017,
+      "phase": 286.51
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.002,
+      "phase": 173.74
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.008,
+      "phase": 355.54
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 227.41
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 169.72
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.183,
+      "phase": 132.7
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.039,
+      "phase": 354.64
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 185.98
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 49.89
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 193.89
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.003,
+      "phase": 205.78
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 191.8
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tsua.json
+++ b/data/ioc/tsua.json
@@ -1,0 +1,289 @@
+{
+  "name": "Su-ao",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 24.5925,
+  "longitude": 121.8658,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tsua",
+    "id": "tsua",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.255,
+    "MHHW": 0.743,
+    "MHW": 0.589,
+    "MSL": 0.174,
+    "MTL": 0.183,
+    "MLW": -0.223,
+    "MLLW": -0.346,
+    "LAT": -1.014,
+    "MHWS": 0.761,
+    "MLWS": -0.413
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.41,
+      "phase": 299
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.177,
+      "phase": 322
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.077,
+      "phase": 289.14
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.051,
+      "phase": 319.55
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.196,
+      "phase": 104.72
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.168,
+      "phase": 79.93
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.061,
+      "phase": 101.7
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.033,
+      "phase": 62.76
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 21.56
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 91.2
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0,
+      "phase": 213.14
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 132.96
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 267.4
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.011,
+      "phase": 277.25
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 302.67
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.021,
+      "phase": 342.18
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 325.2
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.007,
+      "phase": 335.43
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.007,
+      "phase": 305.83
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.004,
+      "phase": 190.37
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 134.3
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 11.18
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.003,
+      "phase": 21.87
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 106.85
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 124.42
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 161.8
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 45.14
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 70.16
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 57.99
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 6.67
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 30.25
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 138.28
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 169.51
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 104.58
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 179.9
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 125.51
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 53.46
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 345.46
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 344.17
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.01,
+      "phase": 280.32
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.005,
+      "phase": 127.58
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.009,
+      "phase": 26.66
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.145,
+      "phase": 133.51
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.024,
+      "phase": 341.94
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.002,
+      "phase": 195.06
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 33.08
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.014,
+      "phase": 68.69
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 220.96
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 336.93
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tsyu.json
+++ b/data/ioc/tsyu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Syunguangzuei",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 21.9856,
+  "longitude": 120.7119,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tsyu",
+    "id": "tsyu",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.195,
+    "MHHW": 0.766,
+    "MHW": 0.54,
+    "MSL": 0.307,
+    "MTL": 0.287,
+    "MLW": 0.034,
+    "MLLW": -0.026,
+    "LAT": -0.399,
+    "MHWS": 0.591,
+    "MLWS": 0.023
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.197,
+      "phase": 321.63
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.087,
+      "phase": 332.63
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.037,
+      "phase": 313.4
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.025,
+      "phase": 344.8
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.218,
+      "phase": 155.57
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.187,
+      "phase": 125.31
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.055,
+      "phase": 159.2
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.036,
+      "phase": 105.2
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 327.68
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 13.45
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 288.65
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 52.09
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.003,
+      "phase": 286.75
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.007,
+      "phase": 286.31
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.005,
+      "phase": 333.6
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.012,
+      "phase": 351.83
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 7.03
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 355.36
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.003,
+      "phase": 6.07
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.003,
+      "phase": 207.36
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.004,
+      "phase": 105.8
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.001,
+      "phase": 86.69
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.009,
+      "phase": 84.55
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.007,
+      "phase": 129.48
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 159.23
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 241.8
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 101.59
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 113.33
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 146.33
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 36.28
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 247.99
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 133.63
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 228.91
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 267.71
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 113.46
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 50.46
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 309.1
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.01,
+      "phase": 256.84
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.005,
+      "phase": 42.27
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 309.13
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 206.98
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.002,
+      "phase": 183.72
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.121,
+      "phase": 127.6
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.035,
+      "phase": 0.86
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0,
+      "phase": 242.42
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.008,
+      "phase": 49.37
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.007,
+      "phase": 75.57
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 146.78
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 286.46
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/ttai.json
+++ b/data/ioc/ttai.json
@@ -1,0 +1,289 @@
+{
+  "name": "Taichung Port",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 24.2878,
+  "longitude": 120.5331,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ttai",
+    "id": "ttai",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 3.261,
+    "MHHW": 1.769,
+    "MHW": 1.76,
+    "MSL": 0,
+    "MTL": 0.018,
+    "MLW": -1.724,
+    "MLLW": -1.721,
+    "LAT": -3.215,
+    "MHWS": 2.097,
+    "MLWS": -2.097
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.679,
+      "phase": 86.11
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.418,
+      "phase": 135.31
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.251,
+      "phase": 46.78
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.163,
+      "phase": 164.15
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.218,
+      "phase": 143.99
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.142,
+      "phase": 113.89
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.056,
+      "phase": 145.31
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.028,
+      "phase": 84.81
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.028,
+      "phase": 73.48
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.013,
+      "phase": 200.5
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.012,
+      "phase": 71.52
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.041,
+      "phase": 111.13
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.068,
+      "phase": 290.33
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.178,
+      "phase": 216.17
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.052,
+      "phase": 141.16
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.332,
+      "phase": 140.24
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.159,
+      "phase": 231.17
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.146,
+      "phase": 181.61
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.114,
+      "phase": 120.84
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.053,
+      "phase": 289.57
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.188,
+      "phase": 303.42
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.24,
+      "phase": 262.28
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.056,
+      "phase": 115.75
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.01,
+      "phase": 287.85
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.021,
+      "phase": 254.46
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.018,
+      "phase": 32.22
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.022,
+      "phase": 275.7
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.019,
+      "phase": 155.22
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.051,
+      "phase": 253.66
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.035,
+      "phase": 350.36
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.048,
+      "phase": 122.37
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.02,
+      "phase": 134.44
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.015,
+      "phase": 155.97
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.018,
+      "phase": 352.65
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.043,
+      "phase": 155.07
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.018,
+      "phase": 104.22
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.008,
+      "phase": 130.75
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.019,
+      "phase": 33.15
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.02,
+      "phase": 149.19
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.042,
+      "phase": 184.32
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.014,
+      "phase": 28.67
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.035,
+      "phase": 184.52
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.186,
+      "phase": 141.74
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.05,
+      "phase": 30.39
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.072,
+      "phase": 233.62
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.148,
+      "phase": 208.12
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.302,
+      "phase": 218.43
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.01,
+      "phase": 15.45
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.024,
+      "phase": 276.47
+    }
+  ],
+  "epoch": {
+    "start": "2024-02-09",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/twai.json
+++ b/data/ioc/twai.json
@@ -1,0 +1,289 @@
+{
+  "name": "Waipu",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 24.6514,
+  "longitude": 120.7714,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=twai",
+    "id": "twai",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum. Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty.",
+  "datums": {
+    "HAT": 3.324,
+    "MHHW": 1.621,
+    "MHW": 1.6,
+    "MSL": 0,
+    "MTL": 0.035,
+    "MLW": -1.529,
+    "MLLW": -1.537,
+    "LAT": -2.848,
+    "MHWS": 1.859,
+    "MLWS": -1.859
+  },
+  "datums_source": "harmonic",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 1.512,
+      "phase": 83.88
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.347,
+      "phase": 119.04
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.223,
+      "phase": 59.2
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.183,
+      "phase": 150.51
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.199,
+      "phase": 142.03
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.111,
+      "phase": 108.42
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.077,
+      "phase": 128.54
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.032,
+      "phase": 70.93
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.064,
+      "phase": 90.12
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.037,
+      "phase": 184.06
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.011,
+      "phase": 65.19
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.051,
+      "phase": 86.12
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.059,
+      "phase": 310.11
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.165,
+      "phase": 225.37
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.026,
+      "phase": 128.49
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.31,
+      "phase": 146.97
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.078,
+      "phase": 267.45
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.174,
+      "phase": 159.99
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.111,
+      "phase": 119.62
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.057,
+      "phase": 302.78
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.207,
+      "phase": 320.81
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.234,
+      "phase": 227.73
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.047,
+      "phase": 86.01
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.011,
+      "phase": 280.07
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 184.62
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.03,
+      "phase": 331.99
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.031,
+      "phase": 249.08
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.033,
+      "phase": 227.31
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.037,
+      "phase": 194.84
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.034,
+      "phase": 9.4
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.046,
+      "phase": 123.78
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.047,
+      "phase": 352.23
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.021,
+      "phase": 19.02
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.015,
+      "phase": 167.4
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.041,
+      "phase": 126.29
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.034,
+      "phase": 88.4
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.014,
+      "phase": 108.4
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.038,
+      "phase": 20.46
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.012,
+      "phase": 118.58
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.041,
+      "phase": 171.34
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.017,
+      "phase": 303.21
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.02,
+      "phase": 196.51
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.203,
+      "phase": 131.54
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.084,
+      "phase": 17.88
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.092,
+      "phase": 227.99
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.09,
+      "phase": 155.06
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.27,
+      "phase": 222.82
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.015,
+      "phase": 150.07
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.024,
+      "phase": 258.72
+    }
+  ],
+  "epoch": {
+    "start": "2024-02-09",
+    "end": "2026-09-04"
+  }
+}

--- a/data/ioc/twun.json
+++ b/data/ioc/twun.json
@@ -1,0 +1,289 @@
+{
+  "name": "Wungang",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.4667,
+  "longitude": 120.1225,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=twun",
+    "id": "twun",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.483,
+    "MHHW": 0.901,
+    "MHW": 0.829,
+    "MSL": 0.214,
+    "MTL": 0.281,
+    "MLW": -0.267,
+    "MLLW": -0.337,
+    "LAT": -1.2,
+    "MHWS": 1.069,
+    "MLWS": -0.641
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.706,
+      "phase": 75.84
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.149,
+      "phase": 114.36
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.105,
+      "phase": 46.99
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.051,
+      "phase": 131.16
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.2,
+      "phase": 159.77
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.154,
+      "phase": 131.58
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.034,
+      "phase": 171.28
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.03,
+      "phase": 111.33
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.029,
+      "phase": 207.8
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.019,
+      "phase": 267.62
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.008,
+      "phase": 171.6
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.02,
+      "phase": 140.13
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.017,
+      "phase": 333.67
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.074,
+      "phase": 204.26
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.031,
+      "phase": 79.79
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.082,
+      "phase": 119.79
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 112.87
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.021,
+      "phase": 159.21
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.042,
+      "phase": 104.71
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.027,
+      "phase": 341.36
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.008,
+      "phase": 72.03
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.045,
+      "phase": 238.67
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.019,
+      "phase": 184.09
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.003,
+      "phase": 135.94
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.002,
+      "phase": 293.08
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 274.56
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 19.57
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 211.26
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.02,
+      "phase": 236.8
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 144.49
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.003,
+      "phase": 55.6
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.005,
+      "phase": 65.92
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 102.82
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 97.83
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.015,
+      "phase": 197.39
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.006,
+      "phase": 179.6
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.002,
+      "phase": 78.25
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.015,
+      "phase": 172.48
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 0.61
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.026,
+      "phase": 277.91
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 81.21
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.014,
+      "phase": 270.24
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.193,
+      "phase": 135.66
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.05,
+      "phase": 31.88
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.028,
+      "phase": 199.87
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.016,
+      "phase": 191.08
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.056,
+      "phase": 199.03
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 35.93
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.005,
+      "phase": 249.71
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/twus.json
+++ b/data/ioc/twus.json
@@ -1,0 +1,289 @@
+{
+  "name": "Wushih",
+  "region": "Taipei",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 24.8686,
+  "longitude": 121.8396,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=twus",
+    "id": "twus",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.189,
+    "MHHW": 0.659,
+    "MHW": 0.55,
+    "MSL": 0.161,
+    "MTL": 0.184,
+    "MLW": -0.183,
+    "MLLW": -0.303,
+    "LAT": -1.061,
+    "MHWS": 0.701,
+    "MLWS": -0.379
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.385,
+      "phase": 315.76
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.155,
+      "phase": 334.5
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.076,
+      "phase": 303.12
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.044,
+      "phase": 331.13
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.199,
+      "phase": 97.87
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.164,
+      "phase": 74.53
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.064,
+      "phase": 96.72
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.032,
+      "phase": 58.15
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.002,
+      "phase": 200.75
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 171.1
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.002,
+      "phase": 196.51
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.001,
+      "phase": 244.97
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.006,
+      "phase": 272.21
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.008,
+      "phase": 269.63
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.011,
+      "phase": 326.31
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.018,
+      "phase": 343.58
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 350.69
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.004,
+      "phase": 63.47
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 350.56
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 223.87
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.011,
+      "phase": 194.11
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.015,
+      "phase": 129.25
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.007,
+      "phase": 285.81
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 98.35
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 121.04
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.006,
+      "phase": 150.07
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 31.5
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.006,
+      "phase": 63.34
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 70.8
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 11.35
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 344.06
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 77.73
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 175.68
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 126.15
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 293.24
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0,
+      "phase": 50.85
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 66.92
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.012,
+      "phase": 352.46
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.008,
+      "phase": 327.71
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.014,
+      "phase": 286.17
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 126.18
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.008,
+      "phase": 3.36
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.168,
+      "phase": 130.81
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.03,
+      "phase": 337.56
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 190.28
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 194.12
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.01,
+      "phase": 58.22
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 254.3
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 290.96
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/txig.json
+++ b/data/ioc/txig.json
@@ -1,0 +1,289 @@
+{
+  "name": "Xiaogang",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 23.1589,
+  "longitude": 121.4036,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=txig",
+    "id": "txig",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.254,
+    "MHHW": 0.781,
+    "MHW": 0.664,
+    "MSL": 0.218,
+    "MTL": 0.227,
+    "MLW": -0.209,
+    "MLLW": -0.294,
+    "LAT": -0.816,
+    "MHWS": 0.879,
+    "MLWS": -0.443
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.473,
+      "phase": 300.25
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.188,
+      "phase": 322.81
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.078,
+      "phase": 283.39
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.059,
+      "phase": 327.61
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.168,
+      "phase": 102.16
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.139,
+      "phase": 79.7
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.037,
+      "phase": 107.44
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.028,
+      "phase": 66.88
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.006,
+      "phase": 222.15
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.003,
+      "phase": 242.11
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 207.89
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 126.77
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.008,
+      "phase": 216.21
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.003,
+      "phase": 49.98
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.008,
+      "phase": 303.74
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.038,
+      "phase": 343.6
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.005,
+      "phase": 244.18
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.019,
+      "phase": 349.05
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.022,
+      "phase": 321.72
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.012,
+      "phase": 196.51
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.023,
+      "phase": 201.63
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.031,
+      "phase": 56.03
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.015,
+      "phase": 64.7
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 56.29
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.008,
+      "phase": 96.88
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 168.53
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 33.75
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.003,
+      "phase": 116.49
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.001,
+      "phase": 85.56
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 351.76
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.006,
+      "phase": 250.46
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 4.24
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 277.6
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 120
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 151.27
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.002,
+      "phase": 304.7
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 109.53
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 315.32
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.007,
+      "phase": 113.71
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.021,
+      "phase": 290.09
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.006,
+      "phase": 169.62
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.01,
+      "phase": 67.54
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.101,
+      "phase": 131.24
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.042,
+      "phase": 1.74
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.008,
+      "phase": 96.11
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.009,
+      "phase": 10.69
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.026,
+      "phase": 71.16
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.006,
+      "phase": 211.81
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 205.72
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/txil.json
+++ b/data/ioc/txil.json
@@ -1,0 +1,289 @@
+{
+  "name": "Xiao Liuqiu",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 22.3533,
+  "longitude": 120.3833,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=txil",
+    "id": "txil",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.021,
+    "MHHW": 0.602,
+    "MHW": 0.365,
+    "MSL": 0.123,
+    "MTL": 0.099,
+    "MLW": -0.167,
+    "MLLW": -0.247,
+    "LAT": -0.569,
+    "MHWS": 0.424,
+    "MLWS": -0.178
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.225,
+      "phase": 348.57
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.076,
+      "phase": 354.75
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.046,
+      "phase": 334.49
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.022,
+      "phase": 358.29
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.197,
+      "phase": 167.33
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.172,
+      "phase": 132.62
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.061,
+      "phase": 163.18
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.034,
+      "phase": 110.37
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.003,
+      "phase": 341.83
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.002,
+      "phase": 23.7
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 304.34
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 39.49
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.007,
+      "phase": 320.44
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.004,
+      "phase": 269.41
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.009,
+      "phase": 346.54
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.008,
+      "phase": 20.91
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 18.49
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.002,
+      "phase": 43.35
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.004,
+      "phase": 9.25
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0,
+      "phase": 342.94
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 178.2
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.011,
+      "phase": 158.29
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.001,
+      "phase": 110.13
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.006,
+      "phase": 165.28
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 180.45
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 243.85
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.003,
+      "phase": 99.03
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.004,
+      "phase": 116.05
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 102.14
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 44.66
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 308.29
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 17.16
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 300.7
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 312.99
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 92.5
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 315.87
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 274.77
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.003,
+      "phase": 197.19
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 6.26
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.012,
+      "phase": 333.26
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 167.62
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 331.42
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.104,
+      "phase": 143.45
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.023,
+      "phase": 31.56
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.001,
+      "phase": 231.25
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.003,
+      "phase": 3.26
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 94.46
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 169.87
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 320.97
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tyon.json
+++ b/data/ioc/tyon.json
@@ -1,0 +1,289 @@
+{
+  "name": "Yongan",
+  "region": "Taiwan",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 22.8189,
+  "longitude": 120.1975,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tyon",
+    "id": "tyon",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 1.209,
+    "MHHW": 0.823,
+    "MHW": 0.646,
+    "MSL": 0.432,
+    "MTL": 0.416,
+    "MLW": 0.186,
+    "MLLW": 0.054,
+    "LAT": -0.357,
+    "MHWS": 0.683,
+    "MLWS": 0.181
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.198,
+      "phase": 9.48
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.053,
+      "phase": 9.41
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.043,
+      "phase": 352.03
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.017,
+      "phase": 22.24
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.172,
+      "phase": 157.24
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.162,
+      "phase": 124.96
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.052,
+      "phase": 154.34
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.036,
+      "phase": 103.38
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.009,
+      "phase": 221.41
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.005,
+      "phase": 264.63
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 210.53
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 31.4
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.004,
+      "phase": 309.27
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.007,
+      "phase": 225.59
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.008,
+      "phase": 24.55
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 64.03
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.001,
+      "phase": 279.13
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.007,
+      "phase": 43.7
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.006,
+      "phase": 73.7
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 293.99
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.002,
+      "phase": 340.74
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.011,
+      "phase": 139.24
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.014,
+      "phase": 207.69
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 134.3
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.006,
+      "phase": 172.13
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.003,
+      "phase": 232.68
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.001,
+      "phase": 63.95
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 125.84
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.004,
+      "phase": 107.36
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 41.29
+    },
+    {
+      "name": "S3",
+      "amplitude": 0,
+      "phase": 180.07
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 344.23
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 185.67
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 215.42
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.002,
+      "phase": 69.37
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 15.92
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 292.48
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.013,
+      "phase": 236.52
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.003,
+      "phase": 87.54
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.007,
+      "phase": 288.72
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 163.63
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.003,
+      "phase": 275.62
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.14,
+      "phase": 122.25
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.041,
+      "phase": 357.15
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.003,
+      "phase": 163.97
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.006,
+      "phase": 55.05
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.005,
+      "phase": 152.43
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.001,
+      "phase": 235.65
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 314.08
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/tzha.json
+++ b/data/ioc/tzha.json
@@ -1,0 +1,289 @@
+{
+  "name": "ZhangTanLi",
+  "region": "Taipei",
+  "country": "Taiwan",
+  "continent": "Asia",
+  "latitude": 25.1406,
+  "longitude": 121.7998,
+  "timezone": "Asia/Taipei",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=tzha",
+    "id": "tzha",
+    "published_harmonics": false,
+    "operator": "Central Weather Administration ( Taiwan )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Central Weather Administration ( Taiwan )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 0.799,
+    "MHHW": 0.441,
+    "MHW": 0.363,
+    "MSL": 0.13,
+    "MTL": 0.164,
+    "MLW": -0.034,
+    "MLLW": -0.162,
+    "LAT": -0.84,
+    "MHWS": 0.397,
+    "MLWS": -0.137
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.206,
+      "phase": 27.97
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.061,
+      "phase": 17.22
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.05,
+      "phase": 4.63
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.018,
+      "phase": 15.49
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.192,
+      "phase": 105.2
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.154,
+      "phase": 81.74
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.06,
+      "phase": 100.57
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.031,
+      "phase": 67.59
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.011,
+      "phase": 146.11
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.008,
+      "phase": 167.69
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.004,
+      "phase": 130.89
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.003,
+      "phase": 243.39
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.009,
+      "phase": 326.73
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.025,
+      "phase": 247.49
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.009,
+      "phase": 42.39
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.012,
+      "phase": 125.77
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.003,
+      "phase": 324.51
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.001,
+      "phase": 310.46
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.008,
+      "phase": 111.67
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.002,
+      "phase": 345.87
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.007,
+      "phase": 238.3
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 278.15
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.006,
+      "phase": 47.5
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.004,
+      "phase": 114.76
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.007,
+      "phase": 111.75
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 155.28
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.005,
+      "phase": 68.96
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.005,
+      "phase": 70.78
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.003,
+      "phase": 33.47
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.006,
+      "phase": 358.15
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 105.18
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.002,
+      "phase": 167.68
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 65.3
+    },
+    {
+      "name": "M8",
+      "amplitude": 0,
+      "phase": 11.65
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.003,
+      "phase": 302.36
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 316.11
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.001,
+      "phase": 295.76
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.011,
+      "phase": 311.59
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.006,
+      "phase": 301.41
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.017,
+      "phase": 258.57
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 137.55
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.007,
+      "phase": 350.15
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.196,
+      "phase": 129.17
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.024,
+      "phase": 324.74
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.007,
+      "phase": 210.89
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.004,
+      "phase": 335.82
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.004,
+      "phase": 216.29
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 230.62
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.001,
+      "phase": 28.64
+    }
+  ],
+  "epoch": {
+    "start": "2024-01-02",
+    "end": "2026-09-05"
+  }
+}

--- a/data/ioc/uper.json
+++ b/data/ioc/uper.json
@@ -1,0 +1,289 @@
+{
+  "name": "Upernavik harbour",
+  "region": "Avannaata",
+  "country": "Greenland",
+  "continent": "Americas",
+  "latitude": 72.78861,
+  "longitude": -56.14667,
+  "timezone": "America/Nuuk",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=uper",
+    "id": "uper",
+    "published_harmonics": false,
+    "operator": "Danish National Space Centre, Technical University of Denmark ( Denmark )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Danish National Space Centre, Technical University of Denmark ( Denmark )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": -0.625,
+    "MHHW": -1.253,
+    "MHW": -1.585,
+    "MSL": -2.04,
+    "MTL": -2.053,
+    "MLW": -2.521,
+    "MLLW": -2.61,
+    "LAT": -3.154,
+    "MHWS": -1.454,
+    "MLWS": -2.626
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.434,
+      "phase": 59.49
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.152,
+      "phase": 90.82
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.094,
+      "phase": 39.17
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.043,
+      "phase": 88.56
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.354,
+      "phase": 243.29
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.126,
+      "phase": 202.11
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.108,
+      "phase": 237.4
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.012,
+      "phase": 181.21
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.001,
+      "phase": 355.34
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.001,
+      "phase": 94.13
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.001,
+      "phase": 265.95
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.002,
+      "phase": 317.9
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.015,
+      "phase": 14.57
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.016,
+      "phase": 2.45
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.017,
+      "phase": 44.39
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.01,
+      "phase": 77.62
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.009,
+      "phase": 84.63
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.003,
+      "phase": 74.29
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.002,
+      "phase": 70.22
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 159.3
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.003,
+      "phase": 66.03
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.004,
+      "phase": 63.89
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.017,
+      "phase": 136.09
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.008,
+      "phase": 268.51
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.021,
+      "phase": 273.29
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.009,
+      "phase": 271.14
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.002,
+      "phase": 328.42
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.002,
+      "phase": 166.65
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.002,
+      "phase": 310.79
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.004,
+      "phase": 5.37
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.001,
+      "phase": 186.92
+    },
+    {
+      "name": "S4",
+      "amplitude": 0,
+      "phase": 160.29
+    },
+    {
+      "name": "N4",
+      "amplitude": 0,
+      "phase": 181.31
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.001,
+      "phase": 225.37
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.001,
+      "phase": 40.74
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.001,
+      "phase": 265.58
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0,
+      "phase": 180.16
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.037,
+      "phase": 199.16
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.021,
+      "phase": 204.98
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.005,
+      "phase": 35.91
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.007,
+      "phase": 121.39
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.005,
+      "phase": 302.09
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.099,
+      "phase": 253.89
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.04,
+      "phase": 229.66
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.004,
+      "phase": 331.89
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 47.32
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.001,
+      "phase": 307.31
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.002,
+      "phase": 12.81
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.002,
+      "phase": 117.54
+    }
+  ],
+  "epoch": {
+    "start": "2023-07-24",
+    "end": "2026-08-13"
+  }
+}

--- a/data/ioc/ushu.json
+++ b/data/ioc/ushu.json
@@ -1,0 +1,289 @@
+{
+  "name": "Ushuaia",
+  "region": "Tierra del Fuego",
+  "country": "Argentina",
+  "continent": "Americas",
+  "latitude": -54.817,
+  "longitude": -68.217,
+  "timezone": "America/Argentina/Ushuaia",
+  "source": {
+    "name": "IOC SLSMF",
+    "url": "https://www.ioc-sealevelmonitoring.org/station.php?code=ushu",
+    "id": "ushu",
+    "published_harmonics": false,
+    "operator": "Armada Argentina Servicio de Hidrografía Naval ( Argentina )"
+  },
+  "license": {
+    "type": "IOC Oceanographic Data Exchange Policy",
+    "commercial_use": false,
+    "url": "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+    "notes": "Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator (Armada Argentina Servicio de Hidrografía Naval ( Argentina )). Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482"
+  },
+  "disclaimers": "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.",
+  "datums": {
+    "HAT": 7.581,
+    "MHHW": 6.739,
+    "MHW": 6.717,
+    "MSL": 6.149,
+    "MTL": 6.156,
+    "MLW": 5.596,
+    "MLLW": 5.46,
+    "LAT": 4.534,
+    "MHWS": 6.757,
+    "MLWS": 5.541
+  },
+  "datums_source": "observed",
+  "chart_datum": "LAT",
+  "type": "reference",
+  "harmonic_constituents": [
+    {
+      "name": "M2",
+      "amplitude": 0.55,
+      "phase": 224.42
+    },
+    {
+      "name": "S2",
+      "amplitude": 0.058,
+      "phase": 231.94
+    },
+    {
+      "name": "N2",
+      "amplitude": 0.143,
+      "phase": 184.38
+    },
+    {
+      "name": "K2",
+      "amplitude": 0.017,
+      "phase": 226.75
+    },
+    {
+      "name": "K1",
+      "amplitude": 0.208,
+      "phase": 98.52
+    },
+    {
+      "name": "O1",
+      "amplitude": 0.156,
+      "phase": 48.38
+    },
+    {
+      "name": "P1",
+      "amplitude": 0.068,
+      "phase": 89.83
+    },
+    {
+      "name": "Q1",
+      "amplitude": 0.033,
+      "phase": 23.5
+    },
+    {
+      "name": "M4",
+      "amplitude": 0.012,
+      "phase": 134.11
+    },
+    {
+      "name": "MS4",
+      "amplitude": 0.007,
+      "phase": 182.43
+    },
+    {
+      "name": "MN4",
+      "amplitude": 0.003,
+      "phase": 115.49
+    },
+    {
+      "name": "M6",
+      "amplitude": 0.006,
+      "phase": 344.21
+    },
+    {
+      "name": "2N2",
+      "amplitude": 0.019,
+      "phase": 143.7
+    },
+    {
+      "name": "MU2",
+      "amplitude": 0.026,
+      "phase": 155.99
+    },
+    {
+      "name": "NU2",
+      "amplitude": 0.026,
+      "phase": 191.95
+    },
+    {
+      "name": "L2",
+      "amplitude": 0.014,
+      "phase": 245.07
+    },
+    {
+      "name": "T2",
+      "amplitude": 0.002,
+      "phase": 293.84
+    },
+    {
+      "name": "R2",
+      "amplitude": 0.005,
+      "phase": 178.15
+    },
+    {
+      "name": "LAMBDA2",
+      "amplitude": 0.005,
+      "phase": 245.13
+    },
+    {
+      "name": "2SM2",
+      "amplitude": 0.001,
+      "phase": 138.27
+    },
+    {
+      "name": "MA2",
+      "amplitude": 0.006,
+      "phase": 36.81
+    },
+    {
+      "name": "MB2",
+      "amplitude": 0.005,
+      "phase": 305.52
+    },
+    {
+      "name": "S1",
+      "amplitude": 0.02,
+      "phase": 96.78
+    },
+    {
+      "name": "M1",
+      "amplitude": 0.002,
+      "phase": 352.88
+    },
+    {
+      "name": "J1",
+      "amplitude": 0.003,
+      "phase": 119.21
+    },
+    {
+      "name": "OO1",
+      "amplitude": 0.005,
+      "phase": 194.3
+    },
+    {
+      "name": "2Q1",
+      "amplitude": 0.007,
+      "phase": 334.97
+    },
+    {
+      "name": "RHO1",
+      "amplitude": 0.008,
+      "phase": 25.74
+    },
+    {
+      "name": "SGM",
+      "amplitude": 0.005,
+      "phase": 11.33
+    },
+    {
+      "name": "M3",
+      "amplitude": 0.005,
+      "phase": 94.76
+    },
+    {
+      "name": "S3",
+      "amplitude": 0.005,
+      "phase": 203.82
+    },
+    {
+      "name": "S4",
+      "amplitude": 0.001,
+      "phase": 90.29
+    },
+    {
+      "name": "N4",
+      "amplitude": 0.001,
+      "phase": 90.97
+    },
+    {
+      "name": "M8",
+      "amplitude": 0.003,
+      "phase": 224.16
+    },
+    {
+      "name": "2MS6",
+      "amplitude": 0.007,
+      "phase": 53.79
+    },
+    {
+      "name": "2MK5",
+      "amplitude": 0.006,
+      "phase": 263.53
+    },
+    {
+      "name": "2MO5",
+      "amplitude": 0.004,
+      "phase": 143.73
+    },
+    {
+      "name": "MM",
+      "amplitude": 0.045,
+      "phase": 145.76
+    },
+    {
+      "name": "MF",
+      "amplitude": 0.026,
+      "phase": 156.29
+    },
+    {
+      "name": "MSF",
+      "amplitude": 0.029,
+      "phase": 347.7
+    },
+    {
+      "name": "MTM",
+      "amplitude": 0.004,
+      "phase": 120.18
+    },
+    {
+      "name": "MSQM",
+      "amplitude": 0.017,
+      "phase": 205.83
+    },
+    {
+      "name": "SA",
+      "amplitude": 0.318,
+      "phase": 301.52
+    },
+    {
+      "name": "SSA",
+      "amplitude": 0.207,
+      "phase": 56.85
+    },
+    {
+      "name": "EP2",
+      "amplitude": 0.006,
+      "phase": 110.54
+    },
+    {
+      "name": "3N2",
+      "amplitude": 0.001,
+      "phase": 189.29
+    },
+    {
+      "name": "3L2",
+      "amplitude": 0.014,
+      "phase": 89.31
+    },
+    {
+      "name": "T3",
+      "amplitude": 0.008,
+      "phase": 290.35
+    },
+    {
+      "name": "R3",
+      "amplitude": 0.007,
+      "phase": 35.1
+    }
+  ],
+  "epoch": {
+    "start": "2020-01-01",
+    "end": "2026-09-05"
+  }
+}

--- a/quality.json
+++ b/quality.json
@@ -1,5 +1,3514 @@
 [
   {
+    "id": "ioc/alex2",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.75,
+      "coverage": 0.001
+    },
+    "issues": [
+      "MHHW (-2.6) < MHW (-2.573)",
+      "MLWS (-2.744) > MLW (-2.815)",
+      "P1 amplitude (0.0860) exceeds K1 (0.0620): physically impossible",
+      "K2 amplitude (0.0250) exceeds S2 (0.0190)"
+    ],
+    "reason": "constituents"
+  },
+  {
+    "id": "ioc/alex3",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.75,
+      "coverage": 0.001
+    },
+    "issues": [
+      "MHHW (-2.6) < MHW (-2.573)",
+      "MLWS (-2.744) > MLW (-2.815)",
+      "P1 amplitude (0.0860) exceeds K1 (0.0620): physically impossible",
+      "K2 amplitude (0.0250) exceeds S2 (0.0190)"
+    ],
+    "reason": "constituents"
+  },
+  {
+    "id": "ioc/ancu",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ancu2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/ancu"
+  },
+  {
+    "id": "ioc/angu",
+    "accepted": true,
+    "score": 58,
+    "factors": {
+      "epoch": 0.132,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.058
+    },
+    "issues": [
+      "MLWS (0.201) > MLW (0.193)",
+      "MHWS (0.353) < MHW (0.361)"
+    ]
+  },
+  {
+    "id": "ioc/aqab",
+    "accepted": true,
+    "score": 72,
+    "factors": {
+      "epoch": 0.099,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/arsu",
+    "accepted": true,
+    "score": 74,
+    "factors": {
+      "epoch": 0.19,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/BANSI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/barc2",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.062
+    },
+    "issues": [
+      "MLWS (0.874) > MLW (0.836)"
+    ]
+  },
+  {
+    "id": "ioc/bcon",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.149,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.298
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/BETSI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/blow",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.058
+    },
+    "issues": [
+      "MLWS (6.823) > MLW (6.794)",
+      "MHWS (6.935) < MHW (6.966)"
+    ]
+  },
+  {
+    "id": "ioc/blueb",
+    "accepted": true,
+    "score": 74,
+    "factors": {
+      "epoch": 0.357,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.785
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/bmsa",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/bmsa2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/bmsa"
+  },
+  {
+    "id": "ioc/bmso",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.248,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.117
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/bois",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.151,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.165
+    },
+    "issues": [
+      "MHHW (5.818) < MHW (6.066)",
+      "MHWS (5.59) < MHW (6.066)",
+      "MSL (5.297) <= MLW (5.46)"
+    ],
+    "reason": "datum"
+  },
+  {
+    "id": "ioc/boye",
+    "accepted": true,
+    "score": 60,
+    "factors": {
+      "epoch": 0.26,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/boye2",
+    "accepted": false,
+    "score": 60,
+    "factors": {
+      "epoch": 0.26,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/boye"
+  },
+  {
+    "id": "ioc/bspe",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.154,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.338
+    },
+    "issues": [
+      "MLWS (4.839) > MLW (4.797)",
+      "MHWS (5.249) < MHW (5.277)"
+    ]
+  },
+  {
+    "id": "ioc/busa",
+    "accepted": true,
+    "score": 72,
+    "factors": {
+      "epoch": 0.334,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.75,
+      "coverage": 1
+    },
+    "issues": [
+      "Q1 amplitude (0.0100) exceeds O1 (0.0040)"
+    ]
+  },
+  {
+    "id": "ioc/camt",
+    "accepted": true,
+    "score": 65,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 0.95,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.599
+    },
+    "issues": [
+      "MHWS (3.258) < MHW (3.292)"
+    ]
+  },
+  {
+    "id": "ioc/CETR",
+    "accepted": true,
+    "score": 69,
+    "factors": {
+      "epoch": 0.187,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.75,
+      "coverage": 1
+    },
+    "issues": [
+      "Q1 amplitude (0.0210) exceeds O1 (0.0090)"
+    ]
+  },
+  {
+    "id": "ioc/chat",
+    "accepted": true,
+    "score": 65,
+    "factors": {
+      "epoch": 0.246,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.362
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/chenn",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/chim2",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.195,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [
+      "MHWS (0.227) < MHW (0.281)"
+    ]
+  },
+  {
+    "id": "ioc/chimb",
+    "accepted": false,
+    "score": 59,
+    "factors": {
+      "epoch": 0.195,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [
+      "MHWS (0.227) < MHW (0.281)"
+    ],
+    "reason": "duplicate",
+    "redundant": "ioc/chim2"
+  },
+  {
+    "id": "ioc/chit",
+    "accepted": true,
+    "score": 67,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.354
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/chnr",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/chnr2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/chnr"
+  },
+  {
+    "id": "ioc/CIDJI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/cmet",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/cmet3",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/cmet"
+  },
+  {
+    "id": "ioc/coli",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/coli2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/coli"
+  },
+  {
+    "id": "ioc/cons2",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/const",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/cons2"
+  },
+  {
+    "id": "ioc/coqu",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/coqu2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/coqu"
+  },
+  {
+    "id": "ioc/corr",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/corr2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/corr"
+  },
+  {
+    "id": "ioc/crnl",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/crnl2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/crnl"
+  },
+  {
+    "id": "ioc/cstr",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/cstr2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/cstr"
+  },
+  {
+    "id": "ioc/cuvie",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/dial",
+    "accepted": true,
+    "score": 61,
+    "factors": {
+      "epoch": 0.206,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.121
+    },
+    "issues": [
+      "MLWS (0.304) > MLW (0.198)",
+      "MHWS (0.35) < MHW (0.453)"
+    ]
+  },
+  {
+    "id": "ioc/ENGSI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/flam",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.058,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.503
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/gale",
+    "accepted": true,
+    "score": 74,
+    "factors": {
+      "epoch": 0.281,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.913
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/gcsb",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.07
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/GESJI",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.184
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/gokc",
+    "accepted": true,
+    "score": 75,
+    "factors": {
+      "epoch": 0.33,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.902
+    },
+    "issues": [
+      "MHWS (1.913) < MHW (2.009)"
+    ]
+  },
+  {
+    "id": "ioc/greg",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/greg2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/greg"
+  },
+  {
+    "id": "ioc/GRJJI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/gtdpr",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.28,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.073
+    },
+    "issues": [
+      "MLWS (-3.53) > MLW (-3.566)",
+      "MHWS (-3.496) < MHW (-3.438)"
+    ]
+  },
+  {
+    "id": "ioc/hoko",
+    "accepted": true,
+    "score": 58,
+    "factors": {
+      "epoch": 0.11,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.075
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/huas",
+    "accepted": true,
+    "score": 61,
+    "factors": {
+      "epoch": 0.322,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/huas2",
+    "accepted": false,
+    "score": 61,
+    "factors": {
+      "epoch": 0.322,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/huas"
+  },
+  {
+    "id": "ioc/iclr",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.349,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ilom",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.2,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ilom2",
+    "accepted": false,
+    "score": 59,
+    "factors": {
+      "epoch": 0.2,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/ilom"
+  },
+  {
+    "id": "ioc/inav",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.356,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.655
+    },
+    "issues": [
+      "MLWS (2.9) > MLW (1.634)",
+      "MHWS (3.252) < MHW (4.73)",
+      "HAT (5.329) < MHHW (9)"
+    ],
+    "reason": "datum"
+  },
+  {
+    "id": "ioc/iqui",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/iqui2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/iqui"
+  },
+  {
+    "id": "ioc/kala",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.568
+    },
+    "issues": [
+      "MHWS (2.252) < MHW (2.295)",
+      "MSL (2.19) <= MLW (2.295)"
+    ],
+    "reason": "datum"
+  },
+  {
+    "id": "ioc/kapi",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.08
+    },
+    "issues": [
+      "SA amplitude (0.500m) is 13.9x the median SA of 2 same-regime neighbour(s) within 25km (0.036m): seasonal contamination"
+    ],
+    "reason": "seasonal"
+  },
+  {
+    "id": "ioc/kata",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.324,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.5,
+      "coverage": 0.793
+    },
+    "issues": [
+      "MLW (3.698) < MLLW (3.771)",
+      "MLWS (3.92) > MLW (3.698)",
+      "MHW (3.836) <= MSL (3.967)",
+      "N2 amplitude (0.0500) exceeds M2 (0.0260)",
+      "Q1 amplitude (0.0780) exceeds O1 (0.0040)"
+    ],
+    "reason": "datum"
+  },
+  {
+    "id": "ioc/kisr",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.173,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/KMMSI",
+    "accepted": true,
+    "score": 61,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.308
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/koli",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.355,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.093
+    },
+    "issues": [
+      "MLWS (6.925) > MLW (6.831)",
+      "MHWS (7.151) < MHW (7.232)"
+    ]
+  },
+  {
+    "id": "ioc/kors",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.09,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.5,
+      "coverage": 1
+    },
+    "issues": [
+      "MLWS (-0.866) > MLW (-1.825)",
+      "MHWS (0.866) < MHW (1.898)",
+      "P1 amplitude (0.5640) exceeds K1 (0.3890): physically impossible",
+      "N2 amplitude (0.7970) exceeds M2 (0.1420)",
+      "Q1 amplitude (0.5740) exceeds O1 (0.1200)"
+    ],
+    "reason": "constituents"
+  },
+  {
+    "id": "ioc/KUTBI",
+    "accepted": true,
+    "score": 58,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/lago",
+    "accepted": true,
+    "score": 66,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.289
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/lalb",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/LAMSI",
+    "accepted": true,
+    "score": 65,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.576
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/larn2",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.153,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.007
+    },
+    "issues": [
+      "MHW (-0.281) <= MSL (-0.253)"
+    ],
+    "reason": "datum"
+  },
+  {
+    "id": "ioc/larn3",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.153,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.007
+    },
+    "issues": [
+      "MHW (-0.281) <= MSL (-0.253)"
+    ],
+    "reason": "datum"
+  },
+  {
+    "id": "ioc/lebu",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/lebu2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/lebu"
+  },
+  {
+    "id": "ioc/leme",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.17,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/lena",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/lirf",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/litz",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/live2",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.098
+    },
+    "issues": [
+      "MLWS (4.08) > MLW (3.002)",
+      "MHWS (8.402) < MHW (9.247)",
+      "HAT (8.979) < MHHW (9.296)"
+    ],
+    "reason": "datum"
+  },
+  {
+    "id": "ioc/lpbc",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.132
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/luga",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/malp2",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.358,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.75,
+      "coverage": 1
+    },
+    "issues": [
+      "MLWS (6.371) > MLW (3.671)",
+      "MHWS (7.375) < MHW (10.73)",
+      "HAT (9.817) < MHHW (14.812)",
+      "Q1 amplitude (0.0240) exceeds O1 (0.0190)"
+    ],
+    "reason": "datum"
+  },
+  {
+    "id": "ioc/marm",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/matr",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.066,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/meji",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/meji2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/meji"
+  },
+  {
+    "id": "ioc/milo",
+    "accepted": true,
+    "score": 67,
+    "factors": {
+      "epoch": 0.107,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.649
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/mnts",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.132,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": [
+      "MLWS (0.442) > MLW (0.393)",
+      "MHWS (0.522) < MHW (0.557)"
+    ]
+  },
+  {
+    "id": "ioc/mpaw",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.154,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.084
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/mpcw",
+    "accepted": true,
+    "score": 68,
+    "factors": {
+      "epoch": 0.154,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.666
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/mpsw",
+    "accepted": true,
+    "score": 60,
+    "factors": {
+      "epoch": 0.154,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.137
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/mpww",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.119,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.126
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/mrms",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.327,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.184
+    },
+    "issues": [
+      "MLWS (-0.19) > MLW (-0.266)",
+      "MHWS (0.19) < MHW (0.308)"
+    ]
+  },
+  {
+    "id": "ioc/MRTM",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.169,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/MRTMI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ms001",
+    "accepted": true,
+    "score": 68,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.395
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/nanc",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.332,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/nhte",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/nksk",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.35,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": [
+      "MHHW (0.331) < MHW (0.34)",
+      "MHWS (0.295) < MHW (0.34)"
+    ]
+  },
+  {
+    "id": "ioc/ntue",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/nhte"
+  },
+  {
+    "id": "ioc/ntue2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/nhte"
+  },
+  {
+    "id": "ioc/ohig3",
+    "accepted": true,
+    "score": 76,
+    "factors": {
+      "epoch": 0.343,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.916
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pagi",
+    "accepted": true,
+    "score": 61,
+    "factors": {
+      "epoch": 0.286,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pagi2",
+    "accepted": false,
+    "score": 61,
+    "factors": {
+      "epoch": 0.286,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/pagi"
+  },
+  {
+    "id": "ioc/pait2",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.211,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [
+      "MHHW (2.118) < MHW (2.121)"
+    ]
+  },
+  {
+    "id": "ioc/paita",
+    "accepted": false,
+    "score": 59,
+    "factors": {
+      "epoch": 0.211,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [
+      "MHHW (2.118) < MHW (2.121)"
+    ],
+    "reason": "duplicate",
+    "redundant": "ioc/pait2"
+  },
+  {
+    "id": "ioc/papo",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/papo2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/papo"
+  },
+  {
+    "id": "ioc/pass",
+    "accepted": true,
+    "score": 57,
+    "factors": {
+      "epoch": 0.057,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.087
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pata",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pata2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/pata"
+  },
+  {
+    "id": "ioc/patu",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.103,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.126
+    },
+    "issues": [
+      "SA amplitude (0.586m) is 36.8x the median SA of 2 same-regime neighbour(s) within 25km (0.016m): seasonal contamination"
+    ],
+    "reason": "seasonal"
+  },
+  {
+    "id": "ioc/PAYJI",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.055,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.75,
+      "coverage": 1
+    },
+    "issues": [
+      "MHWS (1.196) < MHW (1.708)",
+      "P1 amplitude (0.6520) exceeds K1 (0.3220): physically impossible",
+      "Q1 amplitude (0.1310) exceeds O1 (0.0440)"
+    ],
+    "reason": "constituents"
+  },
+  {
+    "id": "ioc/pcha",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pcha2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/pcha"
+  },
+  {
+    "id": "ioc/pedn",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pedn2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/pedn"
+  },
+  {
+    "id": "ioc/peir",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.746
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/PEISI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/petr",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.354,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": [
+      "MHHW (3.6) < MHW (3.611)",
+      "MLWS (2.665) > MLW (2.626)",
+      "MHWS (3.387) < MHW (3.611)"
+    ]
+  },
+  {
+    "id": "ioc/pich",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pich2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/pich"
+  },
+  {
+    "id": "ioc/pisa",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pisa2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/pisa"
+  },
+  {
+    "id": "ioc/pisco",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.201,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.931
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/plat2",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.078
+    },
+    "issues": [
+      "MHWS (5.769) < MHW (5.921)"
+    ]
+  },
+  {
+    "id": "ioc/plop",
+    "accepted": true,
+    "score": 66,
+    "factors": {
+      "epoch": 0.165,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.492
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pmel",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pmel2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/pmel"
+  },
+  {
+    "id": "ioc/pmur",
+    "accepted": true,
+    "score": 66,
+    "factors": {
+      "epoch": 0.327,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.324
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/pnat",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.205,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [
+      "MLWS (3.587) > MLW (3.582)"
+    ]
+  },
+  {
+    "id": "ioc/pnat2",
+    "accepted": false,
+    "score": 59,
+    "factors": {
+      "epoch": 0.205,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [
+      "MLWS (3.587) > MLW (3.582)"
+    ],
+    "reason": "duplicate",
+    "redundant": "ioc/pnat"
+  },
+  {
+    "id": "ioc/prev",
+    "accepted": true,
+    "score": 76,
+    "factors": {
+      "epoch": 0.329,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/PSCA",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.197,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.75,
+      "coverage": 1
+    },
+    "issues": [
+      "MLWS (-0.045) > MLW (-0.046)",
+      "P1 amplitude (0.0130) exceeds K1 (0.0100): physically impossible",
+      "Q1 amplitude (0.0130) exceeds O1 (0.0100)"
+    ],
+    "reason": "constituents"
+  },
+  {
+    "id": "ioc/ptal",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ptal2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/ptal"
+  },
+  {
+    "id": "ioc/ptar",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ptar2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/ptar"
+  },
+  {
+    "id": "ioc/ptbc",
+    "accepted": true,
+    "score": 58,
+    "factors": {
+      "epoch": 0.179,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ptbc2",
+    "accepted": false,
+    "score": 58,
+    "factors": {
+      "epoch": 0.179,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/ptbc"
+  },
+  {
+    "id": "ioc/ptch",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.343,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ptmd2",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.605
+    },
+    "issues": [
+      "MHWS (3.488) < MHW (3.539)"
+    ]
+  },
+  {
+    "id": "ioc/qing",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.358,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": [
+      "MLWS (0.769) > MLW (0.625)",
+      "MHWS (1.443) < MHW (1.559)"
+    ]
+  },
+  {
+    "id": "ioc/qtro",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/qtro2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/qtro"
+  },
+  {
+    "id": "ioc/quel",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/quel2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/quel"
+  },
+  {
+    "id": "ioc/quir",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/quir2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/quir"
+  },
+  {
+    "id": "ioc/rbct",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.096
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/RCCL",
+    "accepted": true,
+    "score": 74,
+    "factors": {
+      "epoch": 0.186,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/sano",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/sano2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/sano"
+  },
+  {
+    "id": "ioc/sema",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/shek",
+    "accepted": true,
+    "score": 70,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.556
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/shen",
+    "accepted": true,
+    "score": 70,
+    "factors": {
+      "epoch": 0.358,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.556
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/SIMSI",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": [
+      "MLWS (-0.36) > MLW (-0.507)",
+      "MHWS (0.36) < MHW (0.502)",
+      "P1 amplitude (0.1760) exceeds K1 (0.0380): physically impossible"
+    ],
+    "reason": "constituents"
+  },
+  {
+    "id": "ioc/sipa",
+    "accepted": true,
+    "score": 65,
+    "factors": {
+      "epoch": 0.086,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.54
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/slor",
+    "accepted": true,
+    "score": 69,
+    "factors": {
+      "epoch": 0.211,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.647
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/sobr",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/sole",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/sole2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/sole"
+  },
+  {
+    "id": "ioc/spjy",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": [
+      "MLWS (0.527) > MLW (0.496)",
+      "MHWS (0.901) < MHW (0.916)"
+    ]
+  },
+  {
+    "id": "ioc/SRMPI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/stari",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.756
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/stlu3",
+    "accepted": true,
+    "score": 65,
+    "factors": {
+      "epoch": 0.262,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.334
+    },
+    "issues": [
+      "MHWS (2.962) < MHW (2.981)"
+    ]
+  },
+  {
+    "id": "ioc/subi",
+    "accepted": false,
+    "score": 0,
+    "factors": {
+      "epoch": 0.358,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.133
+    },
+    "issues": [
+      "MHHW (6.672) < MHW (6.743)",
+      "MHWS (6.251) < MHW (6.743)",
+      "MSL (6.025) <= MLW (6.219)"
+    ],
+    "reason": "datum"
+  },
+  {
+    "id": "ioc/SUBSI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/syro",
+    "accepted": true,
+    "score": 72,
+    "factors": {
+      "epoch": 0.339,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 0.75,
+      "coverage": 1
+    },
+    "issues": [
+      "MLWS (-0.024) > MLW (-0.029)",
+      "MHWS (0.024) < MHW (0.026)",
+      "Q1 amplitude (0.0080) exceeds O1 (0.0040)"
+    ]
+  },
+  {
+    "id": "ioc/talc",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/talc2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/talc"
+  },
+  {
+    "id": "ioc/talt",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [],
+    "reason": "duplicate",
+    "redundant": "ioc/talt2"
+  },
+  {
+    "id": "ioc/talt2",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tanp",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.11
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tare",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/TASJI",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.184
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tasw",
+    "accepted": true,
+    "score": 65,
+    "factors": {
+      "epoch": 0.057,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.576
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tboz",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.339
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/TBSSI",
+    "accepted": true,
+    "score": 71,
+    "factors": {
+      "epoch": 0.056,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tbwc",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.072
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tche",
+    "accepted": true,
+    "score": 60,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.146
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tcim",
+    "accepted": true,
+    "score": 66,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.526
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tcsb",
+    "accepted": true,
+    "score": 75,
+    "factors": {
+      "epoch": 0.242,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tdan",
+    "accepted": true,
+    "score": 58,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.039
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tdas",
+    "accepted": true,
+    "score": 58,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.039
+    },
+    "issues": [
+      "MLW (-0.876) < MLLW (-0.874)"
+    ]
+  },
+  {
+    "id": "ioc/tdog",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.051
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tdoj",
+    "accepted": true,
+    "score": 66,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.526
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tdon",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.273
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tdos",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": [
+      "MLWS (-0.315) > MLW (-0.44)",
+      "MHWS (0.039) < MHW (0.176)"
+    ]
+  },
+  {
+    "id": "ioc/TEUL",
+    "accepted": true,
+    "score": 74,
+    "factors": {
+      "epoch": 0.331,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.861
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tfan",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.39
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tfug",
+    "accepted": true,
+    "score": 67,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.643
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tful",
+    "accepted": true,
+    "score": 60,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.181
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/thou",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.112
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/thsi",
+    "accepted": true,
+    "score": 66,
+    "factors": {
+      "epoch": 0.138,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.532
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/thua",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/thul",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.162,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tjhu",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.361
+    },
+    "issues": [
+      "MLW (-1.071) < MLLW (-1.07)"
+    ]
+  },
+  {
+    "id": "ioc/tjia",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.422
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tjib",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.399
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tlan",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tlia",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.138,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.28
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tlin",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.296
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tlon",
+    "accepted": true,
+    "score": 60,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.181
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tlyu",
+    "accepted": true,
+    "score": 67,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.643
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tmai",
+    "accepted": true,
+    "score": 63,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.375
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tmat",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.138,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/toco",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [
+      "MLW (2.329) < MLLW (2.332)"
+    ]
+  },
+  {
+    "id": "ioc/toco2",
+    "accepted": false,
+    "score": 62,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0
+    },
+    "issues": [
+      "MLW (2.329) < MLLW (2.332)"
+    ],
+    "reason": "duplicate",
+    "redundant": "ioc/toco"
+  },
+  {
+    "id": "ioc/tpen",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.399
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/trin",
+    "accepted": true,
+    "score": 77,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tshi",
+    "accepted": true,
+    "score": 69,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.776
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tshu",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.137,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.28
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tsic",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.11
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tsua",
+    "accepted": true,
+    "score": 67,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.616
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tsyu",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.112
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ttai",
+    "accepted": true,
+    "score": 72,
+    "factors": {
+      "epoch": 0.138,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.942
+    },
+    "issues": [
+      "MLW (-1.724) < MLLW (-1.721)"
+    ]
+  },
+  {
+    "id": "ioc/twai",
+    "accepted": true,
+    "score": 66,
+    "factors": {
+      "epoch": 0.138,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.532
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/twun",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.051
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/twus",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.407
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/txig",
+    "accepted": true,
+    "score": 60,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.146
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/txil",
+    "accepted": true,
+    "score": 62,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.273
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tyon",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.389
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/tzha",
+    "accepted": true,
+    "score": 59,
+    "factors": {
+      "epoch": 0.144,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.101
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/uper",
+    "accepted": true,
+    "score": 73,
+    "factors": {
+      "epoch": 0.164,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 1
+    },
+    "issues": []
+  },
+  {
+    "id": "ioc/ushu",
+    "accepted": true,
+    "score": 64,
+    "factors": {
+      "epoch": 0.359,
+      "recency": 1,
+      "source": 0.495,
+      "quality": 1,
+      "amplitude": 1,
+      "coverage": 0.103
+    },
+    "issues": []
+  },
+  {
     "id": "noaa/1610367",
     "accepted": true,
     "score": 98,
@@ -380,14 +3889,14 @@
   {
     "id": "noaa/1617846",
     "accepted": true,
-    "score": 89,
+    "score": 84,
     "factors": {
       "epoch": 1,
       "recency": 0.75,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.405
+      "coverage": 0.075
     },
     "issues": []
   },
@@ -408,14 +3917,14 @@
   {
     "id": "noaa/1618578",
     "accepted": true,
-    "score": 98,
+    "score": 94,
     "factors": {
       "epoch": 1,
       "recency": 0.75,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.775
     },
     "issues": []
   },
@@ -44692,14 +48201,14 @@
   {
     "id": "noaa/TEC4605",
     "accepted": true,
-    "score": 89,
+    "score": 87,
     "factors": {
       "epoch": 1,
       "recency": 1,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.275
+      "coverage": 0.117
     },
     "issues": []
   },
@@ -45588,28 +49097,28 @@
   {
     "id": "noaa/TEC4775",
     "accepted": true,
-    "score": 92,
+    "score": 88,
     "factors": {
       "epoch": 1,
       "recency": 0.75,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.634
+      "coverage": 0.385
     },
     "issues": []
   },
   {
     "id": "noaa/TEC4777",
     "accepted": true,
-    "score": 92,
+    "score": 88,
     "factors": {
       "epoch": 1,
       "recency": 0.75,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.634
+      "coverage": 0.334
     },
     "issues": []
   },
@@ -46946,14 +50455,14 @@
   {
     "id": "noaa/TPT2905",
     "accepted": true,
-    "score": 70,
+    "score": 56,
     "factors": {
       "epoch": 0,
       "recency": 0,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.096
     },
     "issues": []
   },
@@ -46988,14 +50497,14 @@
   {
     "id": "noaa/TWC0269",
     "accepted": true,
-    "score": 68,
+    "score": 62,
     "factors": {
       "epoch": 0,
       "recency": 0,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.89
+      "coverage": 0.492
     },
     "issues": []
   },
@@ -47044,14 +50553,14 @@
   {
     "id": "noaa/TWC0277",
     "accepted": true,
-    "score": 70,
+    "score": 65,
     "factors": {
       "epoch": 0,
       "recency": 0,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.647
     },
     "issues": []
   },
@@ -47382,14 +50891,14 @@
   {
     "id": "noaa/TWC0349",
     "accepted": true,
-    "score": 66,
+    "score": 63,
     "factors": {
       "epoch": 0,
       "recency": 0,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.743
+      "coverage": 0.503
     },
     "issues": []
   },
@@ -49772,7 +53281,7 @@
     "score": 65,
     "factors": {
       "epoch": 0.085,
-      "recency": 0.9,
+      "recency": 0.89,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -50188,7 +53697,7 @@
     "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -50202,7 +53711,7 @@
     "score": 70,
     "factors": {
       "epoch": 0.287,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.99,
       "quality": 1,
       "amplitude": 1,
@@ -50672,10 +54181,10 @@
   {
     "id": "ticon/alvarado_flotador-22-mex-unam",
     "accepted": false,
-    "score": 36,
+    "score": 35,
     "factors": {
       "epoch": 0.148,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.141,
       "quality": 0,
       "amplitude": 1,
@@ -50787,7 +54296,7 @@
     "score": 72,
     "factors": {
       "epoch": 0.314,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -50900,7 +54409,7 @@
     "score": 86,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -50971,14 +54480,14 @@
   {
     "id": "ticon/ammassalik-297a-dnk-uhslc_rq",
     "accepted": true,
-    "score": 70,
+    "score": 63,
     "factors": {
       "epoch": 0.437,
       "recency": 0.72,
       "source": 0.192,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.576
     },
     "issues": []
   },
@@ -51713,7 +55222,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -53063,7 +56572,7 @@
     "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -53184,7 +56693,7 @@
     "score": 86,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -53349,14 +56858,14 @@
   {
     "id": "ticon/barcelonatg-bar-esp-cmems",
     "accepted": true,
-    "score": 80,
+    "score": 66,
     "factors": {
       "epoch": 1,
       "recency": 0.99,
       "source": 0.02,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.062
     },
     "issues": []
   },
@@ -53757,7 +57266,7 @@
     "score": 87,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -54170,7 +57679,7 @@
     "score": 86,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -54186,7 +57695,7 @@
     "score": 85,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -54294,7 +57803,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -54322,7 +57831,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 0.75,
@@ -54342,7 +57851,7 @@
     "score": 97,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -55239,7 +58748,7 @@
       "source": 0.02,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.131
+      "coverage": 0.111
     },
     "issues": []
   },
@@ -55533,7 +59042,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -56505,7 +60014,7 @@
     "score": 90,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -57152,7 +60661,7 @@
     "score": 86,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -57952,7 +61461,7 @@
     "score": 89,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -58084,7 +61593,7 @@
     "score": 88,
     "factors": {
       "epoch": 0.945,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -58454,7 +61963,7 @@
     "score": 0,
     "factors": {
       "epoch": 0.86,
-      "recency": 0.54,
+      "recency": 0.53,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -59435,7 +62944,7 @@
     "score": 93,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -59805,7 +63314,7 @@
     "score": 78,
     "factors": {
       "epoch": 0.457,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -60022,7 +63531,7 @@
     "score": 85,
     "factors": {
       "epoch": 1,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.99,
       "quality": 1,
       "amplitude": 1,
@@ -60052,7 +63561,7 @@
     "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -60550,7 +64059,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -60783,7 +64292,7 @@
     "score": 95,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -61169,7 +64678,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -61517,7 +65026,7 @@
     "score": 88,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -68696,7 +72205,7 @@
     "score": 73,
     "factors": {
       "epoch": 0.45,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -69329,7 +72838,7 @@
     "score": 86,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -71145,14 +74654,14 @@
   {
     "id": "ticon/eden-60530-aus-bom",
     "accepted": true,
-    "score": 98,
+    "score": 84,
     "factors": {
       "epoch": 1,
       "recency": 0.96,
       "source": 0.939,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.072
     },
     "issues": []
   },
@@ -71670,7 +75179,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -71926,7 +75435,7 @@
     "score": 67,
     "factors": {
       "epoch": 0.361,
-      "recency": 0.53,
+      "recency": 0.52,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -72154,14 +75663,14 @@
   {
     "id": "ticon/exmouth-62435-aus-bom",
     "accepted": true,
-    "score": 98,
+    "score": 88,
     "factors": {
       "epoch": 1,
       "recency": 0.96,
       "source": 0.939,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.324
     },
     "issues": []
   },
@@ -72281,7 +75790,7 @@
     "score": 66,
     "factors": {
       "epoch": 0.066,
-      "recency": 0.9,
+      "recency": 0.89,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -73304,7 +76813,7 @@
     "score": 39,
     "factors": {
       "epoch": 0.059,
-      "recency": 0.27,
+      "recency": 0.26,
       "source": 0,
       "quality": 1,
       "amplitude": 1,
@@ -75323,7 +78832,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -75370,14 +78879,14 @@
   {
     "id": "ticon/gold_coast_southport-60051-aus-bom",
     "accepted": true,
-    "score": 98,
+    "score": 84,
     "factors": {
       "epoch": 1,
       "recency": 0.96,
       "source": 0.939,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.07
     },
     "issues": []
   },
@@ -75387,7 +78896,7 @@
     "score": 89,
     "factors": {
       "epoch": 0.722,
-      "recency": 0.68,
+      "recency": 0.67,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -75433,14 +78942,14 @@
   {
     "id": "ticon/gomeratg-gom-esp-cmems",
     "accepted": true,
-    "score": 74,
+    "score": 70,
     "factors": {
       "epoch": 0.994,
       "recency": 0.99,
       "source": 0.02,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.563
+      "coverage": 0.289
     },
     "issues": []
   },
@@ -76592,7 +80101,7 @@
     "score": 86,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -76785,7 +80294,7 @@
     "score": 58,
     "factors": {
       "epoch": 0.09,
-      "recency": 0.91,
+      "recency": 0.9,
       "source": 0.596,
       "quality": 1,
       "amplitude": 1,
@@ -77769,7 +81278,7 @@
     "score": 87,
     "factors": {
       "epoch": 0.419,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -78335,14 +81844,14 @@
   {
     "id": "ticon/henslung_cove-9958-can-meds",
     "accepted": true,
-    "score": 87,
+    "score": 86,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.169
+      "coverage": 0.132
     },
     "issues": []
   },
@@ -81193,7 +84702,7 @@
     "score": 76,
     "factors": {
       "epoch": 0.321,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -81270,7 +84779,7 @@
     "score": 63,
     "factors": {
       "epoch": 0.196,
-      "recency": 0.44,
+      "recency": 0.43,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -82081,7 +85590,7 @@
     "score": 61,
     "factors": {
       "epoch": 0.698,
-      "recency": 0.86,
+      "recency": 0.85,
       "source": 0.192,
       "quality": 1,
       "amplitude": 1,
@@ -82157,14 +85666,14 @@
   {
     "id": "ticon/jakarta-161a-idn-uhslc_rq",
     "accepted": true,
-    "score": 78,
+    "score": 67,
     "factors": {
       "epoch": 0.965,
       "recency": 0.78,
       "source": 0.192,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.786
+      "coverage": 0.093
     },
     "issues": [
       "MLWS (1.945) > MLW (1.885)",
@@ -83669,7 +87178,7 @@
     "score": 0,
     "factors": {
       "epoch": 0.055,
-      "recency": 0.51,
+      "recency": 0.5,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
@@ -84451,10 +87960,10 @@
   {
     "id": "ticon/kingston_ontario-13988-can-meds",
     "accepted": true,
-    "score": 90,
+    "score": 89,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -84468,14 +87977,14 @@
   {
     "id": "ticon/kingstow-795-vct-uhslc_fd",
     "accepted": true,
-    "score": 83,
+    "score": 73,
     "factors": {
       "epoch": 0.166,
       "recency": 0.99,
       "source": 0.99,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.362
     },
     "issues": []
   },
@@ -84485,7 +87994,7 @@
     "score": 89,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -84576,7 +88085,7 @@
     "score": 92,
     "factors": {
       "epoch": 0.633,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -84590,7 +88099,7 @@
     "score": 72,
     "factors": {
       "epoch": 0.372,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -85103,14 +88612,14 @@
   {
     "id": "ticon/koroni-kor-grc-cmems",
     "accepted": true,
-    "score": 55,
+    "score": 48,
     "factors": {
       "epoch": 0.478,
       "recency": 0.96,
       "source": 0.02,
       "quality": 0,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.568
     },
     "issues": []
   },
@@ -86264,7 +89773,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -86347,7 +89856,7 @@
     "score": 75,
     "factors": {
       "epoch": 0.318,
-      "recency": 0.92,
+      "recency": 0.91,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -86819,7 +90328,7 @@
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.169
+      "coverage": 0.148
     },
     "issues": []
   },
@@ -86876,14 +90385,14 @@
   {
     "id": "ticon/langkawi-142-mys-uhslc_fd",
     "accepted": true,
-    "score": 99,
+    "score": 91,
     "factors": {
       "epoch": 1,
       "recency": 0.99,
       "source": 0.99,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.974
+      "coverage": 0.395
     },
     "issues": []
   },
@@ -88485,7 +91994,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -89015,7 +92524,7 @@
     "score": 83,
     "factors": {
       "epoch": 1,
-      "recency": 0.74,
+      "recency": 0.73,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -89434,7 +92943,7 @@
     "score": 88,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -89448,7 +92957,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -90039,14 +93548,14 @@
   {
     "id": "ticon/macau-338a-prt-uhslc_rq",
     "accepted": true,
-    "score": 68,
+    "score": 63,
     "factors": {
       "epoch": 0.398,
       "recency": 0.59,
       "source": 0.192,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.719
     },
     "issues": []
   },
@@ -91500,14 +95009,14 @@
   {
     "id": "ticon/marmaris-mar-tur-cmems",
     "accepted": true,
-    "score": 46,
+    "score": 35,
     "factors": {
       "epoch": 0.106,
       "recency": 0.96,
       "source": 0.02,
       "quality": 0,
       "amplitude": 1,
-      "coverage": 0.908
+      "coverage": 0.184
     },
     "issues": []
   },
@@ -92025,7 +95534,7 @@
     "score": 0,
     "factors": {
       "epoch": 0.255,
-      "recency": 0.44,
+      "recency": 0.43,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -92749,7 +96258,7 @@
     "score": 60,
     "factors": {
       "epoch": 1,
-      "recency": 0.49,
+      "recency": 0.48,
       "source": 0,
       "quality": 1,
       "amplitude": 1,
@@ -92946,7 +96455,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -93216,7 +96725,7 @@
     "score": 92,
     "factors": {
       "epoch": 0.837,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -94467,7 +97976,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -94625,7 +98134,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -94850,7 +98359,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -95371,7 +98880,7 @@
     "score": 69,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 0,
       "amplitude": 1,
@@ -95487,7 +98996,7 @@
     "score": 79,
     "factors": {
       "epoch": 0.509,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -96365,7 +99874,7 @@
     "score": 91,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -96562,7 +100071,7 @@
     "score": 87,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -97625,7 +101134,7 @@
     "score": 69,
     "factors": {
       "epoch": 0.089,
-      "recency": 0.92,
+      "recency": 0.91,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -97774,7 +101283,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -98389,7 +101898,7 @@
     "score": 66,
     "factors": {
       "epoch": 0.206,
-      "recency": 0.44,
+      "recency": 0.43,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -100585,14 +104094,14 @@
   {
     "id": "ticon/paleafokea-pal-grc-cmems",
     "accepted": true,
-    "score": 47,
+    "score": 43,
     "factors": {
       "epoch": 0.087,
       "recency": 0.96,
       "source": 0.02,
       "quality": 0,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.746
     },
     "issues": []
   },
@@ -101034,7 +104543,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -101221,7 +104730,7 @@
     "score": 85,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -102411,10 +105920,10 @@
   {
     "id": "ticon/point_atkinson_bc-7795-can-meds",
     "accepted": true,
-    "score": 85,
+    "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -102428,7 +105937,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -102443,14 +105952,14 @@
   {
     "id": "ticon/point_fortin-728a-tto-uhslc_rq",
     "accepted": true,
-    "score": 72,
+    "score": 70,
     "factors": {
       "epoch": 0.537,
       "recency": 0.7,
       "source": 0.192,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.913
     },
     "issues": []
   },
@@ -102619,7 +106128,7 @@
     "score": 82,
     "factors": {
       "epoch": 1,
-      "recency": 0.58,
+      "recency": 0.57,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -102665,7 +106174,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.95,
+      "recency": 0.94,
       "source": 0.96,
       "quality": 1,
       "amplitude": 0.75,
@@ -102684,7 +106193,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.95,
+      "recency": 0.94,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -103111,7 +106620,7 @@
     "score": 75,
     "factors": {
       "epoch": 0.554,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -103153,7 +106662,7 @@
     "score": 83,
     "factors": {
       "epoch": 0.752,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -103184,7 +106693,7 @@
     "score": 89,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -103325,7 +106834,7 @@
     "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -103478,7 +106987,7 @@
     "score": 92,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -103509,7 +107018,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -103662,7 +107171,7 @@
     "score": 97,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -103676,7 +107185,7 @@
     "score": 75,
     "factors": {
       "epoch": 0.517,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -103863,7 +107372,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -104048,7 +107557,7 @@
     "score": 73,
     "factors": {
       "epoch": 0.322,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -104259,7 +107768,7 @@
     "score": 78,
     "factors": {
       "epoch": 0.322,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -104289,7 +107798,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -104383,7 +107892,7 @@
     "score": 0,
     "factors": {
       "epoch": 0.057,
-      "recency": 0.51,
+      "recency": 0.5,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
@@ -104402,7 +107911,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -104633,7 +108142,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -104944,7 +108453,7 @@
     "score": 89,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -105426,7 +108935,7 @@
     "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -105523,7 +109032,7 @@
     "score": 49,
     "factors": {
       "epoch": 1,
-      "recency": 0.68,
+      "recency": 0.67,
       "source": 0.131,
       "quality": 0,
       "amplitude": 1,
@@ -106035,14 +109544,14 @@
   {
     "id": "ticon/puerto_williams-287a-chl-uhslc_rq",
     "accepted": true,
-    "score": 76,
+    "score": 74,
     "factors": {
       "epoch": 0.806,
       "recency": 0.73,
       "source": 0.192,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.913
+      "coverage": 0.81
     },
     "issues": []
   },
@@ -106396,7 +109905,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -106410,7 +109919,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -107032,7 +110541,7 @@
     "score": 0,
     "factors": {
       "epoch": 0.537,
-      "recency": 0.55,
+      "recency": 0.54,
       "source": 0.495,
       "quality": 1,
       "amplitude": 1,
@@ -107625,7 +111134,7 @@
     "score": 86,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -107831,7 +111340,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -109032,7 +112541,7 @@
     "score": 73,
     "factors": {
       "epoch": 0.31,
-      "recency": 0.94,
+      "recency": 0.93,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -109166,7 +112675,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -109649,7 +113158,7 @@
     "score": 67,
     "factors": {
       "epoch": 0.096,
-      "recency": 0.93,
+      "recency": 0.92,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -110276,7 +113785,7 @@
       "source": 0.99,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.969
     },
     "issues": []
   },
@@ -110342,7 +113851,7 @@
     "score": 87,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -110428,7 +113937,7 @@
     "score": 85,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -110442,7 +113951,7 @@
     "score": 92,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -110456,7 +113965,7 @@
     "score": 81,
     "factors": {
       "epoch": 0.676,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -110570,7 +114079,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.95,
+      "recency": 0.94,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -111070,14 +114579,14 @@
   {
     "id": "ticon/samothraki-sam-grc-cmems",
     "accepted": true,
-    "score": 53,
+    "score": 51,
     "factors": {
       "epoch": 0.377,
       "recency": 0.97,
       "source": 0.02,
       "quality": 0,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.902
     },
     "issues": []
   },
@@ -111881,7 +115390,7 @@
     "score": 84,
     "factors": {
       "epoch": 0.961,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -112054,7 +115563,7 @@
     "score": 81,
     "factors": {
       "epoch": 0.816,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -112508,7 +116017,7 @@
     "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -112525,7 +116034,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -113157,7 +116666,7 @@
     "score": 76,
     "factors": {
       "epoch": 0.553,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -113313,7 +116822,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -114042,7 +117551,7 @@
     "score": 74,
     "factors": {
       "epoch": 0.448,
-      "recency": 0.94,
+      "recency": 0.93,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -114978,7 +118487,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -115478,14 +118987,14 @@
   {
     "id": "ticon/split-spl-hrv-eseas",
     "accepted": true,
-    "score": 71,
+    "score": 68,
     "factors": {
       "epoch": 0.172,
       "recency": 0.33,
       "source": 0.727,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.756
     },
     "issues": []
   },
@@ -115951,7 +119460,7 @@
     "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -116019,7 +119528,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.64,
+      "recency": 0.63,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -116038,7 +119547,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -116482,7 +119991,7 @@
     "score": 73,
     "factors": {
       "epoch": 0.44,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -116496,7 +120005,7 @@
     "score": 74,
     "factors": {
       "epoch": 0.461,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -116688,7 +120197,7 @@
     "score": 58,
     "factors": {
       "epoch": 1,
-      "recency": 0.28,
+      "recency": 0.27,
       "source": 0,
       "quality": 1,
       "amplitude": 1,
@@ -117120,7 +120629,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -117716,7 +121225,7 @@
     "score": 88,
     "factors": {
       "epoch": 1,
-      "recency": 0.88,
+      "recency": 0.87,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -118955,7 +122464,7 @@
     "score": 96,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -119161,7 +122670,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -119341,7 +122850,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -119439,7 +122948,7 @@
     "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -119788,7 +123297,7 @@
     "score": 98,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -120308,7 +123817,7 @@
     "score": 87,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -120517,7 +124026,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -120826,10 +124335,10 @@
   {
     "id": "ticon/ucluelet_bc-8595-can-meds",
     "accepted": true,
-    "score": 79,
+    "score": 78,
     "factors": {
       "epoch": 0.242,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -120964,7 +124473,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -121158,7 +124667,7 @@
     "score": 0,
     "factors": {
       "epoch": 0.269,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -121625,7 +125134,7 @@
     "score": 85,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -121791,7 +125300,7 @@
     "score": 0,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -121983,7 +125492,7 @@
     "score": 0,
     "factors": {
       "epoch": 0.351,
-      "recency": 0.66,
+      "recency": 0.65,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
@@ -122291,7 +125800,7 @@
     "score": 84,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -122351,10 +125860,10 @@
   {
     "id": "ticon/vieux_quebec-3248-can-meds",
     "accepted": true,
-    "score": 82,
+    "score": 81,
     "factors": {
       "epoch": 0.857,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -122712,14 +126221,14 @@
   {
     "id": "ticon/vlaktevdraantg-vla-nld-cmems",
     "accepted": true,
-    "score": 61,
+    "score": 60,
     "factors": {
       "epoch": 0.586,
       "recency": 0.99,
       "source": 0.02,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 0.263
+      "coverage": 0.207
     },
     "issues": []
   },
@@ -124723,7 +128232,7 @@
     "score": 88,
     "factors": {
       "epoch": 1,
-      "recency": 0.93,
+      "recency": 0.92,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -125098,10 +128607,10 @@
   {
     "id": "ticon/winter_harbour_bc-8735-can-meds",
     "accepted": true,
-    "score": 98,
+    "score": 97,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -125115,7 +128624,7 @@
     "score": 0,
     "factors": {
       "epoch": 0.537,
-      "recency": 0.7,
+      "recency": 0.69,
       "source": 1,
       "quality": 1,
       "amplitude": 1,
@@ -125257,7 +128766,7 @@
     "score": 77,
     "factors": {
       "epoch": 1,
-      "recency": 0.77,
+      "recency": 0.76,
       "source": 0.727,
       "quality": 1,
       "amplitude": 1,
@@ -125405,7 +128914,7 @@
     "score": 75,
     "factors": {
       "epoch": 0.434,
-      "recency": 0.98,
+      "recency": 0.97,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -125512,14 +129021,14 @@
   {
     "id": "ticon/xiamen-376a-chn-uhslc_rq",
     "accepted": true,
-    "score": 81,
+    "score": 73,
     "factors": {
       "epoch": 1,
       "recency": 0.71,
       "source": 0.192,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.454
     },
     "issues": []
   },
@@ -125690,7 +129199,7 @@
     "score": 99,
     "factors": {
       "epoch": 1,
-      "recency": 0.99,
+      "recency": 0.98,
       "source": 0.96,
       "quality": 1,
       "amplitude": 1,
@@ -126035,14 +129544,14 @@
   {
     "id": "ticon/zakynthos-zak-grc-cmems",
     "accepted": true,
-    "score": 68,
+    "score": 65,
     "factors": {
       "epoch": 0.404,
       "recency": 0.98,
       "source": 0.02,
       "quality": 1,
       "amplitude": 1,
-      "coverage": 1
+      "coverage": 0.793
     },
     "issues": []
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,8 @@ export interface StationData {
     id: string;
     published_harmonics: boolean;
     url: string;
+    // Operating agency, where the source relays another operator's gauge (IOC).
+    operator?: string;
   };
 
   // License information

--- a/test/ioc.test.ts
+++ b/test/ioc.test.ts
@@ -3,11 +3,17 @@ import { parseIocSamples } from "../tools/ioc.js";
 
 describe("parseIocSamples", () => {
   test("drops QC-nulled NA rows and parses stime as UTC", () => {
-    const samples = parseIocSamples([
-      { slevel: 1.25, stime: "2025-07-14 00:10:00" },
-      { slevel: "NA", stime: "2025-07-14 00:20:00" },
-      { slevel: -0.5, stime: "2025-07-14 00:30:00" },
-    ]);
+    const samples = parseIocSamples(
+      [
+        "total_days\tcurrent_page\ttotal_pages\tnext_page\tprev_page",
+        "365\t1\t1\t\t",
+        "slevel\tstime\tsensor",
+        "1.25\t2025-07-14 00:10:00\trad",
+        "NA\t2025-07-14 00:20:00\trad",
+        "-0.5\t2025-07-14 00:30:00\trad",
+        "",
+      ].join("\n"),
+    );
     expect(samples).toHaveLength(2);
     expect(samples[0]!.time.toISOString()).toBe("2025-07-14T00:10:00.000Z");
     expect(samples[0]!.level).toBe(1.25);

--- a/test/ioc.test.ts
+++ b/test/ioc.test.ts
@@ -1,0 +1,16 @@
+import { describe, test, expect } from "vitest";
+import { parseIocSamples } from "../tools/ioc.js";
+
+describe("parseIocSamples", () => {
+  test("drops QC-nulled NA rows and parses stime as UTC", () => {
+    const samples = parseIocSamples([
+      { slevel: 1.25, stime: "2025-07-14 00:10:00" },
+      { slevel: "NA", stime: "2025-07-14 00:20:00" },
+      { slevel: -0.5, stime: "2025-07-14 00:30:00" },
+    ]);
+    expect(samples).toHaveLength(2);
+    expect(samples[0]!.time.toISOString()).toBe("2025-07-14T00:10:00.000Z");
+    expect(samples[0]!.level).toBe(1.25);
+    expect(samples[1]!.level).toBe(-0.5);
+  });
+});

--- a/tools/datum.ts
+++ b/tools/datum.ts
@@ -355,7 +355,7 @@ export function parseGeslaSamples(text: string): Sample[] {
 }
 
 /** Bin samples to mean level per UTC hour, sorted ascending. */
-function binHourly(samples: Sample[]): Sample[] {
+export function binHourly(samples: Sample[]): Sample[] {
   const buckets = new Map<number, { sum: number; n: number }>();
   for (const s of samples) {
     const key = Math.floor(s.time.getTime() / HOUR_MS);
@@ -407,6 +407,37 @@ export function computeDatumsFromObservations(
     return null;
 
   return { start: hourly[0]!.time, end, datums };
+}
+
+/**
+ * Combine observed mean datums with harmonic astronomical/amplitude datums.
+ *
+ * Means (MHHW…MLLW) come from observations. The astronomical extremes and
+ * amplitude-derived chart datums live on the harmonic side (computed over a
+ * full nodal cycle, MSL=0 frame); shift them into the observed gauge frame by
+ * adding the observed MSL.
+ */
+export function mergeObservedDatums(
+  harmonic: Datums,
+  observed: Datums,
+): Datums {
+  const shift = observed["MSL"] ?? 0;
+  const HARMONIC_KEYS = [
+    "HAT",
+    "LAT",
+    "LLWLT",
+    "MHWS",
+    "MLWS",
+    "NLLW",
+    "ALLW",
+    "TLT",
+  ];
+  const shifted: Datums = {};
+  for (const k of HARMONIC_KEYS) {
+    const v = harmonic[k];
+    if (v !== undefined) shifted[k] = toFixed(v + shift, 3);
+  }
+  return { ...observed, ...shifted };
 }
 
 export function toFixed(num: number, digits: number) {

--- a/tools/evaluate-quality.ts
+++ b/tools/evaluate-quality.ts
@@ -296,8 +296,9 @@ function checkSeasonalContamination(
   station: Station,
   allStations: Station[],
 ): string | null {
-  // Authoritative sources (NOAA) are trusted; this targets TICON harmonic fits.
-  if (!station.id.startsWith("ticon/")) return null;
+  // Authoritative sources (NOAA) are trusted; this targets harmonic fits
+  // (TICON's, and our own from IOC observations).
+  if (station.id.startsWith("noaa/")) return null;
   if (station.type === "subordinate") return null;
 
   const sa = getAmplitude(station, "SA");

--- a/tools/import-ioc.ts
+++ b/tools/import-ioc.ts
@@ -190,6 +190,8 @@ async function main() {
   const candidates = stations.filter((s) => {
     if (only) return only.includes(s.Code);
     if (s.Lat == null || s.Lon == null) return false;
+    // DART tsunameters are deep-ocean pressure sensors, not tide stations.
+    if (s.Location.trim().startsWith("DART")) return false;
     if (!s.lasttime || Date.parse(s.lasttime.replace(" ", "T") + "Z") < cutoff)
       return false;
     return existing.every(

--- a/tools/import-ioc.ts
+++ b/tools/import-ioc.ts
@@ -222,7 +222,9 @@ async function main() {
           // "Bahia Mansa_CL" → "Bahia Mansa": strip the country suffix some operators append.
           name: s.Location.trim().replace(/_[A-Z]{2}$/, ""),
           ...(region ? { region } : {}),
-          country: geo?.country ?? s.countryname,
+          // Remote gauges miss the geocoder; IOC's own label needs its qualifier
+          // dropped ("Taiwan (Province of China)", "Puerto Rico; U.S.A.").
+          country: geo?.country ?? s.countryname.replace(/\s*[(;].*$/, ""),
           latitude: lat,
           longitude: lon,
           type: "reference",

--- a/tools/import-ioc.ts
+++ b/tools/import-ioc.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+
+/**
+ * Import IOC SLSMF gauges as a derived source: fit harmonic constituents and
+ * reduce datums from quality-controlled observations (issue #124).
+ *
+ * Only gauges that are still reporting and sit more than MIN_DISTANCE_KM from
+ * every station already in data/ are imported; the rest are covered by better
+ * (published-constituent) sources. Records shorter than a year are skipped.
+ *
+ * Usage:
+ *   IOC_API_KEY=… node tools/import-ioc.ts
+ *   IOC_STATIONS=tbvi2,aarh node tools/import-ioc.ts   # restrict to codes
+ *   FORCE=1 node tools/import-ioc.ts                    # re-fit cached stations
+ *   IOC_FROM=2007 node tools/import-ioc.ts              # fetch a longer record
+ */
+
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
+import {
+  normalize,
+  save,
+  load,
+  DATA_DIR,
+  type PartialStationData,
+} from "./station.ts";
+import {
+  computeDatums,
+  computeDatumsFromObservations,
+  mergeObservedDatums,
+  type Sample,
+} from "./datum.ts";
+import { fitHarmonics, isAnalyzable } from "./harmonic-analysis.ts";
+import { distance } from "./filtering.ts";
+import { loadGeocoder } from "./geocode.ts";
+import { fetchStations, fetchOperators, fetchHourlySamples } from "./ioc.ts";
+
+const SOURCE = "ioc";
+const MIN_DISTANCE_KM = 3;
+const MAX_AGE_DAYS = 30;
+const force = process.env["FORCE"] === "1";
+const only = process.env["IOC_STATIONS"]?.split(",").map((s) => s.trim());
+// ponytail: a station-year is a ~40 MB response taking 20–30 s, so default to
+// the last 6 years (plenty for the fit; datums lose only cm-level accuracy vs
+// the full 19-year window). Raise IOC_FROM for a longer record.
+const fromYear = Number(
+  process.env["IOC_FROM"] ?? new Date().getUTCFullYear() - 6,
+);
+
+// The constituent set TICON-4 publishes for nearly every station; all resolve
+// with ≥1 year of hourly data. fitHarmonics drops any @neaps doesn't define.
+const CONSTITUENTS = [
+  "M2",
+  "S2",
+  "N2",
+  "K2",
+  "K1",
+  "O1",
+  "P1",
+  "Q1",
+  "M4",
+  "MS4",
+  "MN4",
+  "M6",
+  "2N2",
+  "MU2",
+  "NU2",
+  "L2",
+  "T2",
+  "R2",
+  "LAMBDA2",
+  "MKS2",
+  "2SM2",
+  "MA2",
+  "MB2",
+  "S1",
+  "M1",
+  "J1",
+  "OO1",
+  "2Q1",
+  "RHO1",
+  "SGM",
+  "M3",
+  "S3",
+  "S4",
+  "N4",
+  "M8",
+  "2MS6",
+  "2MK5",
+  "2MO5",
+  "MM",
+  "MF",
+  "MSF",
+  "MTM",
+  "MSQM",
+  "SA",
+  "SSA",
+  "EP2",
+  "3N2",
+  "3L2",
+  "T3",
+  "R3",
+];
+
+const DATUM_DISCLAIMER =
+  "Datums are relative to the gauge's own zero; IOC SLSMF publishes no vertical datum.";
+
+/** Positions of every station already in data/ (other sources only). */
+async function existingPositions(): Promise<[number, number][]> {
+  const out: [number, number][] = [];
+  for (const source of await readdir(DATA_DIR, { withFileTypes: true })) {
+    if (!source.isDirectory() || source.name === SOURCE) continue;
+    const dir = join(DATA_DIR, source.name);
+    for (const file of await readdir(dir)) {
+      if (!file.endsWith(".json")) continue;
+      const s = JSON.parse(await readFile(join(dir, file), "utf-8"));
+      out.push([s.latitude, s.longitude]);
+    }
+  }
+  return out;
+}
+
+const toISODate = (d: Date) => d.toISOString().split("T")[0]!;
+
+async function fit(code: string) {
+  if (!force) {
+    try {
+      const { harmonic_constituents, datums, datums_source, epoch } =
+        await load(SOURCE, code);
+      // Written by this tool, so both are always present.
+      return {
+        harmonic_constituents,
+        datums,
+        datums_source: datums_source!,
+        epoch: epoch!,
+      };
+    } catch {
+      // not cached; fit below
+    }
+  }
+
+  const samples = await fetchHourlySamples(code, fromYear);
+  if (
+    !isAnalyzable(
+      samples.map((s) => ({ t: s.time.getTime(), level: s.level })),
+      CONSTITUENTS.length,
+    )
+  ) {
+    throw new Error("record too short (< 1 year of QC'd data)");
+  }
+  const harmonic_constituents = fitHarmonics(
+    samples.map((s) => ({ t: s.time.getTime(), level: s.level })),
+    CONSTITUENTS,
+  );
+
+  const harmonic = computeDatums(harmonic_constituents, {});
+  const obs = computeDatumsFromObservations(samples);
+  const span = (a: Sample[]) => ({
+    start: toISODate(a[0]!.time),
+    end: toISODate(a[a.length - 1]!.time),
+  });
+  return obs
+    ? {
+        harmonic_constituents,
+        datums: mergeObservedDatums(harmonic.datums, obs.datums),
+        datums_source: "observed" as const,
+        epoch: { start: toISODate(obs.start), end: toISODate(obs.end) },
+      }
+    : {
+        harmonic_constituents,
+        datums: harmonic.datums,
+        datums_source: "harmonic" as const,
+        epoch: span(samples),
+      };
+}
+
+async function main() {
+  console.log(
+    `=== Importing IOC SLSMF stations ===${force ? " (forcing re-fit)" : ""}\n`,
+  );
+
+  const [stations, operators, existing, geocoder] = await Promise.all([
+    fetchStations(),
+    fetchOperators(),
+    existingPositions(),
+    loadGeocoder(),
+  ]);
+
+  const cutoff = Date.now() - MAX_AGE_DAYS * 86_400_000;
+  const candidates = stations.filter((s) => {
+    if (only) return only.includes(s.Code);
+    if (s.Lat == null || s.Lon == null) return false;
+    if (!s.lasttime || Date.parse(s.lasttime.replace(" ", "T") + "Z") < cutoff)
+      return false;
+    return existing.every(
+      ([lat, lon]) => distance(lat, lon, s.Lat!, s.Lon!) > MIN_DISTANCE_KM,
+    );
+  });
+  console.log(
+    `${stations.length} gauges, ${candidates.length} active and uncovered\n`,
+  );
+
+  let saved = 0;
+  let skipped = 0;
+  for (const s of candidates) {
+    const lat = s.Lat!;
+    const lon = s.Lon!;
+    try {
+      const geo = geocoder.nearest(lat, lon, 50);
+      const region = geo?.region;
+      const operator =
+        s.localoperator != null ? operators.get(s.localoperator) : undefined;
+      const fitted = await fit(s.Code);
+
+      const candidate: PartialStationData = {
+        // "Bahia Mansa_CL" → "Bahia Mansa": strip the country suffix some operators append.
+        name: s.Location.trim().replace(/_[A-Z]{2}$/, ""),
+        ...(region ? { region } : {}),
+        country: geo?.country ?? s.countryname,
+        latitude: lat,
+        longitude: lon,
+        type: "reference",
+        disclaimers: [
+          DATUM_DISCLAIMER,
+          fitted.datums_source === "harmonic"
+            ? "Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty."
+            : "",
+        ]
+          .filter(Boolean)
+          .join(" "),
+        source: {
+          name: "IOC SLSMF",
+          url: `https://www.ioc-sealevelmonitoring.org/station.php?code=${s.Code}`,
+          id: s.Code,
+          published_harmonics: false,
+          ...(operator ? { operator } : {}),
+        },
+        license: {
+          type: "IOC Oceanographic Data Exchange Policy",
+          commercial_use: false,
+          url: "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+          notes:
+            `Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator${operator ? ` (${operator})` : ""}. ` +
+            "Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482",
+        },
+        ...fitted,
+      };
+      await save(SOURCE, normalize(candidate));
+      saved++;
+      process.stdout.write(".");
+    } catch (err: any) {
+      skipped++;
+      console.error(`\n${s.Code} (${s.Location.trim()}): ${err.message}`);
+    }
+  }
+  console.log(
+    `\n\nDone. Saved ${saved}, skipped ${skipped} of ${candidates.length}.`,
+  );
+}
+
+main();

--- a/tools/import-ioc.ts
+++ b/tools/import-ioc.ts
@@ -204,57 +204,63 @@ async function main() {
 
   let saved = 0;
   let skipped = 0;
-  for (const s of candidates) {
-    const lat = s.Lat!;
-    const lon = s.Lon!;
-    try {
-      const geo = geocoder.nearest(lat, lon, 50);
-      const region = geo?.region;
-      const operator =
-        s.localoperator != null ? operators.get(s.localoperator) : undefined;
-      const fitted = await fit(s.Code);
+  const queue = [...candidates];
+  // ponytail: 4 in flight — the server's per-request latency dominates, so a
+  // small pool is ~4× faster and still polite.
+  const worker = async () => {
+    for (let s = queue.shift(); s; s = queue.shift()) {
+      const lat = s.Lat!;
+      const lon = s.Lon!;
+      try {
+        const geo = geocoder.nearest(lat, lon, 50);
+        const region = geo?.region;
+        const operator =
+          s.localoperator != null ? operators.get(s.localoperator) : undefined;
+        const fitted = await fit(s.Code);
 
-      const candidate: PartialStationData = {
-        // "Bahia Mansa_CL" → "Bahia Mansa": strip the country suffix some operators append.
-        name: s.Location.trim().replace(/_[A-Z]{2}$/, ""),
-        ...(region ? { region } : {}),
-        country: geo?.country ?? s.countryname,
-        latitude: lat,
-        longitude: lon,
-        type: "reference",
-        disclaimers: [
-          DATUM_DISCLAIMER,
-          fitted.datums_source === "harmonic"
-            ? "Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty."
-            : "",
-        ]
-          .filter(Boolean)
-          .join(" "),
-        source: {
-          name: "IOC SLSMF",
-          url: `https://www.ioc-sealevelmonitoring.org/station.php?code=${s.Code}`,
-          id: s.Code,
-          published_harmonics: false,
-          ...(operator ? { operator } : {}),
-        },
-        license: {
-          type: "IOC Oceanographic Data Exchange Policy",
-          commercial_use: false,
-          url: "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
-          notes:
-            `Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator${operator ? ` (${operator})` : ""}. ` +
-            "Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482",
-        },
-        ...fitted,
-      };
-      await save(SOURCE, normalize(candidate));
-      saved++;
-      process.stdout.write(".");
-    } catch (err: any) {
-      skipped++;
-      console.error(`\n${s.Code} (${s.Location.trim()}): ${err.message}`);
+        const candidate: PartialStationData = {
+          // "Bahia Mansa_CL" → "Bahia Mansa": strip the country suffix some operators append.
+          name: s.Location.trim().replace(/_[A-Z]{2}$/, ""),
+          ...(region ? { region } : {}),
+          country: geo?.country ?? s.countryname,
+          latitude: lat,
+          longitude: lon,
+          type: "reference",
+          disclaimers: [
+            DATUM_DISCLAIMER,
+            fitted.datums_source === "harmonic"
+              ? "Datums derived from harmonic prediction; the observation record is too short for an empirical reduction, so datum values carry higher uncertainty."
+              : "",
+          ]
+            .filter(Boolean)
+            .join(" "),
+          source: {
+            name: "IOC SLSMF",
+            url: `https://www.ioc-sealevelmonitoring.org/station.php?code=${s.Code}`,
+            id: s.Code,
+            published_harmonics: false,
+            ...(operator ? { operator } : {}),
+          },
+          license: {
+            type: "IOC Oceanographic Data Exchange Policy",
+            commercial_use: false,
+            url: "https://www.ioc-sealevelmonitoring.org/disclaimer.php",
+            notes:
+              `Non-commercial use only per the SLSMF data policy; commercial users should contact the data originator${operator ? ` (${operator})` : ""}. ` +
+              "Constituents fit by this project from SLSMF quality-controlled observations. Cite: Flanders Marine Institute (VLIZ); Intergovernmental Oceanographic Commission (IOC) (2026): Sea level station monitoring facility. https://doi.org/10.14284/482",
+          },
+          ...fitted,
+        };
+        await save(SOURCE, normalize(candidate));
+        saved++;
+        process.stdout.write(".");
+      } catch (err: any) {
+        skipped++;
+        console.error(`\n${s.Code} (${s.Location.trim()}): ${err.message}`);
+      }
     }
-  }
+  };
+  await Promise.all(Array.from({ length: 4 }, worker));
   console.log(
     `\n\nDone. Saved ${saved}, skipped ${skipped} of ${candidates.length}.`,
   );

--- a/tools/import-ticon.ts
+++ b/tools/import-ticon.ts
@@ -8,8 +8,8 @@ import { normalize, save, load, type PartialStationData } from "./station.ts";
 import {
   computeDatums,
   computeDatumsFromObservations,
+  mergeObservedDatums,
   parseGeslaSamples,
-  toFixed,
 } from "./datum.ts";
 import { ensureGeslaData, GESLA_DIR } from "./download-gesla.ts";
 import {
@@ -239,27 +239,8 @@ async function getDatums(
   );
   const obs = computeDatumsFromObservations(samples);
   if (obs) {
-    // Means (MHHW…MLLW) come from observations. The astronomical extremes and
-    // amplitude-derived chart datums live on the harmonic side (computed over a
-    // full nodal cycle, MSL=0 frame); shift them into the observed gauge frame.
-    const shift = obs.datums["MSL"] ?? 0;
-    const HARMONIC_KEYS = [
-      "HAT",
-      "LAT",
-      "LLWLT",
-      "MHWS",
-      "MLWS",
-      "NLLW",
-      "ALLW",
-      "TLT",
-    ];
-    const shifted: Record<string, number> = {};
-    for (const k of HARMONIC_KEYS) {
-      const v = harmonic.datums[k];
-      if (v !== undefined) shifted[k] = toFixed(v + shift, 3);
-    }
     return {
-      datums: { ...obs.datums, ...shifted },
+      datums: mergeObservedDatums(harmonic.datums, obs.datums),
       datums_source: "observed" as const,
       epoch: { start: toISODate(obs.start), end: toISODate(obs.end) },
     };

--- a/tools/ioc.ts
+++ b/tools/ioc.ts
@@ -1,0 +1,124 @@
+/**
+ * IOC Sea Level Station Monitoring Facility (SLSMF) v2 API client.
+ *
+ * SLSMF (https://www.ioc-sealevelmonitoring.org, run by VLIZ for UNESCO/IOC)
+ * relays ~1,600 real-time tide gauges but publishes raw relative sea level only —
+ * no constituents, no vertical datum. We fetch its quality-controlled research
+ * series and fit constituents ourselves (see import-ioc.ts, issue #124).
+ *
+ * Needs an API key in IOC_API_KEY: register at
+ * https://www.ioc-sealevelmonitoring.org/api.php and ask for the gauges API group.
+ * Responses are cached gzipped under tmp/IOC/ (gitignored).
+ */
+
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { gzipSync, gunzipSync } from "zlib";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { binHourly, type Sample } from "./datum.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const IOC_DIR = join(__dirname, "..", "tmp", "IOC");
+const API = "https://api.ioc-sealevelmonitoring.org/v2";
+
+export interface IocStation {
+  Code: string;
+  Location: string;
+  country: string;
+  countryname: string;
+  Lat: number | null;
+  Lon: number | null;
+  localoperator: number | null;
+  lasttime: string | null; // "YYYY-MM-DD HH:MM:SS.SSS" UTC
+}
+
+export interface IocOperator {
+  id: number;
+  fullname: string;
+}
+
+interface IocRow {
+  slevel: number | "NA";
+  stime: string; // "YYYY-MM-DD HH:MM:SS" UTC
+}
+
+async function getJSON<T>(path: string, cacheFile: string): Promise<T> {
+  const file = join(IOC_DIR, cacheFile);
+  try {
+    return JSON.parse(gunzipSync(await readFile(file)).toString());
+  } catch {
+    // not cached
+  }
+  const key = process.env["IOC_API_KEY"];
+  if (!key) {
+    throw new Error(
+      "IOC_API_KEY is not set. Register at https://www.ioc-sealevelmonitoring.org/api.php and request the gauges API group.",
+    );
+  }
+  // ponytail: three tries with a flat back-off; make-fetch-happen's streaming
+  // was ~10× slower than undici on these 40 MB station-years.
+  let text = "";
+  for (let attempt = 1; ; attempt++) {
+    const res = await fetch(`${API}${path}`, { headers: { "X-API-KEY": key } });
+    if (res.ok) {
+      text = await res.text();
+      break;
+    }
+    if (attempt === 3) {
+      throw new Error(`IOC ${path}: ${res.status} ${res.statusText}`);
+    }
+    await new Promise((r) => setTimeout(r, 5_000 * attempt));
+  }
+  await mkdir(dirname(file), { recursive: true });
+  await writeFile(file, gzipSync(text));
+  return JSON.parse(text);
+}
+
+/** All SLSMF stations (cached; delete tmp/IOC/stations.json.gz to refresh). */
+export const fetchStations = () =>
+  getJSON<IocStation[]>("/stations", "stations.json.gz");
+
+/** Operator id → full name. */
+export async function fetchOperators(): Promise<Map<number, string>> {
+  const ops = await getJSON<IocOperator[]>("/operators", "operators.json.gz");
+  return new Map(ops.map((o) => [o.id, o.fullname]));
+}
+
+/** Convert research-endpoint rows to samples, dropping QC-nulled (`NA`) values. */
+export function parseIocSamples(rows: IocRow[]): Sample[] {
+  const samples: Sample[] = [];
+  for (const r of rows) {
+    if (typeof r.slevel !== "number" || !Number.isFinite(r.slevel)) continue;
+    const t = Date.parse(r.stime.replace(" ", "T") + "Z");
+    if (Number.isFinite(t))
+      samples.push({ time: new Date(t), level: r.slevel });
+  }
+  return samples;
+}
+
+/**
+ * Quality-controlled hourly water levels for a station, walking back one
+ * calendar year per request from `until` to `from` (the research endpoint caps
+ * requests at 365 days). Days flagged low-completeness/distinctness/shift and
+ * samples flagged out-of-range/spike/flat are already `NA` upstream. Raw
+ * 1-minute series are binned to hourly means per year to keep memory flat.
+ */
+export async function fetchHourlySamples(
+  code: string,
+  from: number,
+  until = new Date().getUTCFullYear(),
+): Promise<Sample[]> {
+  const years: Sample[][] = [];
+  for (let year = until; year >= from; year--) {
+    const rows = await getJSON<{ data: IocRow[] }>(
+      `/research/stations/${code}/sensors/one-sensor/data` +
+        `?timestart=${year}-01-01&timestop=${year + 1}-01-01&days_per_page=365&page=1&fit_to_sample_rate=true`,
+      join(code, `${year}.json.gz`),
+    );
+    // ponytail: rows only exist from the gauge's first report, so an empty year
+    // means we've reached the start of the record; a full-year outage truncates it.
+    if (rows.data.length === 0) break;
+    years.unshift(binHourly(parseIocSamples(rows.data)));
+  }
+  return years.flat();
+}

--- a/tools/ioc.ts
+++ b/tools/ioc.ts
@@ -37,15 +37,14 @@ export interface IocOperator {
   fullname: string;
 }
 
-interface IocRow {
-  slevel: number | "NA";
-  stime: string; // "YYYY-MM-DD HH:MM:SS" UTC
-}
-
-async function getJSON<T>(path: string, cacheFile: string): Promise<T> {
+async function getText(
+  path: string,
+  cacheFile: string,
+  accept = "application/json",
+): Promise<string> {
   const file = join(IOC_DIR, cacheFile);
   try {
-    return JSON.parse(gunzipSync(await readFile(file)).toString());
+    return gunzipSync(await readFile(file)).toString();
   } catch {
     // not cached
   }
@@ -56,10 +55,12 @@ async function getJSON<T>(path: string, cacheFile: string): Promise<T> {
     );
   }
   // ponytail: three tries with a flat back-off; make-fetch-happen's streaming
-  // was ~10× slower than undici on these 40 MB station-years.
+  // was ~10× slower than undici on these multi-MB station-years.
   let text = "";
   for (let attempt = 1; ; attempt++) {
-    const res = await fetch(`${API}${path}`, { headers: { "X-API-KEY": key } });
+    const res = await fetch(`${API}${path}`, {
+      headers: { "X-API-KEY": key, Accept: accept },
+    });
     if (res.ok) {
       text = await res.text();
       break;
@@ -71,8 +72,11 @@ async function getJSON<T>(path: string, cacheFile: string): Promise<T> {
   }
   await mkdir(dirname(file), { recursive: true });
   await writeFile(file, gzipSync(text));
-  return JSON.parse(text);
+  return text;
 }
+
+const getJSON = async <T>(path: string, cacheFile: string): Promise<T> =>
+  JSON.parse(await getText(path, cacheFile));
 
 /** All SLSMF stations (cached; delete tmp/IOC/stations.json.gz to refresh). */
 export const fetchStations = () =>
@@ -84,14 +88,24 @@ export async function fetchOperators(): Promise<Map<number, string>> {
   return new Map(ops.map((o) => [o.id, o.fullname]));
 }
 
-/** Convert research-endpoint rows to samples, dropping QC-nulled (`NA`) values. */
-export function parseIocSamples(rows: IocRow[]): Sample[] {
+/**
+ * Parse the research endpoint's CSV (a pagination block, then tab-separated
+ * `slevel stime sensor` rows) into samples, dropping QC-nulled (`NA`) values.
+ * CSV is ~40% the size of the JSON form and the server produces it faster.
+ */
+export function parseIocSamples(csv: string): Sample[] {
   const samples: Sample[] = [];
-  for (const r of rows) {
-    if (typeof r.slevel !== "number" || !Number.isFinite(r.slevel)) continue;
-    const t = Date.parse(r.stime.replace(" ", "T") + "Z");
-    if (Number.isFinite(t))
-      samples.push({ time: new Date(t), level: r.slevel });
+  for (const line of csv.split("\n")) {
+    const [slevel, stime] = line.split("\t");
+    const level = Number(slevel);
+    // Skips the header/pagination lines and NA (V8's Date.parse is lenient,
+    // so gate on the timestamp shape rather than on NaN).
+    if (
+      !Number.isFinite(level) ||
+      !/^\d{4}-\d\d-\d\d \d\d:\d\d:\d\d$/.test(stime ?? "")
+    )
+      continue;
+    samples.push({ time: new Date(stime!.replace(" ", "T") + "Z"), level });
   }
   return samples;
 }
@@ -110,15 +124,18 @@ export async function fetchHourlySamples(
 ): Promise<Sample[]> {
   const years: Sample[][] = [];
   for (let year = until; year >= from; year--) {
-    const rows = await getJSON<{ data: IocRow[] }>(
-      `/research/stations/${code}/sensors/one-sensor/data` +
+    // Catalog codes can be upper-case but the research route only knows lower.
+    const csv = await getText(
+      `/research/stations/${code.toLowerCase()}/sensors/one-sensor/data` +
         `?timestart=${year}-01-01&timestop=${year + 1}-01-01&days_per_page=365&page=1&fit_to_sample_rate=true`,
-      join(code, `${year}.json.gz`),
+      join(code, `${year}.csv.gz`),
+      "text/csv",
     );
-    // ponytail: rows only exist from the gauge's first report, so an empty year
-    // means we've reached the start of the record; a full-year outage truncates it.
-    if (rows.data.length === 0) break;
-    years.unshift(binHourly(parseIocSamples(rows.data)));
+    // ponytail: rows only exist from the gauge's first report, so a year with
+    // no rows at all means we've reached the start of the record; a full-year
+    // outage truncates it. (All-NA years still have rows, so keep walking.)
+    if (!/\t\d{4}-\d\d-\d\d /.test(csv)) break;
+    years.unshift(binHourly(parseIocSamples(csv)));
   }
   return years.flat();
 }

--- a/tools/ioc.ts
+++ b/tools/ioc.ts
@@ -58,17 +58,17 @@ async function getText(
   // was ~10× slower than undici on these multi-MB station-years.
   let text = "";
   for (let attempt = 1; ; attempt++) {
-    const res = await fetch(`${API}${path}`, {
-      headers: { "X-API-KEY": key, Accept: accept },
-    });
-    if (res.ok) {
+    try {
+      const res = await fetch(`${API}${path}`, {
+        headers: { "X-API-KEY": key, Accept: accept },
+      });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       text = await res.text();
       break;
+    } catch (err: any) {
+      if (attempt === 3) throw new Error(`IOC ${path}: ${err.message}`);
+      await new Promise((r) => setTimeout(r, 5_000 * attempt));
     }
-    if (attempt === 3) {
-      throw new Error(`IOC ${path}: ${res.status} ${res.statusText}`);
-    }
-    await new Promise((r) => setTimeout(r, 5_000 * attempt));
   }
   await mkdir(dirname(file), { recursive: true });
   await writeFile(file, gzipSync(text));


### PR DESCRIPTION
Closes #124.

Adds the IOC Sea Level Station Monitoring Facility as the database's first **derived** source: constituents are fit by this project from SLSMF's quality-controlled observations (`published_harmonics: false`), and datums are reduced in the gauge's own relative frame.

## What's here

- **`tools/ioc.ts`** — v2 API client. Reads `IOC_API_KEY` (also in this repo's Actions secrets), caches the station list, operators, and each station-year gzipped under `tmp/IOC/`. Uses the CSV form of the research endpoint (under half the size of JSON, ~3× faster server-side) and lower-cases catalog codes, which the research route requires.
- **`tools/import-ioc.ts`** — selects gauges that reported in the last 30 days, sit more than 3 km from every station already in `data/`, and are not DART tsunameters. Pages the research endpoint one year at a time (default: last 6 years, `IOC_FROM` overrides), bins to hourly means, gates on `isAnalyzable`, fits the standard TICON-4 constituent set with `fitHarmonics`, and reduces datums the same way `import-ticon.ts` does. Four stations in flight.
- **`tools/datum.ts`** — the observed/harmonic datum merge moves out of `import-ticon.ts` so both importers share it; `binHourly` is exported.
- **`tools/evaluate-quality.ts`** — the seasonal-contamination gate now applies to every non-NOAA source, since IOC constituents are fits too.
- **Licence** — the SLSMF disclaimer says data "may not be used for any commercial purposes", so every station carries `commercial_use: false`, the DOI citation (10.14284/482), and the operating agency in `source.operator` (whom commercial users must contact). VLIZ confirmed by email that redistributing derived constituents with the citation is fine.
- Docs in `data/ioc/README.md` and a source line in the root README; one unit test for the CSV parser.

## Status

- [x] Importer, docs, tests (full suite passes)
- [x] Trial: Ancud, Chile (`ancu2`) fits consistently against Puerto Montt downstream; Tortola, Ashkhara, Amorgos correctly skipped for < 1 year of QC'd data
- [x] Full run: 320 candidate gauges, 233 fit, 87 skipped for < 1 year of QC'd data
- [x] `evaluate-quality` + `quality.json` regenerated: 175 IOC stations accepted
- [x] Data commit

## Notes

- Batroun (`batr1`) and Garachico (`gara1`) time out server-side (60 s, no response) on every attempt and are not included; `tst1`/`tst2` are IOC test stations and 400.
- Tortola (`tbvi2`) is all-`NA` after QC for 2025 and will not import until the gauge is repaired.
- VLIZ said they compute constituents themselves and offered to point us at them. That could replace the fit later; not pursued here.
- A `workflow_dispatch` job using the Actions secret is a possible follow-up; the run is hours long, so it is not scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

